### PR TITLE
oboe: automatically stop and close a stream when disconnected

### DIFF
--- a/include/oboe/OboeStreamBuilder.h
+++ b/include/oboe/OboeStreamBuilder.h
@@ -190,6 +190,15 @@ public:
         return this;
     }
 
+    /**
+     * Specifies an object to handle data or error related callbacks from the underlying API.
+     *
+     * When an error callback occurs, the associated stream will be stopped
+     * and closed in a separate thread.
+     *
+     * @param streamCallback
+     * @return
+     */
     OboeStreamBuilder *setCallback(OboeStreamCallback *streamCallback) {
         mStreamCallback = streamCallback;
         return this;

--- a/include/oboe/OboeStreamCallback.h
+++ b/include/oboe/OboeStreamCallback.h
@@ -24,22 +24,42 @@ class OboeStream;
 class OboeStreamCallback {
 public:
     virtual ~OboeStreamCallback() = default;
+
     /**
      * A buffer is ready for processing.
      *
-     * @param input buffer containing recorded audio, may be NULL
-     * @param output fill this with audio data to be played, may be NULL
-     * @param number of frames of input or output
+     * @param oboeStream pointer to the associated stream
+     * @param audioData buffer containing input data or a place to put output data
+     * @param numFrames number of frames to be processed
      * @return OBOE_CALLBACK_RESULT_CONTINUE or OBOE_CALLBACK_RESULT_STOP
      */
     virtual oboe_data_callback_result_t onAudioReady(
-            OboeStream *audioStream,
+            OboeStream *oboeStream,
             void *audioData,
             int32_t numFrames) = 0;
 
-    virtual void onError(OboeStream *audioStream, oboe_result_t error) {}
+    /**
+     * This will be called when an error occurs on a stream or when the stream is discomnnected.
+     * The underlying stream will already be stopped by Oboe but not yet closed.
+     * So the stream can be queried.
+     *
+     * @param oboeStream pointer to the associated stream
+     * @param error
+     */
+    virtual void onErrorBeforeClose(OboeStream *oboeStream, oboe_result_t error) {}
+
+    /**
+     * This will be called when an error occurs on a stream or when the stream is disconnected.
+     * The underlying stream will already be stopped AND closed by Oboe.
+     * So the underlyng stream cannot be referenced.
+     *
+     * This callback could be used to reopen a new stream on another device.
+     *
+     * @param oboeStream pointer to the associated stream
+     * @param error
+     */
+    virtual void onErrorAfterClose(OboeStream *oboeStream, oboe_result_t error) {}
 
 };
-
 
 #endif //OBOE_OBOE_STREAM_CALLBACK_H

--- a/src/common/OboeStreamBuilder.cpp
+++ b/src/common/OboeStreamBuilder.cpp
@@ -16,11 +16,11 @@
 
 #include <sys/types.h>
 
+#include "aaudio/OboeStreamAAudio.h"
 #include "OboeDebug.h"
 #include "oboe/Oboe.h"
-
+#include "oboe/OboeStreamBuilder.h"
 #include "opensles/OboeStreamOpenSLES.h"
-#include "aaudio/OboeStreamAAudio.h"
 
 bool OboeStreamBuilder::isAAudioSupported() {
     return OboeStreamAAudio::isSupported();


### PR DESCRIPTION
WARNING: API change
Modifies OboeStreamCallback onError methods.

Adds protection against stopping or closing a stream at the same time
that the error callback is being processed.

Fix issue #1