### PR TITLE
opensles: generate channel masks safely by OS version

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -57,15 +57,19 @@ AudioInputStreamOpenSLES::AudioInputStreamOpenSLES(const AudioStreamBuilder &bui
 AudioInputStreamOpenSLES::~AudioInputStreamOpenSLES() {
 }
 
-int AudioInputStreamOpenSLES::chanCountToChanMask(int channelCount) {
-    // from internal sles_channel_in_mask_from_count(chanCount);
+// Calculate masks specific to INPUT streams.
+SLuint32 AudioInputStreamOpenSLES::channelCountToChannelMask(int channelCount) {
+    // Derived from internal sles_channel_in_mask_from_count(chanCount);
+    // in "frameworks/wilhelm/src/android/channels.cpp".
+    // Yes, it seems strange to use SPEAKER constants to describe inputs.
+    // But that is how OpenSL ES does it internally.
     switch (channelCount) {
         case 1:
             return SL_SPEAKER_FRONT_LEFT;
         case 2:
             return SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
         default:
-            return chanCountToChanMaskDefault(channelCount);
+            return channelCountToChannelMaskDefault(channelCount);
     }
 }
 
@@ -88,7 +92,7 @@ Result AudioInputStreamOpenSLES::open() {
             (SLuint32) (mSampleRate * kMillisPerSecond),    // milliSamplesPerSec
             bitsPerSample,                      // bitsPerSample
             bitsPerSample,                      // containerSize;
-            (SLuint32) chanCountToChanMask(mChannelCount), // channelMask
+            channelCountToChannelMask(mChannelCount), // channelMask
             getDefaultByteOrder(),
     };
 

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -57,9 +57,6 @@ AudioInputStreamOpenSLES::AudioInputStreamOpenSLES(const AudioStreamBuilder &bui
 AudioInputStreamOpenSLES::~AudioInputStreamOpenSLES() {
 }
 
-#define AUDIO_CHANNEL_COUNT_MAX         30u
-#define SL_ANDROID_UNKNOWN_CHANNELMASK  0
-
 int AudioInputStreamOpenSLES::chanCountToChanMask(int channelCount) {
     // from internal sles_channel_in_mask_from_count(chanCount);
     switch (channelCount) {
@@ -67,14 +64,8 @@ int AudioInputStreamOpenSLES::chanCountToChanMask(int channelCount) {
             return SL_SPEAKER_FRONT_LEFT;
         case 2:
             return SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
-        default: {
-            if (channelCount > AUDIO_CHANNEL_COUNT_MAX) {
-                return SL_ANDROID_UNKNOWN_CHANNELMASK;
-            } else {
-                SLuint32 bitfield = (1 << channelCount) - 1;
-                return SL_ANDROID_MAKE_INDEXED_CHANNEL_MASK(bitfield);
-            }
-        }
+        default:
+            return chanCountToChanMaskDefault(channelCount);
     }
 }
 

--- a/src/opensles/AudioInputStreamOpenSLES.h
+++ b/src/opensles/AudioInputStreamOpenSLES.h
@@ -49,8 +49,6 @@ public:
                               StreamState *nextState,
                               int64_t timeoutNanoseconds) override;
 
-    int chanCountToChanMask(int chanCount);
-
     int64_t getFramesWritten() const override;
 
 protected:
@@ -58,6 +56,8 @@ protected:
     Result updateServiceFrameCounter() override;
 
 private:
+
+    SLuint32 channelCountToChannelMask(int chanCount);
 
     Result setRecordState(SLuint32 newState);
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -46,8 +46,8 @@ constexpr int SL_ANDROID_SPEAKER_5DOT1 = (SL_ANDROID_SPEAKER_QUAD
 constexpr int SL_ANDROID_SPEAKER_7DOT1 = (SL_ANDROID_SPEAKER_5DOT1 | SL_SPEAKER_SIDE_LEFT
         | SL_SPEAKER_SIDE_RIGHT);
 
-int AudioOutputStreamOpenSLES::chanCountToChanMask(int channelCount) {
-    int channelMask = 0;
+SLuint32 AudioOutputStreamOpenSLES::channelCountToChannelMask(int channelCount) {
+    SLuint32 channelMask = 0;
 
     switch (channelCount) {
         case  1:
@@ -71,7 +71,7 @@ int AudioOutputStreamOpenSLES::chanCountToChanMask(int channelCount) {
             break;
 
         default:
-            channelMask = chanCountToChanMaskDefault(channelCount);
+            channelMask = channelCountToChannelMaskDefault(channelCount);
             break;
     }
     return channelMask;
@@ -101,7 +101,7 @@ Result AudioOutputStreamOpenSLES::open() {
             (SLuint32) (mSampleRate * kMillisPerSecond),    // milliSamplesPerSec
             bitsPerSample,                      // bitsPerSample
             bitsPerSample,                      // containerSize;
-            (SLuint32) chanCountToChanMask(mChannelCount), // channelMask
+            channelCountToChannelMask(mChannelCount), // channelMask
             getDefaultByteOrder(),
     };
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -46,10 +46,10 @@ constexpr int SL_ANDROID_SPEAKER_5DOT1 = (SL_ANDROID_SPEAKER_QUAD
 constexpr int SL_ANDROID_SPEAKER_7DOT1 = (SL_ANDROID_SPEAKER_5DOT1 | SL_SPEAKER_SIDE_LEFT
         | SL_SPEAKER_SIDE_RIGHT);
 
-int AudioOutputStreamOpenSLES::chanCountToChanMask(int chanCount) {
+int AudioOutputStreamOpenSLES::chanCountToChanMask(int channelCount) {
     int channelMask = 0;
 
-    switch (chanCount) {
+    switch (channelCount) {
         case  1:
             channelMask = SL_SPEAKER_FRONT_CENTER;
             break;
@@ -68,6 +68,10 @@ int AudioOutputStreamOpenSLES::chanCountToChanMask(int chanCount) {
 
         case  8: // 7.1
             channelMask = SL_ANDROID_SPEAKER_7DOT1;
+            break;
+
+        default:
+            channelMask = chanCountToChanMaskDefault(channelCount);
             break;
     }
     return channelMask;

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -48,7 +48,6 @@ public:
                               StreamState *nextState,
                               int64_t timeoutNanoseconds) override;
 
-    int chanCountToChanMask(int chanCount);
 
     int64_t getFramesRead() const override;
 
@@ -59,6 +58,8 @@ protected:
     Result updateServiceFrameCounter() override;
 
 private:
+
+    SLuint32 channelCountToChannelMask(int chanCount);
 
     Result onAfterDestroy() override;
 

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -49,11 +49,11 @@ AudioStreamOpenSLES::~AudioStreamOpenSLES() {
     delete[] mCallbackBuffer;
 }
 
-#define AUDIO_CHANNEL_COUNT_MAX          30u
-#define SL_ANDROID_UNKNOWN_CHANNELMASK   0
+constexpr uint      kAudioChannelCountMax = 30u;
+constexpr SLuint32  SL_ANDROID_UNKNOWN_CHANNELMASK  = 0; // Matches name used internally.
 
-int AudioStreamOpenSLES::chanCountToChanMaskDefault(int channelCount) {
-    if (channelCount > AUDIO_CHANNEL_COUNT_MAX) {
+SLuint32 AudioStreamOpenSLES::channelCountToChannelMaskDefault(int channelCount) {
+    if (channelCount > kAudioChannelCountMax) {
         return SL_ANDROID_UNKNOWN_CHANNELMASK;
     } else {
         SLuint32 bitfield = (1 << channelCount) - 1;

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -74,7 +74,7 @@ public:
 
 protected:
 
-    int chanCountToChanMaskDefault(int channelCount);
+    SLuint32 channelCountToChannelMaskDefault(int channelCount);
 
     virtual Result onBeforeDestroy() { return Result::OK; };
     virtual Result onAfterDestroy() { return Result::OK; };

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -74,6 +74,8 @@ public:
 
 protected:
 
+    int chanCountToChanMaskDefault(int channelCount);
+
     virtual Result onBeforeDestroy() { return Result::OK; };
     virtual Result onAfterDestroy() { return Result::OK; };
 


### PR DESCRIPTION
Indexed channel masks were not supported before N.

Fixes #117