### PR TITLE
Changing callback interface to use references rather than pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ We would love to receive your pull requests. Before we can though, please read t
 
 ## Version history
 
+- 14th February 2018 - v0.11 `AudioStreamCallback` methods use references rather than pointers
+- 18th January 2018 - v0.10 Input streams supported via callbacks (+ minor API changes/bug fixes)
 - 18th October 2017 - v0.9 Initial developer preview

--- a/include/oboe/AudioStreamCallback.h
+++ b/include/oboe/AudioStreamCallback.h
@@ -30,13 +30,13 @@ public:
     /**
      * A buffer is ready for processing.
      *
-     * @param oboeStream pointer to the associated stream
+     * @param oboeStream the associated stream
      * @param audioData buffer containing input data or a place to put output data
      * @param numFrames number of frames to be processed
      * @return DataCallbackResult::Continue or DataCallbackResult::Stop
      */
     virtual DataCallbackResult onAudioReady(
-            AudioStream *oboeStream,
+            const AudioStream &oboeStream,
             void *audioData,
             int32_t numFrames) = 0;
 
@@ -45,10 +45,10 @@ public:
      * The underlying stream will already be stopped by Oboe but not yet closed.
      * So the stream can be queried.
      *
-     * @param oboeStream pointer to the associated stream
+     * @param oboeStream the associated stream
      * @param error
      */
-    virtual void onErrorBeforeClose(AudioStream *oboeStream, Result error) {}
+    virtual void onErrorBeforeClose(const AudioStream &oboeStream, Result error) {}
 
     /**
      * This will be called when an error occurs on a stream or when the stream is disconnected.
@@ -57,10 +57,10 @@ public:
      *
      * This callback could be used to reopen a new stream on another device.
      *
-     * @param oboeStream pointer to the associated stream
+     * @param oboeStream the associated stream
      * @param error
      */
-    virtual void onErrorAfterClose(AudioStream *oboeStream, Result error) {}
+    virtual void onErrorAfterClose(const AudioStream &oboeStream, Result error) {}
 
 };
 

--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -32,7 +32,9 @@
 #define OBOE_VERSION_MAJOR 0
 
 // Type: 8-bit unsigned int. Min value: 0 Max value: 255. See below for description.
-#define OBOE_VERSION_MINOR 10
+// #define OBOE_VERSION_MINOR 9 // Initial developer preview
+// #define OBOE_VERSION_MINOR 10 // Namespaces, input streams supported via callback
+#define OBOE_VERSION_MINOR 11 // AudioStreamCallback uses references rather than pointers
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
 #define OBOE_VERSION_PATCH 0

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -205,7 +205,7 @@ DataCallbackResult AudioStreamAAudio::callOnAudioReady(AAudioStream *stream,
                                                                  void *audioData,
                                                                  int32_t numFrames) {
     return mStreamCallback->onAudioReady(
-            this,
+            *this,
             audioData,
             numFrames);
 }
@@ -215,11 +215,11 @@ void AudioStreamAAudio::onErrorInThread(AAudioStream *stream, Result error) {
     assert(stream == mAAudioStream.load());
     requestStop();
     if (mStreamCallback != nullptr) {
-        mStreamCallback->onErrorBeforeClose(this, error);
+        mStreamCallback->onErrorBeforeClose(*this, error);
     }
     close();
     if (mStreamCallback != nullptr) {
-        mStreamCallback->onErrorAfterClose(this, error);
+        mStreamCallback->onErrorAfterClose(*this, error);
     }
     LOGD("onErrorInThread() - exiting ===================================");
 }

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -49,7 +49,7 @@ DataCallbackResult AudioStream::fireCallback(void *audioData, int32_t numFrames)
     if (mStreamCallback == nullptr) {
         result = onDefaultCallback(audioData, numFrames);
     } else {
-        result = mStreamCallback->onAudioReady(this, audioData, numFrames);
+        result = mStreamCallback->onAudioReady(*this, audioData, numFrames);
         if (getDirection() == Direction::Input) {
             incrementFramesRead(numFrames);
         } else {


### PR DESCRIPTION
Fixes #31. 

How much deeper should this change go? Do we want to modify [`AudioStreamAAudio::callOnAudioReady`](https://github.com/google/oboe/blob/master/src/aaudio/AudioStreamAAudio.h#L95) and other similar methods as well? 

Note: This is a breaking API change, so the hello-oboe app will need to be updated as well. Another example of when it'd be useful to have the sample in this repo. 