### PR TITLE
Refactoring AudioStream::getBufferSizeInFrames to return a ResultWithValue

### DIFF
--- a/include/oboe/AudioStreamBase.h
+++ b/include/oboe/AudioStreamBase.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include "oboe/AudioStreamCallback.h"
 #include "oboe/Definitions.h"
+#include "oboe/ResultWithValue.h"
 
 namespace oboe {
 
@@ -74,15 +75,17 @@ public:
      *
      * @return buffer size or a negative error.
      */
-    virtual int32_t getBufferSizeInFrames() const {
+    virtual ResultWithValue<int32_t> getBufferSizeInFrames() const {
         // By default assume the effective size is the same as capacity.
-        return getBufferCapacityInFrames();
+        return ResultWithValue<int32_t>(getBufferCapacityInFrames());
     }
 
     /**
-     * @return capacityInFrames or OBOE_UNSPECIFIED
+     * @return capacityInFrames or kUnspecified
      */
-    virtual int32_t getBufferCapacityInFrames() const { return mBufferCapacityInFrames; }
+    virtual int32_t getBufferCapacityInFrames() const {
+        return mBufferCapacityInFrames;
+    }
 
     SharingMode getSharingMode() const { return mSharingMode; }
 

--- a/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
@@ -158,13 +158,22 @@ void PlayAudioEngine::setToneOn(bool isToneOn) {
 oboe::DataCallbackResult
 PlayAudioEngine::onAudioReady(oboe::AudioStream *audioStream, void *audioData, int32_t numFrames) {
 
-    int32_t bufferSize = audioStream->getBufferSizeInFrames();
+    int32_t bufferSize = -1;
+    auto bufferSizeResult = audioStream->getBufferSizeInFrames();
 
-    if (mBufferSizeSelection == kBufferSizeAutomatic) {
-        mLatencyTuner->tune();
-    } else if (bufferSize != (mBufferSizeSelection * mFramesPerBurst)) {
-        audioStream->setBufferSizeInFrames(mBufferSizeSelection * mFramesPerBurst);
-        bufferSize = audioStream->getBufferSizeInFrames();
+    if (bufferSizeResult == oboe::Result::OK){
+        bufferSize = bufferSizeResult.value();
+
+        if (mBufferSizeSelection == kBufferSizeAutomatic) {
+            mLatencyTuner->tune();
+        } else if (bufferSize != (mBufferSizeSelection * mFramesPerBurst)) {
+            audioStream->setBufferSizeInFrames(mBufferSizeSelection * mFramesPerBurst);
+
+            auto newBufferSizeResult = audioStream->getBufferSizeInFrames();
+            if (newBufferSizeResult == oboe::Result::OK){
+                bufferSize = newBufferSizeResult.value();
+            }
+        }
     }
 
     /**

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -364,12 +364,12 @@ StreamState AudioStreamAAudio::getState() {
     }
 }
 
-int32_t AudioStreamAAudio::getBufferSizeInFrames() const {
+ResultWithValue<int32_t> AudioStreamAAudio::getBufferSizeInFrames() const {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-        return mLibLoader->stream_getBufferSize(stream);
+        return ResultWithValue<int32_t>(mLibLoader->stream_getBufferSize(stream));
     } else {
-        return static_cast<int32_t>(Result::ErrorNull);
+        return ResultWithValue<int32_t>(Result::ErrorNull);
     }
 }
 

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -69,7 +69,7 @@ public:
                  int64_t timeoutNanoseconds) override;
 
     ResultWithValue<int32_t> setBufferSizeInFrames(int32_t requestedFrames) override;
-    int32_t getBufferSizeInFrames() const override;
+    ResultWithValue<int32_t> getBufferSizeInFrames() const override;
     int32_t getFramesPerBurst() const override;
     ResultWithValue<int32_t> getXRunCount() const override;
 

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -218,9 +218,9 @@ ResultWithValue<int32_t> AudioStreamBuffered::setBufferSizeInFrames(int32_t requ
     }
 }
 
-int32_t AudioStreamBuffered::getBufferSizeInFrames() const {
+ResultWithValue<int32_t> AudioStreamBuffered::getBufferSizeInFrames() const {
     if (mFifoBuffer != nullptr) {
-        return mFifoBuffer->getThresholdFrames();
+        return ResultWithValue<int32_t>(mFifoBuffer->getThresholdFrames());
     } else {
         return AudioStream::getBufferSizeInFrames();
     }

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -47,7 +47,7 @@ public:
 
     ResultWithValue<int32_t> setBufferSizeInFrames(int32_t requestedFrames) override;
 
-    int32_t getBufferSizeInFrames() const override;
+    ResultWithValue<int32_t> getBufferSizeInFrames() const override;
 
     int32_t getBufferCapacityInFrames() const override;
 


### PR DESCRIPTION
I started updating the `AudioStream::get*` methods to return a `ResultWithValue` based on the assumption that we need to handle the case when the stream is null. 

I really don't like this change because of the extra work and noise which is creates when calling the API. 

In particular, take a look at code changes in [`PlayAudioEngine.cpp`](https://github.com/google/oboe/pull/140/commits/e513142b9009be9435f406c0b6459023dcada7a6#diff-0cab96b97d755d2a27561725775b00e0). Getting and setting the buffer size becomes an arduous job of checking the result of every call. 

The thing which sticks in my mind is that if the stream were null you wouldn't be able to call `pStream->getBufferSizeInFrames()` anyway, so it's pointless to return an `Result::ErrorNull`.

Having tried this API change I would advocate for a solution where we (somehow) guarantee (either in code or in documentation) that the AudioStream is never null. Thoughts? 