### PR TITLE
Update FifoBuffer.cpp

### DIFF
--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <memory.h>
 
 #include "common/OboeDebug.h"
 #include "fifo/FifoControllerBase.h"


### PR DESCRIPTION
I get compilation "error: use of undeclared identifier 'memcpy'"
Adding the memory.h include fixes this.