### PR TITLE
oboedebug: support disabling of logging

### DIFF
--- a/src/common/OboeDebug.h
+++ b/src/common/OboeDebug.h
@@ -14,15 +14,21 @@
  * limitations under the License.
  *
  */
+
 #ifndef OBOE_DEBUG_H
 #define OBOE_DEBUG_H
 #include <android/log.h>
 
-#if 1
+#ifndef OBOE_ENABLE_LOGGING
+#define OBOE_ENABLE_LOGGING 1
+#endif /* OBOE_ENABLE_LOGGING */
+
+#if OBOE_ENABLE_LOGGING
 
 #ifndef MODULE_NAME
 #define MODULE_NAME  "OboeAudio"
 #endif
+
 #define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, MODULE_NAME, __VA_ARGS__)
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, MODULE_NAME, __VA_ARGS__)
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, MODULE_NAME, __VA_ARGS__)


### PR DESCRIPTION
Defining OBOE_ENABLE_LOGGING 0

Fixes #166