### PR TITLE
Leave AudioStreamBase::mPerformanceMode unchanged on old platforms

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -167,8 +167,6 @@ SLresult AudioStreamOpenSLES::configurePerformanceMode(SLAndroidConfigurationItf
             LOGW("SetConfiguration(PERFORMANCE_MODE, %u) returned %d", performanceMode, result);
             mPerformanceMode = PerformanceMode::None;
         }
-    } else {
-        mPerformanceMode = PerformanceMode::None;
     }
     return result;
 }


### PR DESCRIPTION
this fix issue https://github.com/google/oboe/issues/172. 

Please carefully review the SMALL change, the behavior is: if the feature is NOT supported, mPerformanceMode is not changed, which means whatever user asks, Oboe would pretend working at that mode. 

The facts:
```
on Android N:                                   InputStream    OutputStream
SL_IID_ANDROIDCONFIGURATION/Interface                  Y           N
SL_ANDROID_KEY_PERFORMANCE_MODE/Key                    N           N
```

the code change makes the first *column* to behave the same as the second *column* above.

I believe that this was added by me when checking into liveEffect sample that broke the protocol :-(.
