### PR TITLE
ResultWithValue: Doc updates, version bump and code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We would love to receive your pull requests. Before we can though, please read t
 
 ## Version history
 
+- [13th June 2018 - v0.11](https://github.com/google/oboe/pull/109) Change `AudioStream` method return types to `ResultWithValue` where appropriate
 - 18th January 2018 - v0.10 Add support for input (recording) streams
 - 18th October 2017 - v0.9 Initial developer preview
 

--- a/docs/FullGuide.md
+++ b/docs/FullGuide.md
@@ -332,15 +332,16 @@ The callback does a non-blocking read from the input stream placing the data int
                 AudioStream *oboeStream,
                 void *audioData,
                 int32_t numFrames){
-            Result result = stream2.read(audioData, numFrames, timeout);
-
-            if (result == numFrames)
-                return DataCallbackResult::Continue;
-            if (result >= 0) {
-                memset(static_cast<sample_type*>(audioData) + result * samplesPerFrame, 0,
-                    sizeof(sample_type) * (numFrames - result) * samplesPerFrame);
-                return DataCallbackResult::Continue;
-            }
+            auto result = stream2.read(audioData, numFrames, timeout);
+            if (result == Result::OK){
+			    if (result == numFrames)
+                    return DataCallbackResult::Continue;
+			    if (result.value() >= 0) {
+                    memset(static_cast<sample_type*>(audioData) + result.value() * samplesPerFrame, 0,
+                        sizeof(sample_type) * (numFrames - result.value()) * samplesPerFrame);
+                    return DataCallbackResult::Continue;
+                }
+			}
             return DataCallbackResult::Stop;
         }
 

--- a/docs/FullGuide.md
+++ b/docs/FullGuide.md
@@ -333,8 +333,9 @@ The callback does a non-blocking read from the input stream placing the data int
                 void *audioData,
                 int32_t numFrames){
             auto result = stream2.read(audioData, numFrames, timeout);
+            // result has type ResultWithValue<int32_t>, which for convenience is coerced to a Result type when compared with another Result.
             if (result == Result::OK){
-			    if (result == numFrames)
+			    if (result.value() == numFrames)
                     return DataCallbackResult::Continue;
 			    if (result.value() >= 0) {
                     memset(static_cast<sample_type*>(audioData) + result.value() * samplesPerFrame, 0,

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -180,7 +180,8 @@ public:
      * The latency of an OUTPUT stream is generally higher than the INPUT latency
      * because an app generally tries to keep the OUTPUT buffer full and the INPUT buffer empty.
      *
-     * @return The latency in milliseconds and Result::OK, or a negative error.
+     * @return a ResultWithValue which has a result of Result::OK and a value containing the latency
+     * in milliseconds, or a result of Result::Error*.
      */
     virtual ResultWithValue<double> calculateLatencyMillis() {
         return ResultWithValue<double>(Result::ErrorUnimplemented);
@@ -201,7 +202,8 @@ public:
      * @param buffer The address of the first sample.
      * @param numFrames Number of frames to write. Only complete frames will be written.
      * @param timeoutNanoseconds Maximum number of nanoseconds to wait for completion.
-     * @return The number of frames actually written and Result::OK, or a negative error.
+     * @return a ResultWithValue which has a result of Result::OK and a value containing the number
+     * of frames actually written, or result of Result::Error*.
      */
     virtual ResultWithValue<int32_t> write(const void *buffer,
                              int32_t numFrames,

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -132,10 +132,11 @@ public:
      *
      * An underrun or overrun can cause an audible "pop" or "glitch".
      *
-     * @return the count or negative error.
+     * @return a result which is either Result::OK with the xRun count as the value, or a
+     * Result::Error* code
      */
-    virtual int32_t getXRunCount() const {
-        return static_cast<int32_t>(Result::ErrorUnimplemented);
+    virtual ResultWithValue<int32_t> getXRunCount() const {
+        return ResultWithValue<int32_t>(Result::ErrorUnimplemented);
     }
 
     /**

--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -32,7 +32,7 @@
 #define OBOE_VERSION_MAJOR 0
 
 // Type: 8-bit unsigned int. Min value: 0 Max value: 255. See below for description.
-#define OBOE_VERSION_MINOR 10
+#define OBOE_VERSION_MINOR 11
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
 #define OBOE_VERSION_PATCH 0

--- a/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
@@ -173,10 +173,10 @@ PlayAudioEngine::onAudioReady(oboe::AudioStream *audioStream, void *audioData, i
      *
      * See https://developer.android.com/studio/profile/systrace-commandline.html
      */
-    int32_t underrunCount = audioStream->getXRunCount();
+    auto underrunCountResult = audioStream->getXRunCount();
 
     Trace::beginSection("numFrames %d, Underruns %d, buffer size %d",
-                        numFrames, underrunCount, bufferSize);
+                        numFrames, underrunCountResult.value(), bufferSize);
 
     int32_t channelCount = audioStream->getChannelCount();
 

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -314,7 +314,7 @@ ResultWithValue<int32_t> AudioStreamAAudio::setBufferSizeInFrames(int32_t reques
         requestedFrames = mBufferCapacityInFrames;
     }
     int32_t newBufferSize = mLibLoader->stream_setBufferSize(mAAudioStream, requestedFrames);
-    ResultWithValue<int32_t>::createBasedOnSign(newBufferSize);
+    return ResultWithValue<int32_t>::createBasedOnSign(newBufferSize);
 }
 
 StreamState AudioStreamAAudio::getState() {

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -271,11 +271,7 @@ ResultWithValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
     if (stream != nullptr) {
         int32_t result = mLibLoader->stream_write(mAAudioStream, buffer,
                                                   numFrames, timeoutNanoseconds);
-        if (result < 0) {
-            return ResultWithValue<int32_t>(static_cast<Result>(result));
-        } else {
-            return ResultWithValue<int32_t>(result);
-        }
+        return ResultWithValue<int32_t>::createBasedOnSign(result);
     } else {
         return ResultWithValue<int32_t>(Result::ErrorNull);
     }
@@ -317,13 +313,8 @@ ResultWithValue<int32_t> AudioStreamAAudio::setBufferSizeInFrames(int32_t reques
     if (requestedFrames > mBufferCapacityInFrames) {
         requestedFrames = mBufferCapacityInFrames;
     }
-    int newBufferSize = mLibLoader->stream_setBufferSize(mAAudioStream, requestedFrames);
-    if (newBufferSize < 0){
-        // Negative buffer size indicates error
-        return ResultWithValue<int32_t>(static_cast<Result>(newBufferSize));
-    } else{
-        return ResultWithValue<int32_t>(newBufferSize);
-    }
+    int32_t newBufferSize = mLibLoader->stream_setBufferSize(mAAudioStream, requestedFrames);
+    ResultWithValue<int32_t>::createBasedOnSign(newBufferSize);
 }
 
 StreamState AudioStreamAAudio::getState() {

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -371,12 +371,12 @@ int64_t AudioStreamAAudio::getFramesWritten() const {
     }
 }
 
-int32_t AudioStreamAAudio::getXRunCount() const {
+ResultWithValue<int32_t> AudioStreamAAudio::getXRunCount() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-        return mLibLoader->stream_getXRunCount(stream);
+        return ResultWithValue<int32_t>::createBasedOnSign(mLibLoader->stream_getXRunCount(stream));
     } else {
-        return static_cast<int32_t>(Result::ErrorNull);
+        return ResultWithValue<int32_t>(Result::ErrorNull);
     }
 }
 

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -71,7 +71,7 @@ public:
     ResultWithValue<int32_t> setBufferSizeInFrames(int32_t requestedFrames) override;
     int32_t getBufferSizeInFrames() const override;
     int32_t getFramesPerBurst() const override;
-    int32_t getXRunCount() const override;
+    ResultWithValue<int32_t> getXRunCount() const override;
 
     int64_t getFramesRead() const override;
     int64_t getFramesWritten() const override;

--- a/src/common/LatencyTuner.cpp
+++ b/src/common/LatencyTuner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Android Open Source Project
+ * Copyright 2017 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/LatencyTuner.cpp
+++ b/src/common/LatencyTuner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Android Open Source Project
+ * Copyright 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,37 +37,39 @@ Result LatencyTuner::tune() {
         reset();
     }
 
-    switch (mState) {
-        case State::Idle:
-            if (--mIdleCountDown <= 0) {
-                mState = State::Active;
-            }
-            mPreviousXRuns = mStream.getXRunCount();
-            if (mPreviousXRuns < 0) {
-                result = static_cast<Result>(mPreviousXRuns); // error code
-                mState = State::Unsupported;
-            }
-            break;
+    // Set state to Active if the idle countdown has reached zero.
+    if (mState == State::Idle && --mIdleCountDown <= 0) {
+        mState = State::Active;
+    }
 
-        case State::Active: {
-            int32_t xRuns = mStream.getXRunCount();
-            if ((xRuns - mPreviousXRuns) > 0) {
-                mPreviousXRuns = xRuns;
+    // When state is Active attempt to change the buffer size if the number of xRuns has increased.
+    if (mState == State::Active) {
+
+        auto xRunCountResult = mStream.getXRunCount();
+        if (xRunCountResult == Result::OK) {
+            if ((xRunCountResult.value() - mPreviousXRuns) > 0) {
+                mPreviousXRuns = xRunCountResult.value();
                 int32_t oldBufferSize = mStream.getBufferSizeInFrames();
                 int32_t requestedBufferSize = oldBufferSize + mStream.getFramesPerBurst();
                 auto setBufferResult = mStream.setBufferSizeInFrames(requestedBufferSize);
-                if (setBufferResult != Result::OK){
+                if (setBufferResult != Result::OK) {
                     result = setBufferResult;
                     mState = State::Unsupported;
-                } else if (setBufferResult.value() == oldBufferSize){
+                } else if (setBufferResult.value() == oldBufferSize) {
                     mState = State::AtMax;
                 }
             }
+        } else {
+            mState = State::Unsupported;
         }
+    }
 
-        case State::AtMax:
-        case State::Unsupported:
-            break;
+    if (mState == State::Unsupported) {
+        result = Result::ErrorUnimplemented;
+    }
+
+    if (mState == State::AtMax) {
+        result = Result::OK;
     }
     return result;
 }

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -94,9 +94,8 @@ int64_t AudioStreamBuffered::predictNextCallbackTime() {
     return mBackgroundRanAtNanoseconds + nanosPerBuffer + margin;
 }
 
-// TODO: Consider returning an error_or_value struct instead.
 // Common code for read/write.
-// @return number of frames transferred or negative error
+// @return Result::OK with frames read/written, or Result::Error*
 ResultWithValue<int32_t>  AudioStreamBuffered::transfer(void *buffer,
                                       int32_t numFrames,
                                       int64_t timeoutNanoseconds) {

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -51,8 +51,8 @@ public:
 
     int32_t getBufferCapacityInFrames() const override;
 
-    int32_t getXRunCount() const override {
-        return mXRunCount;
+    ResultWithValue<int32_t> getXRunCount() const override {
+        return ResultWithValue<int32_t>(mXRunCount);
     }
 
     int64_t getFramesWritten() const override;


### PR DESCRIPTION
## v0.11 ResultWithValue - BREAKING CHANGE!

This change (and [this one](https://github.com/google/oboe/pull/87)) add a new object `ResultWithValue` and change some of the `AudioStream` method signatures in the Oboe library.

### Why make this change? 
Some of the `AudioStream` methods would return a positive (or zero) value if they were successful and a negative value if not. For example, consider the following code which attempts to set a stream's buffer size: 

    int32_t result = stream->setBufferSizeInFrames(newBufferSize)
    if (result < 0){
        LOGD("Error setting buffer size: %s", convertToText(static_cast<Result>(result));
    } else {
        LOGD("New buffer size is: %d", result);
    }

The `setBufferSizeInFrames` method is actually returning two pieces of information: 

1) whether the call succeeded or failed
2) the new buffer size if the call succeeded

The method breaks [the single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle) which can lead to inelegant and confusing code. Also, casting an `int32_t` to a `Result` is a bug waiting to happen! 

### What's new then? 
To solve this problem we added a new object [`ResultWithValue`](https://github.com/google/oboe/blob/master/include/oboe/ResultWithValue.h) which encapsulates the 2 pieces of information above. 

You can check whether an operation was successful by comparing the `ResultWithValue` with a `Result` (e.g. `if (result != Result::OK) { // error }`, or by calling `ResultWithValue::error()`. 

The value can be retrieved by calling `ResultWithValue::value()`. 

The above code can now be made more readable: 

    auto result = stream->setBufferSizeInFrames(newBufferSize)
    if (result != Result::OK){
        LOGD("Error setting buffer size: %s", convertToText(result.error());
    } else {
        LOGD("New buffer size is: %d", result.value());
    }

### Which methods are affected?
The following methods in AudioStream have updated method signatures: 

    ResultWithValue<int32_t> setBufferSizeInFrames(int32_t requestedFrames)
    ResultWithValue<int32_t> getXRunCount()
    ResultWithValue<double> calculateLatencyMillis()
    ResultWithValue<int32_t> write(const void *buffer,
                             int32_t numFrames,
                             int64_t timeoutNanoseconds)
    virtual ResultWithValue<int32_t> read(void *buffer,
                            int32_t numFrames,
                            int64_t timeoutNanoseconds)

If you are using any of the above methods you'll need to update your code in line with the example above. 





