### PR TITLE
oboe callback: remove onExit()

### DIFF
--- a/include/oboe/OboeStreamCallback.h
+++ b/include/oboe/OboeStreamCallback.h
@@ -39,13 +39,6 @@ public:
 
     virtual void onError(OboeStream *audioStream, oboe_result_t error) {}
 
-    /**
-     * The callback thread is exiting.
-     *
-     * @param reason Why it is exiting. OBOE_OK if requested.
-     *               Or maybe OBOE_ERROR_TIMEOUT or OBOE_ERROR_DISCONNECTED.
-     */
-    virtual void onExit(oboe_result_t reason) {}
 };
 
 


### PR DESCRIPTION
This was unused and unimplemented.
Also difficult to implement.
