### PR TITLE
oboe: add ErrorOrValue dual return

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <ctime>
 #include "oboe/Definitions.h"
+#include "oboe/ErrorOrValue.h"
 #include "oboe/AudioStreamBuilder.h"
 #include "oboe/AudioStreamBase.h"
 
@@ -174,16 +175,16 @@ public:
      * @param timeoutNanoseconds Maximum number of nanoseconds to wait for completion.
      * @return The number of frames actually written or a negative error.
      */
-    virtual int32_t write(const void *buffer,
+    virtual ErrorOrValue<int32_t> write(const void *buffer,
                              int32_t numFrames,
                              int64_t timeoutNanoseconds) {
-        return static_cast<int32_t>(Result::ErrorUnimplemented);
+        return ErrorOrValue<int32_t>(Result::ErrorUnimplemented);
     }
 
-    virtual int32_t read(void *buffer,
+    virtual ErrorOrValue<int32_t> read(void *buffer,
                             int32_t numFrames,
                             int64_t timeoutNanoseconds) {
-        return static_cast<int32_t>(Result::ErrorUnimplemented);
+        return ErrorOrValue<int32_t>(Result::ErrorUnimplemented);
     }
 
     /**

--- a/include/oboe/ErrorOrValue.h
+++ b/include/oboe/ErrorOrValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ public:
             , mError(error) {}
 
     explicit ErrorOrValue(T value)
-            : mValue(value < 0 ? 0 : value)
-            , mError(value < 0 ? static_cast<Result>(value) : oboe::Result::OK) {}
+            : mValue(value)
+            , mError(oboe::Result::OK) {}
 
     oboe::Result error() const {
         return mError;
@@ -41,12 +41,21 @@ public:
     }
 
     /**
-     * Quick way to check for an error.
-     * @return true if an error occurred  // TODO does this seem backwards?
+     * @return true if OK
      */
-    explicit operator bool() const { return mError != oboe::Result::OK; }
+    explicit operator bool() const { return mError == oboe::Result::OK; }
 
-    bool operator !() const { return mError == oboe::Result::OK; }
+    /**
+     * Quick way to check for an error.
+     *
+     * The caller could write something like this:
+     * <code>
+     *     if (!result) { printf("Got error %s\n", convertToText(result.error())); }
+     * </code>
+     *
+     * @return true if an error occurred
+     */
+    bool operator !() const { return mError != oboe::Result::OK; }
 
 private:
     const T             mValue;

--- a/include/oboe/ErrorOrValue.h
+++ b/include/oboe/ErrorOrValue.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_ERROR_OR_VALUE_H
+#define OBOE_ERROR_OR_VALUE_H
+
+#include "oboe/Definitions.h"
+
+namespace oboe {
+
+template <typename T>
+class ErrorOrValue {
+public:
+    explicit ErrorOrValue(oboe::Result error)
+            : mValue{}
+            , mError(error) {}
+
+    explicit ErrorOrValue(T value)
+            : mValue(value < 0 ? 0 : value)
+            , mError(value < 0 ? static_cast<Result>(value) : oboe::Result::OK) {}
+
+    oboe::Result error() const {
+        return mError;
+    }
+
+    T value() const {
+        return mValue;
+    }
+
+    /**
+     * Quick way to check for an error.
+     * @return true if an error occurred  // TODO does this seem backwards?
+     */
+    explicit operator bool() const { return mError != oboe::Result::OK; }
+
+    bool operator !() const { return mError == oboe::Result::OK; }
+
+private:
+    const T             mValue;
+    const oboe::Result  mError;
+};
+
+} // namespace oboe
+
+#endif //OBOE_ERROR_OR_VALUE_H

--- a/include/oboe/Oboe.h
+++ b/include/oboe/Oboe.h
@@ -18,6 +18,7 @@
 #define OBOE_OBOE_H
 
 #include "oboe/Definitions.h"
+#include "oboe/ErrorOrValue.h"
 #include "oboe/LatencyTuner.h"
 #include "oboe/AudioStream.h"
 #include "oboe/AudioStreamBase.h"

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -282,25 +282,29 @@ Result AudioStreamAAudio::requestStop() {
 }
 
 // TODO: Update to return tuple of Result and framesWritten (avoids cast)
-int32_t AudioStreamAAudio::write(const void *buffer,
+ErrorOrValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
                                      int32_t numFrames,
                                      int64_t timeoutNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-        return mLibLoader->stream_write(mAAudioStream, buffer, numFrames, timeoutNanoseconds);
+        int32_t result = mLibLoader->stream_write(mAAudioStream, buffer,
+                                                  numFrames, timeoutNanoseconds);
+        return ErrorOrValue<int32_t>(result);
     } else {
-        return static_cast<int32_t>(Result::ErrorNull);
+        return ErrorOrValue<int32_t>(Result::ErrorNull);
     }
 }
 
-int32_t AudioStreamAAudio::read(void *buffer,
+ErrorOrValue<int32_t>   AudioStreamAAudio::read(void *buffer,
                                  int32_t numFrames,
                                  int64_t timeoutNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-        return mLibLoader->stream_read(mAAudioStream, buffer, numFrames, timeoutNanoseconds);
+        int32_t result = mLibLoader->stream_read(mAAudioStream, buffer,
+                                                 numFrames, timeoutNanoseconds);
+        return ErrorOrValue<int32_t>(result);
     } else {
-        return static_cast<int32_t>(Result::ErrorNull);
+        return ErrorOrValue<int32_t>(Result::ErrorNull);
     }
 }
 

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -281,7 +281,6 @@ Result AudioStreamAAudio::requestStop() {
     }
 }
 
-// TODO: Update to return tuple of Result and framesWritten (avoids cast)
 ErrorOrValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
                                      int32_t numFrames,
                                      int64_t timeoutNanoseconds) {
@@ -289,7 +288,11 @@ ErrorOrValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
     if (stream != nullptr) {
         int32_t result = mLibLoader->stream_write(mAAudioStream, buffer,
                                                   numFrames, timeoutNanoseconds);
-        return ErrorOrValue<int32_t>(result);
+        if (result < 0) {
+            return ErrorOrValue<int32_t>(static_cast<Result>(result));
+        } else {
+            return ErrorOrValue<int32_t>(result);
+        }
     } else {
         return ErrorOrValue<int32_t>(Result::ErrorNull);
     }
@@ -302,7 +305,11 @@ ErrorOrValue<int32_t>   AudioStreamAAudio::read(void *buffer,
     if (stream != nullptr) {
         int32_t result = mLibLoader->stream_read(mAAudioStream, buffer,
                                                  numFrames, timeoutNanoseconds);
-        return ErrorOrValue<int32_t>(result);
+        if (result < 0) {
+            return ErrorOrValue<int32_t>(static_cast<Result>(result));
+        } else {
+            return ErrorOrValue<int32_t>(result);
+        }
     } else {
         return ErrorOrValue<int32_t>(Result::ErrorNull);
     }

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -60,11 +60,11 @@ public:
     Result requestFlush() override;
     Result requestStop() override;
 
-    int32_t write(const void *buffer,
+    ErrorOrValue<int32_t> write(const void *buffer,
                   int32_t numFrames,
                   int64_t timeoutNanoseconds) override;
 
-    int32_t read(void *buffer,
+    ErrorOrValue<int32_t> read(void *buffer,
                  int32_t numFrames,
                  int64_t timeoutNanoseconds) override;
 

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -110,7 +110,7 @@ ErrorOrValue<int32_t>  AudioStreamBuffered::transfer(void *buffer,
         LOGE("AudioStreamBuffered::%s(): numFrames is negative", __func__);
         return ErrorOrValue<int32_t>(Result::ErrorOutOfRange);
     } else if (numFrames == 0) {
-        return ErrorOrValue<int32_t>(0);
+        return ErrorOrValue<int32_t>(numFrames);
     }
     if (timeoutNanoseconds < 0) {
         LOGE("AudioStreamBuffered::%s(): timeoutNanoseconds is negative", __func__);

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -37,11 +37,11 @@ public:
     void allocateFifo();
 
 
-    int32_t write(const void *buffer,
+    ErrorOrValue<int32_t> write(const void *buffer,
                   int32_t numFrames,
                   int64_t timeoutNanoseconds) override;
 
-    int32_t read(void *buffer,
+    ErrorOrValue<int32_t> read(void *buffer,
                  int32_t numFrames,
                  int64_t timeoutNanoseconds) override;
 
@@ -74,7 +74,7 @@ private:
     void markCallbackTime(int numFrames);
 
     // Read or write to the FIFO.
-    int32_t transfer(void *buffer, int32_t numFrames, int64_t timeoutNanoseconds);
+    ErrorOrValue<int32_t> transfer(void *buffer, int32_t numFrames, int64_t timeoutNanoseconds);
 
     void incrementXRunCount() {
         mXRunCount++;


### PR DESCRIPTION
For returning an error code and a frame count, or other value, at the same time.