### PR TITLE
add const modifier to oboe::AudioStream::getFramesPerBurst()

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -142,7 +142,7 @@ public:
      *
      * @return burst size
      */
-    virtual int32_t getFramesPerBurst() = 0;
+    virtual int32_t getFramesPerBurst() const = 0;
 
     bool isPlaying();
 

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -342,7 +342,7 @@ int32_t AudioStreamAAudio::getBufferSizeInFrames() const {
     }
 }
 
-int32_t AudioStreamAAudio::getFramesPerBurst() {
+int32_t AudioStreamAAudio::getFramesPerBurst() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         return mLibLoader->stream_getFramesPerBurst(stream);

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -70,7 +70,7 @@ public:
 
     Result setBufferSizeInFrames(int32_t requestedFrames) override;
     int32_t getBufferSizeInFrames() const override;
-    int32_t getFramesPerBurst() override;
+    int32_t getFramesPerBurst() const override;
     int32_t getXRunCount() const override;
 
     int64_t getFramesRead() const override;

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -168,7 +168,7 @@ SLresult AudioStreamOpenSLES::registerBufferQueueCallback() {
     return result;
 }
 
-int32_t AudioStreamOpenSLES::getFramesPerBurst() {
+int32_t AudioStreamOpenSLES::getFramesPerBurst() const {
     return mFramesPerBurst;
 }
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -57,7 +57,7 @@ public:
      */
     StreamState getState() override { return mState; }
 
-    int32_t getFramesPerBurst() override;
+    int32_t getFramesPerBurst() const override;
 
 
     AudioApi getAudioApi() const override {


### PR DESCRIPTION
It is more of a question: most of "get" functions are const, this getFramePerBurst() is not. Is this intentional? after adding "const", it still works.

the benefit is that: user does not have to do something like:
  const_cast<AudioStream*>(stream)->getFramesPerBurst() anymore

thanks