### PR TITLE
oboe: optimize getSdkVersion()

### DIFF
--- a/src/common/Utilities.cpp
+++ b/src/common/Utilities.cpp
@@ -170,10 +170,14 @@ const char *convertToText<AudioApi >(AudioApi audioApi) {
 
 int getSdkVersion() {
 #ifdef __ANDROID__
-    char sdk[PROP_VALUE_MAX] = {0};
-    if (__system_property_get("ro.build.version.sdk", sdk) != 0) {
-        return atoi(sdk);
+    static int sCachedSdkVersion = -1;
+    if (sCachedSdkVersion == -1) {
+        char sdk[PROP_VALUE_MAX] = {0};
+        if (__system_property_get("ro.build.version.sdk", sdk) != 0) {
+            sCachedSdkVersion = atoi(sdk);
+        }
     }
+    return sCachedSdkVersion;
 #endif
     return -1;
 }


### PR DESCRIPTION
Cache version because it will not change.