### PR TITLE
oboe: add blocking read/write

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -151,9 +151,9 @@ public:
      * This monotonic counter will never get reset.
      * @return the number of frames written so far
      */
-    virtual int64_t getFramesWritten() { return mFramesWritten; }
+    virtual int64_t getFramesWritten() const { return mFramesWritten; }
 
-    virtual int64_t getFramesRead() { return static_cast<int64_t>(Result::ErrorUnimplemented); }
+    virtual int64_t getFramesRead() const { return mFramesRead; }
 
     virtual Result getTimestamp(clockid_t clockId,
                                        int64_t *framePosition,
@@ -197,6 +197,9 @@ protected:
     virtual int64_t incrementFramesWritten(int32_t frames) {
         return mFramesWritten += frames;
     }
+    virtual int64_t incrementFramesRead(int32_t frames) {
+        return mFramesRead += frames;
+    }
 
     /**
      * Wait for a transition from one state to another.
@@ -219,7 +222,9 @@ protected:
     AudioFormat mNativeFormat = AudioFormat::Invalid;
 
 private:
+    // TODO these should be atomic like in AAudio
     int64_t              mFramesWritten = 0;
+    int64_t              mFramesRead = 0;
     int                  mPreviousScheduler = -1;
 };
 

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -70,7 +70,6 @@ static void oboe_aaudio_error_callback_proc(
     }
 }
 
-
 namespace oboe {
 
 /*
@@ -301,6 +300,18 @@ int32_t AudioStreamAAudio::write(const void *buffer,
     }
 }
 
+int32_t AudioStreamAAudio::read(void *buffer,
+                                 int32_t numFrames,
+                                 int64_t timeoutNanoseconds)
+{
+    AAudioStream *stream = mAAudioStream.load();
+    if (stream != nullptr) {
+        return mLibLoader->stream_read(mAAudioStream, buffer, numFrames, timeoutNanoseconds);
+    } else {
+        return static_cast<int32_t>(Result::ErrorNull);
+    }
+}
+
 Result AudioStreamAAudio::waitForStateChange(StreamState currentState,
                                         StreamState *nextState,
                                         int64_t timeoutNanoseconds)
@@ -358,8 +369,7 @@ int32_t AudioStreamAAudio::getFramesPerBurst()
     }
 }
 
-int64_t AudioStreamAAudio::getFramesRead()
-{
+int64_t AudioStreamAAudio::getFramesRead() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_getFramesRead(stream);
@@ -367,8 +377,8 @@ int64_t AudioStreamAAudio::getFramesRead()
         return static_cast<int32_t>(Result::ErrorNull);
     }
 }
-int64_t AudioStreamAAudio::getFramesWritten()
-{
+
+int64_t AudioStreamAAudio::getFramesWritten() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_getFramesWritten(stream);

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -27,10 +27,8 @@
 #include <sys/system_properties.h>
 #endif
 
-
 using namespace oboe;
 AAudioLoader *AudioStreamAAudio::mLibLoader = nullptr;
-
 
 // 'C' wrapper for the data callback method
 static aaudio_data_callback_result_t oboe_aaudio_data_callback_proc(
@@ -79,8 +77,7 @@ AudioStreamAAudio::AudioStreamAAudio(const AudioStreamBuilder &builder)
     : AudioStream(builder)
     , mFloatCallbackBuffer(nullptr)
     , mShortCallbackBuffer(nullptr)
-    , mAAudioStream(nullptr)
-{
+    , mAAudioStream(nullptr) {
     mCallbackThreadEnabled.store(false);
     LOGD("AudioStreamAAudio() call isSupported()");
     isSupported();
@@ -244,8 +241,7 @@ Result AudioStreamAAudio::convertApplicationDataToNative(int32_t numFrames) {
     return result;
 }
 
-Result AudioStreamAAudio::requestStart()
-{
+Result AudioStreamAAudio::requestStart() {
     std::lock_guard<std::mutex> lock(mLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
@@ -255,8 +251,7 @@ Result AudioStreamAAudio::requestStart()
     }
 }
 
-Result AudioStreamAAudio::requestPause()
-{
+Result AudioStreamAAudio::requestPause() {
     std::lock_guard<std::mutex> lock(mLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
@@ -276,8 +271,7 @@ Result AudioStreamAAudio::requestFlush() {
     }
 }
 
-Result AudioStreamAAudio::requestStop()
-{
+Result AudioStreamAAudio::requestStop() {
     std::lock_guard<std::mutex> lock(mLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
@@ -290,8 +284,7 @@ Result AudioStreamAAudio::requestStop()
 // TODO: Update to return tuple of Result and framesWritten (avoids cast)
 int32_t AudioStreamAAudio::write(const void *buffer,
                                      int32_t numFrames,
-                                     int64_t timeoutNanoseconds)
-{
+                                     int64_t timeoutNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_write(mAAudioStream, buffer, numFrames, timeoutNanoseconds);
@@ -302,8 +295,7 @@ int32_t AudioStreamAAudio::write(const void *buffer,
 
 int32_t AudioStreamAAudio::read(void *buffer,
                                  int32_t numFrames,
-                                 int64_t timeoutNanoseconds)
-{
+                                 int64_t timeoutNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_read(mAAudioStream, buffer, numFrames, timeoutNanoseconds);
@@ -314,8 +306,7 @@ int32_t AudioStreamAAudio::read(void *buffer,
 
 Result AudioStreamAAudio::waitForStateChange(StreamState currentState,
                                         StreamState *nextState,
-                                        int64_t timeoutNanoseconds)
-{
+                                        int64_t timeoutNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
 
@@ -332,16 +323,14 @@ Result AudioStreamAAudio::waitForStateChange(StreamState currentState,
     }
 }
 
-Result AudioStreamAAudio::setBufferSizeInFrames(int32_t requestedFrames)
-{
+Result AudioStreamAAudio::setBufferSizeInFrames(int32_t requestedFrames) {
     if (requestedFrames > mBufferCapacityInFrames) {
         requestedFrames = mBufferCapacityInFrames;
     }
     return static_cast<Result>(mLibLoader->stream_setBufferSize(mAAudioStream, requestedFrames));
 }
 
-StreamState AudioStreamAAudio::getState()
-{
+StreamState AudioStreamAAudio::getState() {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return static_cast<StreamState>(mLibLoader->stream_getState(stream));
@@ -359,8 +348,7 @@ int32_t AudioStreamAAudio::getBufferSizeInFrames() const {
     }
 }
 
-int32_t AudioStreamAAudio::getFramesPerBurst()
-{
+int32_t AudioStreamAAudio::getFramesPerBurst() {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_getFramesPerBurst(stream);

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -387,8 +387,7 @@ int64_t AudioStreamAAudio::getFramesWritten() const {
     }
 }
 
-int32_t AudioStreamAAudio::getXRunCount()
-{
+int32_t AudioStreamAAudio::getXRunCount() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_getXRunCount(stream);

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -61,16 +61,20 @@ public:
     Result requestStop() override;
 
     int32_t write(const void *buffer,
-                             int32_t numFrames,
-                             int64_t timeoutNanoseconds) override;
+                  int32_t numFrames,
+                  int64_t timeoutNanoseconds) override;
+
+    int32_t read(void *buffer,
+                 int32_t numFrames,
+                 int64_t timeoutNanoseconds) override;
 
     Result setBufferSizeInFrames(int32_t requestedFrames) override;
     int32_t getBufferSizeInFrames() const override;
     int32_t getFramesPerBurst() override;
     int32_t getXRunCount() override;
 
-    int64_t getFramesRead() override;
-    int64_t getFramesWritten() override;
+    int64_t getFramesRead() const override;
+    int64_t getFramesWritten() const override;
 
     Result waitForStateChange(StreamState currentState,
                               StreamState *nextState,

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -71,7 +71,7 @@ public:
     Result setBufferSizeInFrames(int32_t requestedFrames) override;
     int32_t getBufferSizeInFrames() const override;
     int32_t getFramesPerBurst() override;
-    int32_t getXRunCount() override;
+    int32_t getXRunCount() const override;
 
     int64_t getFramesRead() const override;
     int64_t getFramesWritten() const override;

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -60,6 +60,8 @@ FifoBuffer::FifoBuffer( uint32_t   bytesPerFrame,
         , mFramesUnderrunCount(0)
         , mUnderrunCount(0)
 {
+    assert(bytesPerFrame > 0);
+    assert(capacityInFrames > 0);
     mFifo = new FifoControllerIndirect(capacityInFrames,
                                        capacityInFrames,
                                        readIndexAddress,

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <memory.h>
+#include <assert.h>
 
 #include "common/OboeDebug.h"
 #include "fifo/FifoControllerBase.h"
@@ -36,12 +37,15 @@ FifoBuffer::FifoBuffer(uint32_t bytesPerFrame, uint32_t capacityInFrames)
         , mFramesUnderrunCount(0)
         , mUnderrunCount(0)
 {
+    assert(bytesPerFrame > 0);
+    assert(capacityInFrames > 0);
     mFifo = new FifoController(capacityInFrames, capacityInFrames);
     // allocate buffer
     int32_t bytesPerBuffer = bytesPerFrame * capacityInFrames;
     mStorage = new uint8_t[bytesPerBuffer];
     mStorageOwned = true;
-    LOGD("FifoProcessor: numFrames = %d, bytesPerFrame = %d", capacityInFrames, bytesPerFrame);
+    LOGD("FifoProcessor: capacityInFrames = %d, bytesPerFrame = %d",
+         capacityInFrames, bytesPerFrame);
 }
 
 FifoBuffer::FifoBuffer( uint32_t   bytesPerFrame,
@@ -64,7 +68,8 @@ FifoBuffer::FifoBuffer( uint32_t   bytesPerFrame,
                                        writeIndexAddress);
     mStorage = dataStorageAddress;
     mStorageOwned = false;
-    LOGD("FifoProcessor: capacityInFrames = %d, bytesPerFrame = %d", capacityInFrames, bytesPerFrame);
+    LOGD("FifoProcessor: capacityInFrames = %d, bytesPerFrame = %d",
+         capacityInFrames, bytesPerFrame);
 }
 
 FifoBuffer::~FifoBuffer() {

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -32,7 +32,6 @@ FifoBuffer::FifoBuffer(uint32_t bytesPerFrame, uint32_t capacityInFrames)
         : mFrameCapacity(capacityInFrames)
         , mBytesPerFrame(bytesPerFrame)
         , mStorage(NULL)
-        , mReadAtNanoseconds(0)
         , mFramesReadCount(0)
         , mFramesUnderrunCount(0)
         , mUnderrunCount(0)
@@ -57,7 +56,6 @@ FifoBuffer::FifoBuffer( uint32_t   bytesPerFrame,
         : mFrameCapacity(capacityInFrames)
         , mBytesPerFrame(bytesPerFrame)
         , mStorage(dataStorageAddress)
-        , mReadAtNanoseconds(0)
         , mFramesReadCount(0)
         , mFramesUnderrunCount(0)
         , mUnderrunCount(0)
@@ -161,7 +159,6 @@ int32_t FifoBuffer::write(const void *buffer, int32_t framesToWrite) {
 }
 
 int32_t FifoBuffer::readNow(void *buffer, int32_t numFrames) {
-    mLastReadSize = numFrames;
     int32_t framesLeft = numFrames;
     int32_t framesRead = read(buffer, numFrames);
     framesLeft -= framesRead;
@@ -173,18 +170,8 @@ int32_t FifoBuffer::readNow(void *buffer, int32_t numFrames) {
         int32_t bytesToZero = convertFramesToBytes(framesLeft);
         memset(buffer, 0, bytesToZero);
     }
-    mReadAtNanoseconds = AudioClock::getNanoseconds();
 
     return framesRead;
-}
-
-    // FIXME remove
-int64_t FifoBuffer::getNextReadTime(int frameRate) {
-    if (mReadAtNanoseconds == 0) {
-        return 0;
-    }
-    int64_t nanosPerBuffer = (kNanosPerSecond * mLastReadSize) / frameRate;
-    return mReadAtNanoseconds + nanosPerBuffer;
 }
 
 uint32_t FifoBuffer::getThresholdFrames() const {

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -178,6 +178,7 @@ int32_t FifoBuffer::readNow(void *buffer, int32_t numFrames) {
     return framesRead;
 }
 
+    // FIXME remove
 int64_t FifoBuffer::getNextReadTime(int frameRate) {
     if (mReadAtNanoseconds == 0) {
         return 0;

--- a/src/fifo/FifoBuffer.h
+++ b/src/fifo/FifoBuffer.h
@@ -52,8 +52,6 @@ public:
 
     int32_t readNow(void *buffer, int32_t numFrames);
 
-    int64_t getNextReadTime(int32_t frameRate);
-
     uint32_t getUnderrunCount() const { return mUnderrunCount; }
 
     FifoControllerBase *getFifoControllerBase() { return mFifo; }
@@ -85,11 +83,9 @@ private:
     uint8_t* mStorage;
     bool     mStorageOwned; // did this object allocate the storage?
     FifoControllerBase *mFifo;
-    int64_t  mReadAtNanoseconds;
     uint64_t mFramesReadCount;
     uint64_t mFramesUnderrunCount;
     uint32_t mUnderrunCount; // need? just use frames
-    uint32_t mLastReadSize;
 };
 
 } // namespace oboe

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -64,7 +64,7 @@ Result AudioInputStreamOpenSLES::open() {
     // configure audio sink
     SLDataLocator_AndroidSimpleBufferQueue loc_bufq = {
             SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE,    // locatorType
-            static_cast<SLuint32>(mBurstsPerBuffer)};   // numBuffers
+            static_cast<SLuint32>(kBufferQueueLength)};   // numBuffers
 
     // Define the audio data format.
     SLDataFormat_PCM format_pcm = {
@@ -139,10 +139,7 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
-    oboeResult = finishOpen();
-    if (oboeResult != oboe::Result::OK) {
-        goto error;
-    }
+    allocateFifo();
 
     return Result::OK;
 

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -139,6 +139,11 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
+    oboeResult = finishOpen();
+    if (oboeResult != oboe::Result::OK) {
+        goto error;
+    }
+
     return Result::OK;
 
 error:

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -88,7 +88,7 @@ Result AudioOutputStreamOpenSLES::open() {
     // configure audio source
     SLDataLocator_AndroidSimpleBufferQueue loc_bufq = {
             SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE,    // locatorType
-            static_cast<SLuint32>(mBurstsPerBuffer)};   // numBuffers
+            static_cast<SLuint32>(kBufferQueueLength)};   // numBuffers
 
     // Define the audio data format.
     SLDataFormat_PCM format_pcm = {
@@ -141,10 +141,7 @@ Result AudioOutputStreamOpenSLES::open() {
         goto error;
     }
 
-    oboeResult = finishOpen();
-    if (oboeResult != oboe::Result::OK) {
-        goto error;
-    }
+    allocateFifo();
 
     return Result::OK;
 error:

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -141,6 +141,11 @@ Result AudioOutputStreamOpenSLES::open() {
         goto error;
     }
 
+    oboeResult = finishOpen();
+    if (oboeResult != oboe::Result::OK) {
+        goto error;
+    }
+
     return Result::OK;
 error:
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -28,80 +28,184 @@ AudioStreamBuffered::AudioStreamBuffered(const AudioStreamBuilder &builder)
         : AudioStream(builder) {
 }
 AudioStreamBuffered::~AudioStreamBuffered() {
-    delete mFifoBuffer;
+    LOGD("~AudioStreamBuffered() called");
 }
 
-Result AudioStreamBuffered::finishOpen() {
+void AudioStreamBuffered::allocateFifo() {
     // If the caller does not provide a callback use our own internal
     // callback that reads data from the FIFO.
-    if (getCallback() == nullptr) {
-        LOGD("AudioStreamBuffered(): new FifoBuffer(bytesPerFrame=%d", getBytesPerFrame());
+    if (usingFIFO()) {
         // FIFO is configured with the same format and channels as the stream.
-        mFifoBuffer = new FifoBuffer(getBytesPerFrame(), 1024); // TODO size?
-        // Create a callback that reads from the FIFO
-        mInternalCallback = std::unique_ptr<AudioStreamBufferedCallback>(new AudioStreamBufferedCallback(this));
-        mStreamCallback = mInternalCallback.get();
+        int32_t capacity = getBufferCapacityInFrames();
+        if (capacity == oboe::kUnspecified) {
+            capacity = getFramesPerBurst() * 16; // arbitrary
+            mBufferCapacityInFrames = capacity;
+        }
+        LOGD("AudioStreamBuffered(): new FifoBuffer(bytesPerFrame=%d, capacity=%d)",
+             getBytesPerFrame(), capacity);
+        mFifoBuffer.reset(new FifoBuffer(getBytesPerFrame(), capacity));
         LOGD("AudioStreamBuffered(): mStreamCallback = %p", mStreamCallback);
     }
-    return Result::OK;
+}
+
+int64_t AudioStreamBuffered::getFramesWritten() const {
+    if (usingFIFO()) {
+        return (int64_t) mFifoBuffer->getWriteCounter();
+    } else {
+        return AudioStream::getFramesWritten();
+    }
+}
+
+int64_t AudioStreamBuffered::getFramesRead() const {
+    if (usingFIFO()) {
+        return (int64_t) mFifoBuffer->getReadCounter();
+    } else {
+        return AudioStream::getFramesRead();
+    }
+}
+
+
+    // This is called by the OpenSL ES callback to read or write the back end of the FIFO.
+DataCallbackResult AudioStreamBuffered::onDefaultCallback(void *audioData, int numFrames) {
+    int32_t framesTransferred  = 0;
+
+    if (getDirection() == oboe::Direction::Output) {
+        // Read from the FIFO and write to audioData
+        framesTransferred = mFifoBuffer->readNow(audioData, numFrames);
+        LOGV("%s() read %d / %d frames from FIFO", __func__, framesTransferred, numFrames);
+    } else {
+        // Read from audioData and write to the FIFO
+        framesTransferred = mFifoBuffer->write(audioData, numFrames); // FIXME writeNow????
+        LOGV("%s() wrote %d / %d frames to FIFO", __func__, framesTransferred, numFrames);
+    }
+
+    if (framesTransferred < numFrames) {
+        // TODO If we do not allow FIFO to wrap then our timestamps will drift when there is an XRun!
+        incrementXRunCount();
+    }
+    markCallbackTime(numFrames); // so foreground knows how long to wait.
+    return DataCallbackResult::Continue;
+}
+
+void AudioStreamBuffered::markCallbackTime(int numFrames) {
+    mLastBackgroundSize = numFrames;
+    mBackgroundRanAtNanoseconds = AudioClock::getNanoseconds();
+}
+
+int64_t AudioStreamBuffered::predictNextCallbackTime() {
+    if (mBackgroundRanAtNanoseconds == 0) {
+        return 0;
+    }
+    int64_t nanosPerBuffer = (kNanosPerSecond * mLastBackgroundSize) / getSampleRate();
+    const int64_t margin = 200 * kNanosPerMicrosecond; // arbitrary delay so we wake up just after
+    return mBackgroundRanAtNanoseconds + nanosPerBuffer + margin;
 }
 
 // TODO: This method should return a tuple of Result,int32_t where the
 // 2nd return param is the frames written. Maybe not!
+
+// Common code for read/write.
+int32_t AudioStreamBuffered::transfer(void *buffer,
+                                      int32_t numFrames,
+                                      int64_t timeoutNanoseconds) {
+    // Validate arguments.
+    if (buffer == nullptr) {
+        LOGE("AudioStreamBuffered::%s(): buffer is NULL", __func__);
+        return (int32_t) Result ::ErrorNull;
+    }
+    if (numFrames < 0) {
+        LOGE("AudioStreamBuffered::%s(): numFrames is negative", __func__);
+        return (int32_t) Result::ErrorOutOfRange;
+    } else if (numFrames == 0) {
+        return 0;
+    }
+    if (timeoutNanoseconds < 0) {
+        LOGE("AudioStreamBuffered::%s(): timeoutNanoseconds is negative", __func__);
+        return (int32_t) Result ::ErrorOutOfRange;
+    }
+
+    int32_t result = 0;
+    uint8_t *data = (uint8_t *)buffer;
+    int32_t framesLeft = numFrames;
+    int64_t timeToQuit = 0;
+    bool repeat = true;
+
+    // Calculate when to timeout.
+    if (timeoutNanoseconds > 0) {
+        timeToQuit = AudioClock::getNanoseconds() + timeoutNanoseconds;
+    }
+
+    // Loop until we get the data, or we have an error, or we timeout.
+    do {
+        // read or write
+        if (getDirection() == Direction::Input) {
+            result = mFifoBuffer->read(data, framesLeft);
+        } else {
+            result = mFifoBuffer->write(data, framesLeft);
+        }
+        if (result > 0) {
+            data += mFifoBuffer->convertFramesToBytes(result);
+            framesLeft -= result;
+        }
+
+        // If we need more data then sleep and try again.
+        if (framesLeft > 0 && result >= 0 && timeoutNanoseconds > 0) {
+            int64_t timeNow = AudioClock::getNanoseconds();
+            if (timeNow >= timeToQuit) {
+                LOGE("AudioStreamBuffered::%s(): TIMEOUT", __func__);
+                repeat = false; // TIMEOUT
+            } else {
+                // Figure out how long to sleep.
+                int64_t sleepForNanos;
+                int64_t wakeTimeNanos = predictNextCallbackTime();
+                if (wakeTimeNanos <= 0) {
+                    // No estimate available. Sleep for one burst.
+                    sleepForNanos = (getFramesPerBurst() * kNanosPerSecond) / getSampleRate();
+                } else {
+                    // Don't sleep past timeout.
+                    if (wakeTimeNanos > timeToQuit) {
+                        wakeTimeNanos = timeToQuit;
+                    }
+                    sleepForNanos = wakeTimeNanos - timeNow;
+                    // Avoid rapid loop with no sleep.
+                    const int64_t minSleepTime = kNanosPerMillisecond; // arbitrary
+                    if (sleepForNanos < minSleepTime) {
+                        sleepForNanos = minSleepTime;
+                    }
+                }
+
+                AudioClock::sleepForNanos(sleepForNanos);
+            }
+
+        } else {
+            repeat = false;
+        }
+    } while(repeat);
+
+    return result < 0 ? result : (numFrames - framesLeft);
+}
+
+// Write to the FIFO so the callback can read from it.
 int32_t AudioStreamBuffered::write(const void *buffer,
                                    int32_t numFrames,
-                                   int64_t timeoutNanoseconds)
-{
-    int32_t result = 0;
-    uint8_t *source = (uint8_t *)buffer;
-    int32_t framesLeft = numFrames;
-    while(framesLeft > 0 && result >= 0) {
-        result = mFifoBuffer->write(source, framesLeft);
-        LOGD("AudioStreamBuffered::%s(): wrote %d / %d frames to FIFO, [0] = %f",
-             __func__, result, framesLeft, ((float *)source)[0]);
-        if (result > 0) {
-            source += mFifoBuffer->convertFramesToBytes(result);
-            incrementFramesWritten(result);
-            framesLeft -= result;
-        }
-        if (framesLeft > 0 && result >= 0) {
-            int64_t wakeTimeNanos =  mFifoBuffer->getNextReadTime(getSampleRate());
-            // TODO use timeoutNanoseconds
-            AudioClock::sleepUntilNanoTime(wakeTimeNanos);
-        }
+                                   int64_t timeoutNanoseconds) {
+    if (getDirection() == Direction::Input) {
+        return (int32_t) Result::ErrorUnavailable;  // TODO review, better error code?
     }
-    return result;
+    return transfer((void *) buffer, numFrames, timeoutNanoseconds);
 }
 
-// Read from the FIFO that was written by the callback.
+// Read data from the FIFO that was written by the callback.
 int32_t AudioStreamBuffered::read(void *buffer,
                                   int32_t numFrames,
-                                  int64_t timeoutNanoseconds)
-{
-    static int readCount = 0;
-    int32_t result = 0;
-    uint8_t *destination = (uint8_t *)buffer;
-    int32_t framesLeft = numFrames;
-    while(framesLeft > 0 && result >= 0) {
-        result = mFifoBuffer->read(destination, framesLeft);
-        LOGD("AudioStreamBuffered::%s(): read %d/%d frames from FIFO, #%d",
-             __func__, result, framesLeft, readCount);
-        if (result > 0) {
-            destination += mFifoBuffer->convertFramesToBytes(result);
-            incrementFramesRead(result);
-            framesLeft -= result;
-            readCount++;
-        }
-        if (framesLeft > 0 && result >= 0) {
-            // FIXME use proper timing model, borrow one from AAudio
-            // TODO use timeoutNanoseconds
-            AudioClock::sleepForNanos(4 * kNanosPerMillisecond);
-        }
+                                  int64_t timeoutNanoseconds) {
+    if (getDirection() == Direction::Output) {
+        return (int32_t) Result::ErrorUnavailable; // TODO review, better error code?
     }
-
-    return result;
+    return transfer(buffer, numFrames, timeoutNanoseconds);
 }
 
+// Only supported when we are not using a callback.
 Result AudioStreamBuffered::setBufferSizeInFrames(int32_t requestedFrames)
 {
     if (mFifoBuffer != nullptr) {
@@ -115,7 +219,6 @@ Result AudioStreamBuffered::setBufferSizeInFrames(int32_t requestedFrames)
     }
 }
 
-
 int32_t AudioStreamBuffered::getBufferSizeInFrames() const {
     if (mFifoBuffer != nullptr) {
         return mFifoBuffer->getThresholdFrames();
@@ -126,7 +229,7 @@ int32_t AudioStreamBuffered::getBufferSizeInFrames() const {
 
 int32_t AudioStreamBuffered::getBufferCapacityInFrames() const {
     if (mFifoBuffer != nullptr) {
-        return mFifoBuffer->getBufferCapacityInFrames(); // Maybe set mBufferCapacity in constructor
+        return mFifoBuffer->getBufferCapacityInFrames();
     } else {
         return AudioStream::getBufferCapacityInFrames();
     }

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -33,7 +33,6 @@ public:
 
     AudioStreamBuffered();
     explicit AudioStreamBuffered(const AudioStreamBuilder &builder);
-    ~AudioStreamBuffered();
 
     void allocateFifo();
 

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -108,7 +108,10 @@ Result AudioStreamOpenSLES::open() {
     LOGD("AudioStreamOpenSLES(): mBytesPerCallback = %d", mBytesPerCallback);
 
     mSharingMode = SharingMode::Shared;
-    mBufferCapacityInFrames = mFramesPerBurst * mBurstsPerBuffer;
+
+    if (!usingFIFO()) {
+        mBufferCapacityInFrames = mFramesPerBurst * kBufferQueueLength;
+    }
 
     return Result::OK;
 }
@@ -130,10 +133,10 @@ SLresult AudioStreamOpenSLES::enqueueCallbackBuffer(SLAndroidSimpleBufferQueueIt
 
 SLresult AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq) {
     // Ask the callback to fill the output buffer with data.
-    Result result = fireCallback(mCallbackBuffer, mFramesPerCallback);
-    if (result != Result::OK) {
+    DataCallbackResult result = fireCallback(mCallbackBuffer, mFramesPerCallback);
+    if (result != DataCallbackResult::Continue) {
         LOGE("Oboe callback returned %d", result);
-        return SL_RESULT_INTERNAL_ERROR;
+        return SL_RESULT_INTERNAL_ERROR; // TODO How should we stop OpenSL ES.
     } else {
         // Pass the data to OpenSLES.
         return enqueueCallbackBuffer(bq);

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -74,6 +74,7 @@ Result AudioStreamOpenSLES::open() {
     // API 21+: FLOAT
     // API <21: INT16
     if (mFormat == AudioFormat::Unspecified){
+        // TODO use runtime check
         mFormat = (__ANDROID_API__ < __ANDROID_API_L__) ?
                   AudioFormat::I16 : AudioFormat::Float;
     }

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -117,12 +117,12 @@ Result AudioStreamOpenSLES::open() {
 }
 
 Result AudioStreamOpenSLES::close() {
-    if (mObjectInterface != NULL) {
+    if (mObjectInterface != nullptr) {
         (*mObjectInterface)->Destroy(mObjectInterface);
-        mObjectInterface = NULL;
+        mObjectInterface = nullptr;
 
     }
-    mSimpleBufferQueueInterface = NULL;
+    mSimpleBufferQueueInterface = nullptr;
     EngineOpenSLES::getInstance().close();
     return Result::OK;
 }

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -27,6 +27,7 @@
 namespace oboe {
 
 constexpr int kBitsPerByte = 8;
+constexpr int kBufferQueueLength = 2; // double buffered for callbacks
 
 /**
  * INTERNAL USE ONLY


### PR DESCRIPTION
Use FIFO for OpenSL ES.
This will allow blocking read/write calls on a stream without using a callback.

