### PR TITLE
Use SLAndroidDataFormat_PCM_EX for input stream on API 23+

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -101,12 +101,16 @@ Result AudioInputStreamOpenSLES::open() {
 
     /**
      * API 21 (Lollipop) introduced support for floating-point data representation and an extended
-     * data format type: SLAndroidDataFormat_PCM_EX. If running on API 21+ use this newer format
-     * type, creating it from our original format.
+     * data format type for audio playback: SLAndroidDataFormat_PCM_EX.
+     *
+     * The support for floating-point data representation and the extended data format type for
+     * audio record was only added in API 23 (Marshmallow).
+     *
+     * If running on API 23+ use this newer format type, creating it from our original format.
      */
 
     SLAndroidDataFormat_PCM_EX format_pcm_ex;
-    if (getSdkVersion() >= __ANDROID_API_L__) {
+    if (getSdkVersion() >= __ANDROID_API_M__) {
         SLuint32 representation = OpenSLES_ConvertFormatToRepresentation(getFormat());
         // Fill in the format structure.
         format_pcm_ex = OpenSLES_createExtendedFormat(format_pcm, representation);


### PR DESCRIPTION
The floating-point data representation and the extended data
format type SLAndroidDataFormat_PCM_EX were added in Lollipop
only for audio playback, but not audio record.

The float record capability was added in Marshmallow.

- https://android.googlesource.com/platform/frameworks/wilhelm/+/lollipop-release/src/android/AudioRecorder_to_android.cpp#167
- https://android.googlesource.com/platform/frameworks/wilhelm/+/lollipop-mr1-release/src/android/AudioRecorder_to_android.cpp#167
- https://android.googlesource.com/platform/frameworks/wilhelm/+/marshmallow-release/src/android/AudioRecorder_to_android.cpp#167

This should address issue #192 

Previously, the tests were not passing on a Nexus 5 running Android 5.1.1, and the LiveEffect sample app was not working as expected.

```
Running main() from gtest_main.cc
[==========] Running 59 tests from 5 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from UtilityFunctions
[ RUN      ] UtilityFunctions.Converts16BitIntegerToSizeOf2Bytes
[       OK ] UtilityFunctions.Converts16BitIntegerToSizeOf2Bytes (0 ms)
[ RUN      ] UtilityFunctions.ConvertsFloatToSizeOf4Bytes
[       OK ] UtilityFunctions.ConvertsFloatToSizeOf4Bytes (0 ms)
[----------] 2 tests from UtilityFunctions (0 ms total)

[----------] 32 tests from StreamClosedReturnValues
[ RUN      ] StreamClosedReturnValues.GetChannelCountReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetChannelCountReturnsLastKnownValue (5 ms)
[ RUN      ] StreamClosedReturnValues.GetDirectionReturnsLastKnownValue
/Users/vbarthel/Documents/git-projects/oboe-fork/tests/testStreamClosedMethods.cpp:41: Failure
Expected equality of these values:
  r
    Which is: 4-byte object <80-FC FF-FF>
  Result::OK
    Which is: 4-byte object <00-00 00-00>
Failed to open stream ErrorInternal
```

And an error log complaining about the non PCM format could be observed in the Logcat while running the tests:

```
09-04 08:15:35.623 10771-10771/? E/libOpenSLES: Cannot create AudioRecorder: data sink must be in PCM format
    Cannot create AudioRecorder: invalid source or sink
09-04 08:15:35.623 10771-10771/? W/libOpenSLES: Leaving Engine::CreateAudioRecorder (SL_RESULT_PARAMETER_INVALID)
```

With those changes, the tests are now passing and the LiveEffect sample is now working as expected.

```
Running main() from gtest_main.cc
[==========] Running 59 tests from 5 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from UtilityFunctions
[ RUN      ] UtilityFunctions.Converts16BitIntegerToSizeOf2Bytes
[       OK ] UtilityFunctions.Converts16BitIntegerToSizeOf2Bytes (0 ms)
[ RUN      ] UtilityFunctions.ConvertsFloatToSizeOf4Bytes
[       OK ] UtilityFunctions.ConvertsFloatToSizeOf4Bytes (0 ms)
[----------] 2 tests from UtilityFunctions (0 ms total)

[----------] 32 tests from StreamClosedReturnValues
[ RUN      ] StreamClosedReturnValues.GetChannelCountReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetChannelCountReturnsLastKnownValue (5 ms)
[ RUN      ] StreamClosedReturnValues.GetDirectionReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetDirectionReturnsLastKnownValue (6 ms)
[ RUN      ] StreamClosedReturnValues.GetSampleRateReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetSampleRateReturnsLastKnownValue (6 ms)
[ RUN      ] StreamClosedReturnValues.GetFramesPerCallbackReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetFramesPerCallbackReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetFormatReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetFormatReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetBufferSizeInFramesReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetBufferSizeInFramesReturnsLastKnownValue (4 ms)
[ RUN      ] StreamClosedReturnValues.GetBufferCapacityInFramesReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetBufferCapacityInFramesReturnsLastKnownValue (3 ms)
[ RUN      ] StreamClosedReturnValues.GetSharingModeReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetSharingModeReturnsLastKnownValue (1 ms)
[ RUN      ] StreamClosedReturnValues.GetPerformanceModeReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetPerformanceModeReturnsLastKnownValue (1 ms)
[ RUN      ] StreamClosedReturnValues.GetDeviceIdReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetDeviceIdReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetCallbackReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetCallbackReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetUsageReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetUsageReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetContentTypeReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetContentTypeReturnsLastKnownValue (1 ms)
[ RUN      ] StreamClosedReturnValues.GetInputPresetReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetInputPresetReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetSessionIdReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetSessionIdReturnsLastKnownValue (4 ms)
[ RUN      ] StreamClosedReturnValues.StreamStateIsClosed
[       OK ] StreamClosedReturnValues.StreamStateIsClosed (2 ms)
[ RUN      ] StreamClosedReturnValues.GetXRunCountReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetXRunCountReturnsLastKnownValue (1 ms)
[ RUN      ] StreamClosedReturnValues.GetFramesPerBurstReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetFramesPerBurstReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.IsPlayingReturnsFalse
[       OK ] StreamClosedReturnValues.IsPlayingReturnsFalse (2 ms)
[ RUN      ] StreamClosedReturnValues.GetBytesPerFrameReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetBytesPerFrameReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetBytesPerSampleReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetBytesPerSampleReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetFramesWrittenReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetFramesWrittenReturnsLastKnownValue (109 ms)
[ RUN      ] StreamClosedReturnValues.GetFramesReadReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetFramesReadReturnsLastKnownValue (27 ms)
[ RUN      ] StreamClosedReturnValues.GetTimestampReturnsErrorClosedIfSupported
[       OK ] StreamClosedReturnValues.GetTimestampReturnsErrorClosedIfSupported (3 ms)
[ RUN      ] StreamClosedReturnValues.GetAudioApiReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetAudioApiReturnsLastKnownValue (2 ms)
[ RUN      ] StreamClosedReturnValues.GetUsesAAudioReturnsLastKnownValue
[       OK ] StreamClosedReturnValues.GetUsesAAudioReturnsLastKnownValue (1 ms)
[ RUN      ] StreamClosedReturnValues.StreamStateControlsReturnClosed
[       OK ] StreamClosedReturnValues.StreamStateControlsReturnClosed (2 ms)
[ RUN      ] StreamClosedReturnValues.WaitForStateChangeReturnsOK
[       OK ] StreamClosedReturnValues.WaitForStateChangeReturnsOK (2 ms)
[ RUN      ] StreamClosedReturnValues.SetBufferSizeInFramesReturnsClosed
[       OK ] StreamClosedReturnValues.SetBufferSizeInFramesReturnsClosed (2 ms)
[ RUN      ] StreamClosedReturnValues.CalculateLatencyInMillisReturnsClosedIfSupported
[       OK ] StreamClosedReturnValues.CalculateLatencyInMillisReturnsClosedIfSupported (1 ms)
[ RUN      ] StreamClosedReturnValues.ReadReturnsClosed
[       OK ] StreamClosedReturnValues.ReadReturnsClosed (2 ms)
[ RUN      ] StreamClosedReturnValues.WriteReturnsClosed
[       OK ] StreamClosedReturnValues.WriteReturnsClosed (2 ms)
[----------] 32 tests from StreamClosedReturnValues (216 ms total)

[----------] 17 tests from StreamStates
[ RUN      ] StreamStates.OutputStreamStateIsOpenAfterOpening
[       OK ] StreamStates.OutputStreamStateIsOpenAfterOpening (2 ms)
[ RUN      ] StreamStates.OutputStreamStateIsStartedAfterStarting
[       OK ] StreamStates.OutputStreamStateIsStartedAfterStarting (53 ms)
[ RUN      ] StreamStates.OutputStreamStateIsPausedAfterPausing
[       OK ] StreamStates.OutputStreamStateIsPausedAfterPausing (72 ms)
[ RUN      ] StreamStates.OutputStreamStateIsStoppedAfterStopping
[       OK ] StreamStates.OutputStreamStateIsStoppedAfterStopping (32 ms)
[ RUN      ] StreamStates.InputStreamStateIsOpenAfterOpening
[       OK ] StreamStates.InputStreamStateIsOpenAfterOpening (5 ms)
[ RUN      ] StreamStates.InputStreamStateIsStartedAfterStarting
[       OK ] StreamStates.InputStreamStateIsStartedAfterStarting (22 ms)
[ RUN      ] StreamStates.OutputStreamStateIsStartedAfterStartingTwice
[       OK ] StreamStates.OutputStreamStateIsStartedAfterStartingTwice (12 ms)
[ RUN      ] StreamStates.InputStreamStateIsStartedAfterStartingTwice
[       OK ] StreamStates.InputStreamStateIsStartedAfterStartingTwice (25 ms)
[ RUN      ] StreamStates.OutputStreamStateIsStoppedAfterStoppingTwice
[       OK ] StreamStates.OutputStreamStateIsStoppedAfterStoppingTwice (14 ms)
[ RUN      ] StreamStates.InputStreamStateIsStoppedAfterStoppingTwice
[       OK ] StreamStates.InputStreamStateIsStoppedAfterStoppingTwice (28 ms)
[ RUN      ] StreamStates.OutputStreamStateIsPausedAfterPausingTwice
[       OK ] StreamStates.OutputStreamStateIsPausedAfterPausingTwice (17 ms)
[ RUN      ] StreamStates.InputStreamDoesNotSupportPause
[       OK ] StreamStates.InputStreamDoesNotSupportPause (35 ms)
[ RUN      ] StreamStates.OutputStreamLeftRunningShouldNotInterfereWithNextOpen
[       OK ] StreamStates.OutputStreamLeftRunningShouldNotInterfereWithNextOpen (74 ms)
[ RUN      ] StreamStates.InputStreamLeftRunningShouldNotInterfereWithNextOpen
[       OK ] StreamStates.InputStreamLeftRunningShouldNotInterfereWithNextOpen (98 ms)
[ RUN      ] StreamStates.OutputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen
[       OK ] StreamStates.OutputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen (60 ms)
[ RUN      ] StreamStates.InputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen
[       OK ] StreamStates.InputLowLatencyStreamLeftRunningShouldNotInterfereWithNextOpen (76 ms)
[ RUN      ] StreamStates.InputStreamStateIsStoppedAfterStopping
[       OK ] StreamStates.InputStreamStateIsStoppedAfterStopping (31 ms)
[----------] 17 tests from StreamStates (662 ms total)

[----------] 5 tests from StreamOpen
[ RUN      ] StreamOpen.ForOpenSLESDefaultSampleRateIsUsed
[       OK ] StreamOpen.ForOpenSLESDefaultSampleRateIsUsed (6 ms)
[ RUN      ] StreamOpen.ForOpenSLESDefaultFramesPerBurstIsUsed
[       OK ] StreamOpen.ForOpenSLESDefaultFramesPerBurstIsUsed (4 ms)
[ RUN      ] StreamOpen.ForOpenSLESDefaultChannelCountIsUsed
[       OK ] StreamOpen.ForOpenSLESDefaultChannelCountIsUsed (5 ms)
[ RUN      ] StreamOpen.OutputForOpenSLESPerformanceModeShouldBeNone
[       OK ] StreamOpen.OutputForOpenSLESPerformanceModeShouldBeNone (2 ms)
[ RUN      ] StreamOpen.InputForOpenSLESPerformanceModeShouldBeNone
[       OK ] StreamOpen.InputForOpenSLESPerformanceModeShouldBeNone (5 ms)
[----------] 5 tests from StreamOpen (24 ms total)

[----------] 3 tests from XRunBehaviour
[ RUN      ] XRunBehaviour.SupportedWhenStreamIsUsingAAudio
[       OK ] XRunBehaviour.SupportedWhenStreamIsUsingAAudio (5 ms)
[ RUN      ] XRunBehaviour.NotSupportedOnOpenSLESWhenStreamIsUsingCallback
[       OK ] XRunBehaviour.NotSupportedOnOpenSLESWhenStreamIsUsingCallback (3 ms)
[ RUN      ] XRunBehaviour.SupportedOnOpenSLESWhenStreamIsUsingBlockingIO
[       OK ] XRunBehaviour.SupportedOnOpenSLESWhenStreamIsUsingBlockingIO (4 ms)
[----------] 3 tests from XRunBehaviour (12 ms total)

[----------] Global test environment tear-down
[==========] 59 tests from 5 test cases ran. (914 ms total)
[  PASSED  ] 59 tests.
```

**Important:** I do not have the knowledge required to fully understand the consequences of those changes, especially regarding the `AudioOutputStreamOpenSLES` counterpart. With those changes, on a device running Lollipop, `AudioOutputStreamOpenSLES` will open playback stream using `SLAndroidDataFormat_PCM_EX`, but `AudioInputStreamOpenSLES` won't. Could it be a problem in term of consistency/compatibility? 