### PR TITLE
oboe: cleanup OpenSL ES input

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -186,7 +186,6 @@ public:
         return static_cast<int32_t>(Result::ErrorUnimplemented);
     }
 
-
     /**
      *
      * @return the API that this stream uses
@@ -228,8 +227,8 @@ protected:
      *   or ErrorTimeout.
      */
     virtual Result waitForStateTransition(StreamState startingState,
-                                              StreamState endingState,
-                                              int64_t timeoutNanoseconds);
+                                          StreamState endingState,
+                                          int64_t timeoutNanoseconds);
 
     /**
      * Override this to provide a default for when the application did not specify a callback.

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -61,8 +61,8 @@ DataCallbackResult AudioStream::fireCallback(void *audioData, int32_t numFrames)
 }
 
 Result AudioStream::waitForStateTransition(StreamState startingState,
-                                               StreamState endingState,
-                                               int64_t timeoutNanoseconds)
+                                           StreamState endingState,
+                                           int64_t timeoutNanoseconds)
 {
     StreamState state = getState();
     StreamState nextState = state;

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -156,12 +156,13 @@ Result AudioInputStreamOpenSLES::close() {
 Result AudioInputStreamOpenSLES::setRecordState(SLuint32 newState) {
     Result result = Result::OK;
     LOGD("AudioInputStreamOpenSLES::setRecordState(%d)", newState);
-    if (mRecordInterface == NULL) {
+    if (mRecordInterface == nullptr) {
+        LOGE("AudioInputStreamOpenSLES::SetRecordState() mRecordInterface is null");
         return Result::ErrorInvalidState;
     }
     SLresult slResult = (*mRecordInterface)->SetRecordState(mRecordInterface, newState);
     if(SL_RESULT_SUCCESS != slResult) {
-        LOGD("AudioInputStreamOpenSLES::setPlayState() returned %s", getSLErrStr(slResult));
+        LOGE("AudioInputStreamOpenSLES::SetRecordState() returned %s", getSLErrStr(slResult));
         result = Result::ErrorInvalidState; // TODO review
     } else {
         setState(StreamState::Pausing);
@@ -173,9 +174,7 @@ Result AudioInputStreamOpenSLES::requestStart()
 {
     LOGD("AudioInputStreamOpenSLES::requestStart()");
     Result result = setRecordState(SL_RECORDSTATE_RECORDING);
-    if(result != Result::OK) {
-        result = Result::ErrorInvalidState; // TODO review
-    } else {
+    if(result == Result::OK) {
         // Enqueue the first buffer so that we have data ready in the callback.
         enqueueCallbackBuffer(mSimpleBufferQueueInterface);
         setState(StreamState::Starting);

--- a/src/opensles/AudioInputStreamOpenSLES.h
+++ b/src/opensles/AudioInputStreamOpenSLES.h
@@ -55,7 +55,7 @@ private:
 
     Result setRecordState(SLuint32 newState);
 
-    SLRecordItf mRecordInterface;
+    SLRecordItf mRecordInterface = nullptr;
 };
 
 } // namespace oboe


### PR DESCRIPTION
Init imRecordInterface to nullptr.
Better logs.