### PR TITLE
Expose header directory to users via CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ set (oboe_sources
 add_library(oboe STATIC ${oboe_sources})
 
 # Specify directories which the compiler should look for headers
-target_include_directories(oboe PRIVATE src include)
+target_include_directories(oboe
+                           PRIVATE src 
+                           PUBLIC include)
 
 target_compile_options(oboe PRIVATE -std=c++11
                             PRIVATE -Wall


### PR DESCRIPTION
by PUBLIC for include directory, it will be automatically included for users using add_subdirectory(); it would also copy to the release directory if there is configures ( I think ).

a little convenience for users: it seems older versions were using public, latest one changed it to private