### PR TITLE
Tidy up for stream closed default values

### DIFF
--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -178,6 +178,10 @@ ResultWithValue<int32_t> AudioStreamBuffered::transfer(void *buffer,
 ResultWithValue<int32_t> AudioStreamBuffered::write(const void *buffer,
                                    int32_t numFrames,
                                    int64_t timeoutNanoseconds) {
+    if (getState() == StreamState::Closed){
+        return ResultWithValue<int32_t>(Result::ErrorClosed);
+    }
+
     if (getDirection() == Direction::Input) {
         return ResultWithValue<int32_t>(Result::ErrorUnavailable); // TODO review, better error code?
     }
@@ -189,6 +193,10 @@ ResultWithValue<int32_t> AudioStreamBuffered::write(const void *buffer,
 ResultWithValue<int32_t> AudioStreamBuffered::read(void *buffer,
                                   int32_t numFrames,
                                   int64_t timeoutNanoseconds) {
+    if (getState() == StreamState::Closed){
+        return ResultWithValue<int32_t>(Result::ErrorClosed);
+    }
+
     if (getDirection() == Direction::Output) {
         return ResultWithValue<int32_t>(Result::ErrorUnavailable); // TODO review, better error code?
     }
@@ -199,6 +207,10 @@ ResultWithValue<int32_t> AudioStreamBuffered::read(void *buffer,
 // Only supported when we are not using a callback.
 ResultWithValue<int32_t> AudioStreamBuffered::setBufferSizeInFrames(int32_t requestedFrames)
 {
+    if (getState() == StreamState::Closed){
+        return ResultWithValue<int32_t>(Result::ErrorClosed);
+    }
+
     if (mFifoBuffer != nullptr) {
         if (requestedFrames > mFifoBuffer->getBufferCapacityInFrames()) {
             requestedFrames = mFifoBuffer->getBufferCapacityInFrames();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 
+# TODO: Remove this line and inherit it from the host environment
+set(ANDROID_NDK /Users/donturner/Library/Android/sdk/ndk-bundle)
+
 # Include GoogleTest library
 set(GOOGLETEST_ROOT ${ANDROID_NDK}/sources/third_party/googletest)
 add_library(gtest STATIC ${GOOGLETEST_ROOT}/src/gtest_main.cc ${GOOGLETEST_ROOT}/src/gtest-all.cc)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,8 @@
 # e.g. /Library/Android/sdk/ndk-bundle
 # - Android device or emulator attached and accessible via adb
 #
-# Instructions: 
+# Instructions:
+# Install the LiveEffect sample app, run it once and grant the recording permission (TODO: Make this step easier)
 # Run this script from within the oboe/tests directory. A directory 'build' will be 
 # created containing the test binary. This binary will then be copied to the device/emulator
 # and executed. 

--- a/tests/testStreamClosedMethods.cpp
+++ b/tests/testStreamClosedMethods.cpp
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * TODO:
- Create test runner APK
- Remove hardcoded ANDROID_NDK from cmake config
- */
-
 #include <gtest/gtest.h>
 #include <oboe/Oboe.h>
 
@@ -318,4 +312,39 @@ TEST_F(StreamClosedReturnValues, WaitForStateChangeReturnsClosed){
     openAndCloseStream();
     StreamState next;
     ASSERT_EQ(mStream->waitForStateChange(StreamState::Open, &next, 0), Result::ErrorClosed);
+}
+
+TEST_F(StreamClosedReturnValues, SetBufferSizeInFramesReturnsClosed){
+
+    openAndCloseStream();
+    auto r = mStream->setBufferSizeInFrames(192);
+    ASSERT_EQ(r.error(), Result::ErrorClosed);
+}
+
+TEST_F(StreamClosedReturnValues, CalculateLatencyInMillisReturnsClosedIfSupported){
+
+    openAndCloseStream();
+
+    if (mStream->getAudioApi() == AudioApi::AAudio){
+        auto r = mStream->calculateLatencyMillis();
+        ASSERT_EQ(r.error(), Result::ErrorClosed);
+    }
+}
+
+TEST_F(StreamClosedReturnValues, ReadReturnsClosed){
+
+    openAndCloseStream();
+
+    void *buffer;
+    auto r = mStream->read(buffer, 1, 0);
+    ASSERT_EQ(r.error(), Result::ErrorClosed);
+}
+
+TEST_F(StreamClosedReturnValues, WriteReturnsClosed){
+
+    openAndCloseStream();
+
+    void *buffer;
+    auto r = mStream->write(buffer, 1, 0);
+    ASSERT_EQ(r.error(), Result::ErrorClosed);
 }


### PR DESCRIPTION
Tests added and the following methods have been updated to return `Result::ErrorClosed` when the audio stream is closed 

    setBuferSizeInFrames
    calculateLatencyInMillis
    read 
    write
