### PR TITLE
check usingFifo() for getFramesRead/Written()

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -356,26 +356,6 @@ public:
 protected:
 
     /**
-     * Increment the frames written to this stream
-     *
-     * @param frames number of frames to increment by
-     * @return total frames which have been written
-     */
-    virtual int64_t incrementFramesWritten(int32_t frames) {
-        return mFramesWritten += frames;
-    }
-
-    /**
-     * Increment the frames which have been read from this stream
-     *
-     * @param frames number of frames to increment by
-     * @return total frames which have been read
-     */
-    virtual int64_t incrementFramesRead(int32_t frames) {
-        return mFramesRead += frames;
-    }
-
-    /**
      * Wait for a transition from one state to another.
      * @return OK if the endingState was observed, or ErrorUnexpectedState
      *   if any state that was not the startingState or endingState was observed
@@ -431,6 +411,7 @@ protected:
 
 private:
     int                  mPreviousScheduler = -1;
+
 };
 
 } // namespace oboe

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -66,7 +66,7 @@ public:
     /**
      * Close the stream and deallocate any resources from the open() call.
      */
-    virtual Result close() = 0;
+    virtual Result close();
 
     /**
      * Start the stream. This will block until the stream has been started, an error occurs
@@ -229,7 +229,7 @@ public:
      *
      * @return the number of frames written so far
      */
-    virtual int64_t getFramesWritten() { return mFramesWritten; }
+    virtual int64_t getFramesWritten();
 
     /**
      * The number of audio frames read from the stream.
@@ -237,7 +237,7 @@ public:
      *
      * @return the number of frames read so far
      */
-    virtual int64_t getFramesRead() { return mFramesRead; }
+    virtual int64_t getFramesRead();
 
     /**
      * Calculate the latency of a stream based on getTimestamp().
@@ -394,6 +394,16 @@ protected:
     }
 
     AudioFormat mNativeFormat = AudioFormat::Invalid;
+
+    /**
+     * Update mFramesWritten.
+     */
+    virtual void updateFramesWritten() = 0;
+
+    /**
+     * Update mFramesRead.
+     */
+    virtual void updateFramesRead() = 0;
 
     /**
      * Number of frames which have been written into the stream

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -221,13 +221,16 @@ error2:
     return result;
 }
 
-Result AudioStreamAAudio::close()
-{
+Result AudioStreamAAudio::close() {
     // The main reason we have this mutex if to prevent a collision between a call
     // by the application to stop a stream at the same time that an onError callback
     // is being executed because of a disconnect. The close will delete the stream,
     // which could otherwise cause the requestStop() to crash.
     std::lock_guard<std::mutex> lock(mLock);
+
+    // Update frame counter variables to avoid retrograde motion.
+    getFramesWritten();
+    getFramesRead();
 
     // This will delete the AAudio stream object so we need to null out the pointer.
     AAudioStream *stream = mAAudioStream.exchange(nullptr);

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -228,9 +228,7 @@ Result AudioStreamAAudio::close() {
     // which could otherwise cause the requestStop() to crash.
     std::lock_guard<std::mutex> lock(mLock);
 
-    // Update frame counter variables to avoid retrograde motion.
-    getFramesWritten();
-    getFramesRead();
+    AudioStream::close();
 
     // This will delete the AAudio stream object so we need to null out the pointer.
     AAudioStream *stream = mAAudioStream.exchange(nullptr);
@@ -443,20 +441,18 @@ int32_t AudioStreamAAudio::getFramesPerBurst() {
     return mFramesPerBurst;
 }
 
-int64_t AudioStreamAAudio::getFramesRead() {
+void AudioStreamAAudio::updateFramesRead() {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         mFramesRead = mLibLoader->stream_getFramesRead(stream);
     }
-    return mFramesRead;
 }
 
-int64_t AudioStreamAAudio::getFramesWritten() {
+void AudioStreamAAudio::updateFramesWritten() {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         mFramesWritten = mLibLoader->stream_getFramesWritten(stream);
     }
-    return mFramesWritten;
 }
 
 ResultWithValue<int32_t> AudioStreamAAudio::getXRunCount() const {

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -74,9 +74,6 @@ public:
     ResultWithValue<int32_t> getXRunCount() const override;
     bool isXRunCountSupported() const override { return true; }
 
-    int64_t getFramesRead() override;
-    int64_t getFramesWritten() override;
-
     ResultWithValue<double> calculateLatencyMillis() override;
 
     Result waitForStateChange(StreamState currentState,
@@ -108,6 +105,9 @@ public:
 
 protected:
     Result convertApplicationDataToNative(int32_t numFrames); // TODO remove?
+
+    void updateFramesRead() override;
+    void updateFramesWritten() override;
 
 private:
 

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -50,11 +50,6 @@ DataCallbackResult AudioStream::fireCallback(void *audioData, int32_t numFrames)
         result = onDefaultCallback(audioData, numFrames);
     } else {
         result = mStreamCallback->onAudioReady(this, audioData, numFrames);
-        if (getDirection() == Direction::Input) {
-            incrementFramesRead(numFrames);
-        } else {
-            incrementFramesWritten(numFrames);
-        }
     }
 
     return result;

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -34,6 +34,13 @@ Result AudioStream::open() {
     return Result::OK;
 }
 
+Result AudioStream::close() {
+    // Update local counters so they can be read after the close.
+    updateFramesWritten();
+    updateFramesRead();
+    return Result::OK;
+}
+
 DataCallbackResult AudioStream::fireCallback(void *audioData, int32_t numFrames) {
     int scheduler = sched_getscheduler(0) & ~SCHED_RESET_ON_FORK; // for current thread
     if (scheduler != mPreviousScheduler) {
@@ -117,6 +124,16 @@ bool AudioStream::isPlaying() {
 
 int32_t AudioStream::getBytesPerSample() const {
     return convertFormatToSizeInBytes(mFormat);
+}
+
+int64_t AudioStream::getFramesRead() {
+    updateFramesRead();
+    return mFramesRead;
+}
+
+int64_t AudioStream::getFramesWritten() {
+    updateFramesWritten();
+    return mFramesWritten;
 }
 
 } // namespace oboe

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -280,11 +280,15 @@ Result AudioInputStreamOpenSLES::requestStop() {
         setState(initialState);
     }
     return result;
-
 }
 
 int64_t AudioInputStreamOpenSLES::getFramesWritten() {
-    return getFramesProcessedByServer();
+    if (usingFIFO()) {
+        return AudioStreamBuffered::getFramesWritten();
+    } else {
+        mFramesWritten = getFramesProcessedByServer();
+        return mFramesWritten;
+    }
 }
 
 Result AudioInputStreamOpenSLES::updateServiceFrameCounter() {

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -282,12 +282,11 @@ Result AudioInputStreamOpenSLES::requestStop() {
     return result;
 }
 
-int64_t AudioInputStreamOpenSLES::getFramesWritten() {
+void AudioInputStreamOpenSLES::updateFramesWritten() {
     if (usingFIFO()) {
-        return AudioStreamBuffered::getFramesWritten();
+        AudioStreamBuffered::updateFramesWritten();
     } else {
         mFramesWritten = getFramesProcessedByServer();
-        return mFramesWritten;
     }
 }
 

--- a/src/opensles/AudioInputStreamOpenSLES.h
+++ b/src/opensles/AudioInputStreamOpenSLES.h
@@ -45,11 +45,11 @@ public:
     Result requestFlush() override;
     Result requestStop() override;
 
-    int64_t getFramesWritten() override;
-
 protected:
 
     Result updateServiceFrameCounter() override;
+
+    void updateFramesWritten() override;
 
 private:
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -318,12 +318,11 @@ void AudioOutputStreamOpenSLES::setFramesRead(int64_t framesRead) {
     mPositionMillis.set(millisWritten);
 }
 
-int64_t AudioOutputStreamOpenSLES::getFramesRead() {
+void AudioOutputStreamOpenSLES::updateFramesRead() {
     if (usingFIFO()) {
-        return AudioStreamBuffered::getFramesRead();
+        AudioStreamBuffered::updateFramesRead();
     } else {
         mFramesRead = getFramesProcessedByServer();
-        return mFramesRead;
     }
 }
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -319,7 +319,12 @@ void AudioOutputStreamOpenSLES::setFramesRead(int64_t framesRead) {
 }
 
 int64_t AudioOutputStreamOpenSLES::getFramesRead() {
-    return getFramesProcessedByServer();
+    if (usingFIFO()) {
+        return AudioStreamBuffered::getFramesRead();
+    } else {
+        mFramesRead = getFramesProcessedByServer();
+        return mFramesRead;
+    }
 }
 
 Result AudioOutputStreamOpenSLES::updateServiceFrameCounter() {

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -44,13 +44,13 @@ public:
     Result requestFlush() override;
     Result requestStop() override;
 
-    int64_t getFramesRead() override;
-
 protected:
 
     void setFramesRead(int64_t framesRead);
 
     Result updateServiceFrameCounter() override;
+
+    void updateFramesRead() override;
 
 private:
 

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -43,22 +43,20 @@ void AudioStreamBuffered::allocateFifo() {
             mBufferCapacityInFrames = capacity;
         }
         // TODO consider using std::make_unique if we require c++14
-        mFifoBuffer.reset( new FifoBuffer(getBytesPerFrame(), capacity));
+        mFifoBuffer.reset(new FifoBuffer(getBytesPerFrame(), capacity));
     }
 }
 
-int64_t AudioStreamBuffered::getFramesWritten() {
+void AudioStreamBuffered::updateFramesWritten() {
     if (mFifoBuffer) {
         mFramesWritten = static_cast<int64_t>(mFifoBuffer->getWriteCounter());
-    }
-    return mFramesWritten;
+    } // or else it will get updated by processBufferCallback()
 }
 
-int64_t AudioStreamBuffered::getFramesRead() {
+void AudioStreamBuffered::updateFramesRead() {
     if (mFifoBuffer) {
         mFramesRead = static_cast<int64_t>(mFifoBuffer->getReadCounter());
-    }
-    return mFramesRead;
+    } // or else it will get updated by processBufferCallback()
 }
 
 // This is called by the OpenSL ES callback to read or write the back end of the FIFO.

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -72,7 +72,6 @@ protected:
 
 private:
 
-
     int64_t predictNextCallbackTime();
 
     void markCallbackTime(int numFrames);
@@ -84,7 +83,7 @@ private:
         mXRunCount++;
     }
 
-    std::unique_ptr<FifoBuffer>                  mFifoBuffer;
+    std::unique_ptr<FifoBuffer>                  mFifoBuffer{};
 
     int64_t mBackgroundRanAtNanoseconds = 0;
     int32_t mLastBackgroundSize = 0;

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -57,10 +57,6 @@ public:
 
     bool isXRunCountSupported() const override;
 
-    int64_t getFramesWritten() override;
-
-    int64_t getFramesRead() override;
-
 protected:
 
     DataCallbackResult onDefaultCallback(void *audioData, int numFrames) override;
@@ -69,6 +65,9 @@ protected:
     bool usingFIFO() const { return getCallback() == nullptr; }
 
     virtual Result updateServiceFrameCounter() { return Result::OK; };
+
+    void updateFramesRead() override;
+    void updateFramesWritten() override;
 
 private:
 
@@ -83,7 +82,7 @@ private:
         mXRunCount++;
     }
 
-    std::unique_ptr<FifoBuffer>                  mFifoBuffer{};
+    std::unique_ptr<FifoBuffer>   mFifoBuffer{};
 
     int64_t mBackgroundRanAtNanoseconds = 0;
     int32_t mLastBackgroundSize = 0;

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -216,9 +216,7 @@ Result AudioStreamOpenSLES::close() {
     if (mState == StreamState::Closed){
         return Result::ErrorClosed;
     } else {
-        // Update frame counter variables so they can be read after close.
-        getFramesWritten();
-        getFramesRead();
+        AudioStreamBuffered::close();
 
         onBeforeDestroy();
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -114,10 +114,9 @@ protected:
     uint8_t              *mCallbackBuffer = nullptr;
     int32_t               mBytesPerCallback = oboe::kUnspecified;
     int32_t               mFramesPerBurst = 0;
-    int32_t               mBurstsPerBuffer = 2; // Double buffered
     StreamState           mState = StreamState::Uninitialized;
 
-    MonotonicCounter  mPositionMillis; // for tracking OpenSL ES service position
+    MonotonicCounter      mPositionMillis; // for tracking OpenSL ES service position
 };
 
 } // namespace oboe


### PR DESCRIPTION
For better frame counting in OpenSL ES.
When a FIFO was being used, getFramesRead() was returning
the server position. It should return the FIFO position.

Fixes #153