### PR TITLE
Fix incorrect logic for OpenSL ES performance configurations

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -125,7 +125,7 @@ SLuint32 AudioStreamOpenSLES::convertPerformanceMode(PerformanceMode oboeMode) c
             openslMode =  SL_ANDROID_PERFORMANCE_NONE;
             break;
         case PerformanceMode::LowLatency:
-            openslMode =  (getSessionId() != SessionId::None) ?  SL_ANDROID_PERFORMANCE_LATENCY : SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS;
+            openslMode =  (getSessionId() == SessionId::None) ?  SL_ANDROID_PERFORMANCE_LATENCY : SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS;
             break;
         case PerformanceMode::PowerSaving:
             openslMode =  SL_ANDROID_PERFORMANCE_POWER_SAVING;


### PR DESCRIPTION
When there is no stream session id `SL_ANDROID_PERFORMANCE_LATENCY` should be used
When there is a stream session id `SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS` should be used