### PR TITLE
a couple of tweaks for OpenSL ES: UNPROCESSED + Errors on logcat tearing down OpenSL

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -57,7 +57,7 @@ int AudioInputStreamOpenSLES::chanCountToChanMask(int channelCount) {
 Result AudioInputStreamOpenSLES::open() {
 
     Result oboeResult = AudioStreamOpenSLES::open();
-    if (Result::OK != oboeResult)  return oboeResult;
+    if (Result::OK != oboeResult) return oboeResult;
 
     SLuint32 bitsPerSample = getBytesPerSample() * kBitsPerByte;
 
@@ -97,29 +97,37 @@ Result AudioInputStreamOpenSLES::open() {
     SLDataLocator_IODevice loc_dev = {SL_DATALOCATOR_IODEVICE,
                                       SL_IODEVICE_AUDIOINPUT,
                                       SL_DEFAULTDEVICEID_AUDIOINPUT,
-                                      NULL };
-    SLDataSource audioSrc = {&loc_dev, NULL };
+                                      NULL};
+    SLDataSource audioSrc = {&loc_dev, NULL};
 
     SLresult result = EngineOpenSLES::getInstance().createAudioRecorder(&mObjectInterface,
-                                                                       &audioSrc,
-                                                                       &audioSink);
+                                                                        &audioSrc,
+                                                                        &audioSink);
     if (SL_RESULT_SUCCESS != result) {
         LOGE("createAudioRecorder() result:%s", getSLErrStr(result));
         goto error;
     }
 
-    // Configure the voice recognition preset, which has no
+    // Configure the unprocessed preset
+    // or voice recognition as fallback, which has no
     // signal processing, for lower latency.
     SLAndroidConfigurationItf inputConfig;
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
-                                            SL_IID_ANDROIDCONFIGURATION,
-                                            &inputConfig);
+                                               SL_IID_ANDROIDCONFIGURATION,
+                                               &inputConfig);
     if (SL_RESULT_SUCCESS == result) {
-        SLuint32 presetValue = SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION;
-        (*inputConfig)->SetConfiguration(inputConfig,
-                                         SL_ANDROID_KEY_RECORDING_PRESET,
-                                         &presetValue,
-                                         sizeof(SLuint32));
+        SLuint32 presetValue = SL_ANDROID_RECORDING_PRESET_UNPROCESSED;
+        result = (*inputConfig)->SetConfiguration(inputConfig,
+                                                  SL_ANDROID_KEY_RECORDING_PRESET,
+                                                  &presetValue,
+                                                  sizeof(SLuint32));
+        if (SL_RESULT_SUCCESS != result) {
+            presetValue = SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION;
+            (*inputConfig)->SetConfiguration(inputConfig,
+                                             SL_ANDROID_KEY_RECORDING_PRESET,
+                                             &presetValue,
+                                             sizeof(SLuint32));
+        }
     }
 
     result = (*mObjectInterface)->Realize(mObjectInterface, SL_BOOLEAN_FALSE);
@@ -143,7 +151,7 @@ Result AudioInputStreamOpenSLES::open() {
 
     return Result::OK;
 
-error:
+    error:
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE
 }
 
@@ -161,7 +169,7 @@ Result AudioInputStreamOpenSLES::setRecordState(SLuint32 newState) {
         return Result::ErrorInvalidState;
     }
     SLresult slResult = (*mRecordInterface)->SetRecordState(mRecordInterface, newState);
-    if(SL_RESULT_SUCCESS != slResult) {
+    if (SL_RESULT_SUCCESS != slResult) {
         LOGE("AudioInputStreamOpenSLES::SetRecordState() returned %s", getSLErrStr(slResult));
         result = Result::ErrorInvalidState; // TODO review
     } else {
@@ -170,11 +178,10 @@ Result AudioInputStreamOpenSLES::setRecordState(SLuint32 newState) {
     return result;
 }
 
-Result AudioInputStreamOpenSLES::requestStart()
-{
+Result AudioInputStreamOpenSLES::requestStart() {
     LOGD("AudioInputStreamOpenSLES::requestStart()");
     Result result = setRecordState(SL_RECORDSTATE_RECORDING);
-    if(result == Result::OK) {
+    if (result == Result::OK) {
         // Enqueue the first buffer so that we have data ready in the callback.
         enqueueCallbackBuffer(mSimpleBufferQueueInterface);
         setState(StreamState::Starting);
@@ -186,7 +193,7 @@ Result AudioInputStreamOpenSLES::requestStart()
 Result AudioInputStreamOpenSLES::requestPause() {
     LOGD("AudioInputStreamOpenSLES::requestStop()");
     Result result = setRecordState(SL_RECORDSTATE_PAUSED);
-    if(result != Result::OK) {
+    if (result != Result::OK) {
         result = Result::ErrorInvalidState; // TODO review
     } else {
         setState(StreamState::Pausing);
@@ -201,7 +208,7 @@ Result AudioInputStreamOpenSLES::requestFlush() {
 Result AudioInputStreamOpenSLES::requestStop() {
     LOGD("AudioInputStreamOpenSLES::requestStop()");
     Result result = setRecordState(SL_RECORDSTATE_STOPPED);
-    if(result != Result::OK) {
+    if (result != Result::OK) {
         result = Result::ErrorInvalidState; // TODO review
     } else {
         setState(StreamState::Stopping);
@@ -210,8 +217,8 @@ Result AudioInputStreamOpenSLES::requestStop() {
 }
 
 Result AudioInputStreamOpenSLES::waitForStateChange(StreamState currentState,
-                                                     StreamState *nextState,
-                                                     int64_t timeoutNanoseconds) {
+                                                    StreamState *nextState,
+                                                    int64_t timeoutNanoseconds) {
     LOGD("AudioInputStreamOpenSLES::waitForStateChange()");
     if (mRecordInterface == NULL) {
         return Result::ErrorInvalidState;

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -148,11 +148,16 @@ error:
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE
 }
 
+Result AudioOutputStreamOpenSLES::onAfterDestroy() {
+    OutputMixerOpenSL::getInstance().close();
+
+    return Result::OK;
+}
+
 Result AudioOutputStreamOpenSLES::close() {
     requestPause();
     // invalidate any interfaces
     mPlayInterface = NULL;
-    OutputMixerOpenSL::getInstance().close();
     return AudioStreamOpenSLES::close();
 }
 

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -52,6 +52,8 @@ public:
 
 private:
 
+    Result onAfterDestroy() override;
+
     /**
      * Set OpenSL ES PLAYSTATE.
      *

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -117,13 +117,19 @@ Result AudioStreamOpenSLES::open() {
 }
 
 Result AudioStreamOpenSLES::close() {
+    onBeforeDestroy();
+
     if (mObjectInterface != nullptr) {
         (*mObjectInterface)->Destroy(mObjectInterface);
         mObjectInterface = nullptr;
 
     }
+
+    onAfterDestroy();
+
     mSimpleBufferQueueInterface = nullptr;
     EngineOpenSLES::getInstance().close();
+
     return Result::OK;
 }
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -73,6 +73,9 @@ public:
 
 protected:
 
+    virtual Result onBeforeDestroy() { return Result::OK; };
+    virtual Result onAfterDestroy() { return Result::OK; };
+
     static SLuint32 getDefaultByteOrder();
 
     SLresult registerBufferQueueCallback();


### PR DESCRIPTION
hi! i guess this is my public PR :)

anyway, a couple of things here:

* changed the recording preset for OpenSL ES to `SL_ANDROID_RECORDING_PRESET_UNPROCESSED` since it's meant to be used whenever you need raw sound, truly unprocessed (no AGC, no EC, no HPF). [more info](http://source.android.youdaxue.com/compatibility/android-cdd#5_11_capture_for_unprocessed). 
one can read around that the preset to be used for raw sound is `SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION`, but for me (my device is a bq aquaris X pro) that preset, though my recorded voice is clear, didn't gave me pleasant results when i play the guitar and sing and record. it caused some weird artifacts; it was like the background room noise (i guess my own voice echo on walls, street sounds, etc.) sounded like trough they would sound through a phone call. i think it's because there's some high pass filter there, and make sense IMHO for voice recognition purpose. also, if unprocessed preset is not available for some reason, the fallback is voice recognition.

* again for OpenSL backend when closing the streams, though it worked and no crash, i saw errors on AS logcat from libOpenSLES. the reason was how the output stream was closed: the mixer was destroyed **before** destroy the player, which was *attached* to it so then the error was shown. so, i've added some *abstract* methods (`onBeforeDestroy` and `onAfterDestroy` to `AudioStreamOpenSLES` in order to provide subclasses a more fine grained approach to handle their tearing down flow.

also, i use a lot the android studio auto-format feature, so excuse me if there're some code style auto formatting stuff here.