### PR TITLE
opensles: fix PerformanceMode setting

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -134,7 +134,11 @@ Result AudioInputStreamOpenSLES::open() {
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
                                             SL_IID_ANDROIDCONFIGURATION,
                                             &configItf);
-    if (SL_RESULT_SUCCESS == result) {
+
+    if (SL_RESULT_SUCCESS != result) {
+        LOGW("%s() GetInterface(SL_IID_ANDROIDCONFIGURATION) failed with %s",
+             __func__, getSLErrStr(result));
+    } else {
         SLuint32 presetValue = OpenSLES_convertInputPreset(getInputPreset());
         result = (*configItf)->SetConfiguration(configItf,
                                          SL_ANDROID_KEY_RECORDING_PRESET,

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -74,6 +74,7 @@ SLuint32 AudioInputStreamOpenSLES::channelCountToChannelMask(int channelCount) {
 }
 
 Result AudioInputStreamOpenSLES::open() {
+    SLAndroidConfigurationItf configItf = nullptr;
 
     Result oboeResult = AudioStreamOpenSLES::open();
     if (Result::OK != oboeResult) return oboeResult;
@@ -130,7 +131,6 @@ Result AudioInputStreamOpenSLES::open() {
     }
 
     // Configure the stream.
-    SLAndroidConfigurationItf configItf;
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
                                             SL_IID_ANDROIDCONFIGURATION,
                                             &configItf);
@@ -169,6 +169,11 @@ Result AudioInputStreamOpenSLES::open() {
     }
 
     result = AudioStreamOpenSLES::registerBufferQueueCallback();
+    if (SL_RESULT_SUCCESS != result) {
+        goto error;
+    }
+
+    result = updateStreamParameters(configItf);
     if (SL_RESULT_SUCCESS != result) {
         goto error;
     }

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -144,7 +144,6 @@ Result AudioOutputStreamOpenSLES::open() {
             goto error;
         }
     }
-    assert(configItf != nullptr);
 
     result = (*mObjectInterface)->Realize(mObjectInterface, SL_BOOLEAN_FALSE);
     if (SL_RESULT_SUCCESS != result) {

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -79,6 +79,8 @@ SLuint32 AudioOutputStreamOpenSLES::channelCountToChannelMask(int channelCount) 
 }
 
 Result AudioOutputStreamOpenSLES::open() {
+    SLAndroidConfigurationItf configItf = nullptr;
+
     Result oboeResult = AudioStreamOpenSLES::open();
     if (Result::OK != oboeResult)  return oboeResult;
 
@@ -130,16 +132,19 @@ Result AudioOutputStreamOpenSLES::open() {
     }
 
     // Configure the stream.
-    SLAndroidConfigurationItf configItf;
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
                                                SL_IID_ANDROIDCONFIGURATION,
-                                               &configItf);
-    if (SL_RESULT_SUCCESS == result) {
+                                               (void *)&configItf);
+    if (SL_RESULT_SUCCESS != result) {
+        LOGW("%s() GetInterface(SL_IID_ANDROIDCONFIGURATION) failed with %s",
+             __func__, getSLErrStr(result));
+    } else {
         result = configurePerformanceMode(configItf);
         if (SL_RESULT_SUCCESS != result) {
             goto error;
         }
     }
+    assert(configItf != nullptr);
 
     result = (*mObjectInterface)->Realize(mObjectInterface, SL_BOOLEAN_FALSE);
     if (SL_RESULT_SUCCESS != result) {
@@ -154,6 +159,11 @@ Result AudioOutputStreamOpenSLES::open() {
     }
 
     result = AudioStreamOpenSLES::registerBufferQueueCallback();
+    if (SL_RESULT_SUCCESS != result) {
+        goto error;
+    }
+
+    result = updateStreamParameters(configItf);
     if (SL_RESULT_SUCCESS != result) {
         goto error;
     }

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -174,18 +174,29 @@ PerformanceMode AudioStreamOpenSLES::convertPerformanceMode(SLuint32 openslMode)
 }
 
 SLresult AudioStreamOpenSLES::configurePerformanceMode(SLAndroidConfigurationItf configItf) {
+
+    if (configItf == nullptr) {
+        LOGW("%s() called with NULL configuration", __func__);
+        mPerformanceMode = PerformanceMode::None;
+        return SL_RESULT_INTERNAL_ERROR;
+    }
+    if (getSdkVersion() < __ANDROID_API_N_MR1__) {
+        LOGW("%s() not supported until N_MR1", __func__);
+        mPerformanceMode = PerformanceMode::None;
+        return SL_RESULT_SUCCESS;
+    }
+
     SLresult result = SL_RESULT_SUCCESS;
-    if(getSdkVersion() >= __ANDROID_API_N_MR1__) {
-        SLuint32 performanceMode = convertPerformanceMode(getPerformanceMode());
-        result = (*configItf)->SetConfiguration(configItf, SL_ANDROID_KEY_PERFORMANCE_MODE,
-                                                         &performanceMode, sizeof(performanceMode));
-        if (SL_RESULT_SUCCESS != result) {
-            LOGW("SetConfiguration(PERFORMANCE_MODE, %u) returned %d", performanceMode, result);
-            mPerformanceMode = PerformanceMode::None;
-        }
-    } else {
+    SLuint32 performanceMode = convertPerformanceMode(getPerformanceMode());
+    LOGD("SetConfiguration(SL_ANDROID_KEY_PERFORMANCE_MODE, SL %u) called", performanceMode);
+    result = (*configItf)->SetConfiguration(configItf, SL_ANDROID_KEY_PERFORMANCE_MODE,
+                                                     &performanceMode, sizeof(performanceMode));
+    if (SL_RESULT_SUCCESS != result) {
+        LOGW("SetConfiguration(PERFORMANCE_MODE, SL %u) returned %s",
+             performanceMode, getSLErrStr(result));
         mPerformanceMode = PerformanceMode::None;
     }
+
     return result;
 }
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -92,6 +92,9 @@ protected:
 
     SLresult configurePerformanceMode(SLAndroidConfigurationItf configItf);
 
+    SLresult updateStreamParameters(SLAndroidConfigurationItf configItf);
+
+    PerformanceMode convertPerformanceMode(SLuint32 openslMode) const;
     SLuint32 convertPerformanceMode(PerformanceMode oboeMode) const;
 
     /**

--- a/src/opensles/EngineOpenSLES.cpp
+++ b/src/opensles/EngineOpenSLES.cpp
@@ -79,8 +79,8 @@ SLresult EngineOpenSLES::createAudioPlayer(SLObjectItf *objectItf,
                                            SLDataSource *audioSource,
                                            SLDataSink *audioSink) {
 
-    const SLInterfaceID ids[] = {SL_IID_BUFFERQUEUE};
-    const SLboolean reqs[] = {SL_BOOLEAN_TRUE};
+    const SLInterfaceID ids[] = {SL_IID_BUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION};
+    const SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 
     return (*mEngineInterface)->CreateAudioPlayer(mEngineInterface, objectItf, audioSource,
                                                   audioSink,
@@ -91,8 +91,7 @@ SLresult EngineOpenSLES::createAudioRecorder(SLObjectItf *objectItf,
                                              SLDataSource *audioSource,
                                              SLDataSink *audioSink) {
 
-    const SLInterfaceID ids[] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
-                                 SL_IID_ANDROIDCONFIGURATION };
+    const SLInterfaceID ids[] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION };
     const SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 
     return (*mEngineInterface)->CreateAudioRecorder(mEngineInterface, objectItf, audioSource,

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -69,3 +69,23 @@ TEST_F(StreamOpen, ForOpenSLESDefaultChannelCountIsUsed){
     ASSERT_EQ(mStream->getChannelCount(), 1);
     closeStream();
 }
+
+TEST_F(StreamOpen, OutputForOpenSLESPerformanceModeShouldBeNone){
+    // We will not get a LowLatency stream if we request 16000 Hz.
+    mBuilder.setSampleRate(16000);
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
+    mBuilder.setDirection(Direction::Output);
+    openStream(AudioApi::OpenSLES);
+    ASSERT_EQ((int)mStream->getPerformanceMode(), (int)PerformanceMode::None);
+    closeStream();
+}
+
+TEST_F(StreamOpen, InputForOpenSLESPerformanceModeShouldBeNone){
+    // We will not get a LowLatency stream if we request 16000 Hz.
+    mBuilder.setSampleRate(16000);
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
+    mBuilder.setDirection(Direction::Input);
+    openStream(AudioApi::OpenSLES);
+    ASSERT_EQ((int)mStream->getPerformanceMode(), (int)PerformanceMode::None);
+    closeStream();
+}

--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -24,7 +24,8 @@ class StreamStates : public ::testing::Test {
 protected:
 
     void SetUp(){
-
+        mBuilder.setPerformanceMode(PerformanceMode::None);
+        mBuilder.setDirection(Direction::Output);
     }
 
     bool openStream(Direction direction) {
@@ -267,11 +268,21 @@ TEST_F(StreamStates, InputStreamDoesNotSupportPause){
     closeStream();
 }
 
-TEST_F(StreamStates, OutputStreamLeftRunningShouldNotInterfereWithNextOpen){
+TEST_F(StreamStates, OutputStreamLeftRunningShouldNotInterfereWithNextOpen) {
     checkStreamLeftRunningShouldNotInterfereWithNextOpen(Direction::Output);
 }
 
-TEST_F(StreamStates, InputStreamLeftRunningShouldNotInterfereWithNextOpen){
+TEST_F(StreamStates, InputStreamLeftRunningShouldNotInterfereWithNextOpen) {
+    checkStreamLeftRunningShouldNotInterfereWithNextOpen(Direction::Input);
+}
+
+TEST_F(StreamStates, OutputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen) {
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
+    checkStreamLeftRunningShouldNotInterfereWithNextOpen(Direction::Output);
+}
+
+TEST_F(StreamStates, InputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen) {
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
     checkStreamLeftRunningShouldNotInterfereWithNextOpen(Direction::Input);
 }
 


### PR DESCRIPTION
The LowLatency request was not getting set correctly because
GetInterface was failing.

Also the final PerformanceMode was not being queried after the stream was created.
So it was set to whatever the caller requested instead of the actual value.

Fixes #197
Fixes #179