### PR TITLE
For OpenSL ES, bypass PERFORMANCE_MODE for android N and older platforms

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -137,11 +137,17 @@ SLuint32 AudioStreamOpenSLES::convertPerformanceMode(PerformanceMode oboeMode) c
 }
 
 SLresult AudioStreamOpenSLES::configurePerformanceMode(SLAndroidConfigurationItf configItf) {
-    SLuint32 performanceMode = convertPerformanceMode(getPerformanceMode());
-    SLresult result = (*configItf)->SetConfiguration(configItf, SL_ANDROID_KEY_PERFORMANCE_MODE,
-                                            &performanceMode, sizeof(performanceMode));
-    if (SL_RESULT_SUCCESS != result) {
-        LOGE("SetConfiguration(PERFORMANCE_MODE, %u) returned %d", performanceMode, result);
+    SLresult result = SL_RESULT_SUCCESS;
+    if(getSdkVersion() >= __ANDROID_API_N_MR1__) {
+        SLuint32 performanceMode = convertPerformanceMode(getPerformanceMode());
+        result = (*configItf)->SetConfiguration(configItf, SL_ANDROID_KEY_PERFORMANCE_MODE,
+                                                         &performanceMode, sizeof(performanceMode));
+        if (SL_RESULT_SUCCESS != result) {
+            LOGW("SetConfiguration(PERFORMANCE_MODE, %u) returned %d", performanceMode, result);
+            mPerformanceMode = PerformanceMode::None;
+        }
+    } else {
+        mPerformanceMode = PerformanceMode::None;
     }
     return result;
 }


### PR DESCRIPTION
This is fixes issue https://github.com/google/oboe/issues/124, and LiveEffect will work for older platforms. Please carefully review it: my reading is that NMR1 began having the feature.
