### PR TITLE
opensles: make Input pause unimplemented

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -230,12 +230,14 @@ Result AudioInputStreamOpenSLES::requestStart() {
 
 
 Result AudioInputStreamOpenSLES::requestPause() {
-    LOGD("AudioInputStreamOpenSLES::requestPause() is unavailable for input streams");
-    return Result::ErrorUnimplemented;
+    LOGW("AudioInputStreamOpenSLES::requestPause() is intentionally not implemented for input "
+         "streams");
+    return Result::ErrorUnimplemented; // Matches AAudio behavior.
 }
 
 Result AudioInputStreamOpenSLES::requestFlush() {
-    LOGW("AudioInputStreamOpenSLES::%s() UNIMPLEMENTED", __func__);
+    LOGW("AudioInputStreamOpenSLES::requestFlush() is intentionally not implemented for input "
+         "streams");
     return Result::ErrorUnimplemented; // Matches AAudio behavior.
 }
 

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -230,20 +230,8 @@ Result AudioInputStreamOpenSLES::requestStart() {
 
 
 Result AudioInputStreamOpenSLES::requestPause() {
-
-    LOGD("AudioInputStreamOpenSLES::requestPause()");
-    StreamState initialState = getState();
-    if (initialState == StreamState::Closed) return Result::ErrorClosed;
-
-    setState(StreamState::Pausing);
-    Result result = setRecordState(SL_RECORDSTATE_PAUSED);
-    if (result == Result::OK) {
-        mPositionMillis.reset32(); // OpenSL ES resets its millisecond position when paused.
-        setState(StreamState::Paused);
-    } else {
-        setState(initialState);
-    }
-    return result;
+    LOGD("AudioInputStreamOpenSLES::requestPause() is unavailable for input streams");
+    return Result::ErrorUnavailable;
 }
 
 Result AudioInputStreamOpenSLES::requestFlush() {

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -247,7 +247,8 @@ Result AudioInputStreamOpenSLES::requestPause() {
 }
 
 Result AudioInputStreamOpenSLES::requestFlush() {
-    return Result::ErrorUnimplemented; // TODO
+    LOGW("AudioInputStreamOpenSLES::%s() UNIMPLEMENTED", __func__);
+    return Result::ErrorUnimplemented; // Matches AAudio behavior.
 }
 
 Result AudioInputStreamOpenSLES::requestStop() {

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -231,7 +231,7 @@ Result AudioInputStreamOpenSLES::requestStart() {
 
 Result AudioInputStreamOpenSLES::requestPause() {
     LOGD("AudioInputStreamOpenSLES::requestPause() is unavailable for input streams");
-    return Result::ErrorUnavailable;
+    return Result::ErrorUnimplemented;
 }
 
 Result AudioInputStreamOpenSLES::requestFlush() {

--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -154,7 +154,7 @@ TEST_F(StreamStates, InputStreamDoesNotSupportPause){
     EXPECT_EQ(r, Result::OK);
     r = mStream->requestPause();
 
-    ASSERT_EQ(r, Result::ErrorUnavailable) << convertToText(r);
+    ASSERT_EQ(r, Result::ErrorUnimplemented) << convertToText(r);
     closeStream();
 }
 

--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -35,7 +35,9 @@ protected:
 
     bool openInputStream(){
         mBuilder.setDirection(Direction::Input);
-        return openStream();
+        bool isOpened = openStream();
+        EXPECT_EQ(mStream->getDirection(), Direction::Input) << convertToText(mStream->getDirection());
+        return isOpened;
     }
 
     void closeStream(){
@@ -145,26 +147,16 @@ TEST_F(StreamStates, InputStreamStateIsStartedAfterStarting){
     closeStream();
 }
 
-/*
- * TODO: what should the state be when we try to pause an input stream?
- * TEST_F(StreamStates, InputStreamStateIsAfterPausing){
+TEST_F(StreamStates, InputStreamDoesNotSupportPause){
 
     openInputStream();
-
-    StreamState next = StreamState::Unknown;
     auto r = mStream->requestStart();
     EXPECT_EQ(r, Result::OK);
     r = mStream->requestPause();
-    EXPECT_EQ(r, Result::OK);
 
-    r = mStream->waitForStateChange(StreamState::Pausing, &next, kTimeoutInNanos);
-    EXPECT_EQ(r, Result::OK);
-
-    ASSERT_EQ(next, StreamState::Paused);
-
+    ASSERT_EQ(r, Result::ErrorUnavailable) << convertToText(r);
     closeStream();
-}*/
-
+}
 
 TEST_F(StreamStates, InputStreamStateIsStoppedAfterStopping){
 


### PR DESCRIPTION
This is to match the behavior of AAudio.

Fixes #88