### PR TITLE
Adding travis ci to the repo

### DIFF
--- a/.ci_tools/build_samples.sh
+++ b/.ci_tools/build_samples.sh
@@ -1,0 +1,44 @@
+# Configurations:
+#  temp file name to hold build result
+BUILD_RESULT_FILE=build_result.txt
+
+# Repo root directory
+REPO_ROOT_DIR=.
+
+
+declare projects=(
+    samples
+)
+
+for d in "${projects[@]}"; do
+    pushd ${REPO_ROOT_DIR}/${d} >/dev/null
+    TERM=dumb ./gradlew  -q clean assembleDebug
+    popd >/dev/null
+done
+
+
+# Check the apks that all get built fine
+# TBD: add echo after it is merged
+#        samples/echo/build/outputs/apk/debug/echo-debug.apk
+declare apks=(
+    samples/hello-oboe/build/outputs/apk/debug/hello-oboe-debug.apk
+    samples/MegaDrone/build/outputs/apk/debug/MegaDrone-debug.apk
+    samples/RhythmGame/build/outputs/apk/debug/RhythmGame-debug.apk
+)
+
+rm -fr ${BUILD_RESULT_FILE}
+for apk in "${apks[@]}"; do
+  if [ ! -f ${REPO_ROOT_DIR}/${apk} ]; then
+    export SAMPLE_CI_RESULT=1
+    echo ${apk} does not build >> ${BUILD_RESULT_FILE}
+  fi
+done
+
+if [ -f ${BUILD_RESULT_FILE} ]; then
+   echo  "******* Failed Builds ********:"
+   cat  ${BUILD_RESULT_FILE}
+else
+  echo "======= BUILD SUCCESS ======="
+fi
+
+rm -fr ${BUILD_RESULT_FILE}

--- a/.ci_tools/misc_ci.sh
+++ b/.ci_tools/misc_ci.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set +e
+
+MISC_STATUS=0
+
+# check that all targetSdkVersion are 26+
+# test "$(grep -H targetSdkVersion */app/build.gradle | tee /dev/stderr | cut -d= -f 2 | xargs -n1 echo | sort | uniq | wc -l)" = "2"
+# check that there is no tabs in AndroidManifest
+(! grep -n $'\t' */*/src/main/AndroidManifest.xml) | cat -t;
+MISC_STATUS=$(($MISC_STATUS + ${PIPESTATUS[0]}))
+
+# check that there is no trailing spaces in AndroidManifest
+(! grep -E '\s+$' */*/src/main/AndroidManifest.xml) | cat -e;
+MISC_STATUS=$(($MISC_STATUS + ${PIPESTATUS[0]}))
+
+# populate the error to final status
+if [[ "$MISC_STATUS" -ne 0 ]]; then
+    SAMPLE_CI_RESULT=$(($SAMPLE_CI_RESULT + 1))
+fi

--- a/.ci_tools/run_samples.sh
+++ b/.ci_tools/run_samples.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# TBD: load apks on emulator
+#

--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# assumption:
+#  - pwd must be inside the repo's homed directory (android-ndk)
+#  - upon completion, we are still in the same directory ( no change )
+
+TMP_SETUP_FILENAME=versions_.txt
+
+# parse all build.gradle to find the specified tokens' version
+# usage:
+#    retrive_versions  token version_file
+# where
+#    token: the token to search for inside build.grade
+#           version string is right after the token string
+#    version_file: file to hold the given versions
+#                  one version at a line
+retrieve_versions() {
+#   $1: token; $2 version_file
+    if [[ -z $1 ]] || [[ -z $2 ]]; then
+        echo "input string(s) may be empty: token: $1; version_file: $2"
+        return 1
+    fi
+
+    find . -type f -name 'build.gradle' -exec grep $1 {} +  | \
+    sed "s/^.*$1//" | sed 's/[=+]//g' |   \
+    sed 's/"//g' | sed "s/'//g" |     \
+    sed 's/[[:space:]]//g' | \
+    awk '!seen[$0]++' > $2
+    
+    return 0
+}
+
+## Retrieve all necessary Android Platforms and install them all
+retrieve_versions compileSdkVersion $TMP_SETUP_FILENAME
+
+# fixups
+sed -i '/COMPILE_SDK_VERSION/d' $TMP_SETUP_FILENAME
+# Install platforms
+while read -r version_; do
+	echo y | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-$version_";
+done < $TMP_SETUP_FILENAME
+#echo "Android platforms:"; cat $TMP_SETUP_FILENAME;rm -f $TMP_SETUP_FILENAME
+
+## Retrieve constraint-layout versions
+retrieve_versions "constraint-layout:"  $TMP_SETUP_FILENAME
+while read -r version_; do
+    echo y | $ANDROID_HOME/tools/bin/sdkmanager \
+        "extras;m2repository;com;android;support;constraint;constraint-layout;$version_"
+done < $TMP_SETUP_FILENAME
+#echo "constraint-layout versions:"; cat $TMP_SETUP_FILENAME;
+rm -f $TMP_SETUP_FILENAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: android
+sudo: true
+android:
+  components:
+    - tools
+    - platform-tools
+    - extra-google-m2repository
+    - extra-android-m2repository
+addons:
+  apt_packages:
+    - pandoc
+before_install:
+  - sudo apt-get install ant
+install:
+  - touch ~/.android/repositories.cfg
+  - echo y | sdkmanager "ndk-bundle"
+  - echo y | sdkmanager "cmake;3.6.4111459"
+  - echo y | sdkmanager "lldb;3.1"
+  # the following line triggers Trivis-CI's 4MB log limit
+    #  - sdkmanager --update
+before_script:
+  - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+
+script:
+  # scripts excutes inside our repo directory on CI machine
+  - export SAMPLE_CI_RESULT=0
+  - source .ci_tools/setup_env.sh
+  - source .ci_tools/build_samples.sh
+  - source .ci_tools/run_samples.sh
+  - source .ci_tools/misc_ci.sh
+  - eval "[[ $SAMPLE_CI_RESULT == 0 ]]"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oboe
+# Oboe [![Build Status](https://travis-ci.org/google/oboe.svg?branch=master)](https://travis-ci.org/google/oboe)
 **Oboe is currently in developer preview.**
 
 Oboe is a C++ library which makes it easy to build high-performance audio apps on Android. It was created primarily to allow developers to target a simplified API that works across multiple API levels back to API level 16 (Jelly Bean).
@@ -37,3 +37,7 @@ We would love to receive your pull requests. Before we can though, please read t
 
 - 18th January 2018 - v0.10 Add support for input (recording) streams
 - 18th October 2017 - v0.9 Initial developer preview
+
+## License
+[LICENSE](LICENSE)
+

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -21,11 +21,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -33,7 +33,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }


### PR DESCRIPTION
Adding CI to the repo:

- use samples directory ci every check-in
- only checking build to be successful

The final one should look like this one:
- [repo](https://github.com/ggfan/testOboe)
- [ci-page](https://travis-ci.org/ggfan/testOboe)

If you are interested, let me know. In order for it to work, additional steps:

- enable travis-ci on your repo (only repo owner could do it )
- merge in this pull-request

only then could think of how to do run-time for the built samples ( emulator or firebase ci with devices )

Kindly share your thoughts: if you like it, let's the fun begin