### PR TITLE
fix readNow buffer pointer

### DIFF
--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -164,8 +164,10 @@ int32_t FifoBuffer::readNow(void *buffer, int32_t numFrames) {
     // Zero out any samples we could not set.
     if (framesLeft > 0) {
         mUnderrunCount++;
+        uint8_t *destination = reinterpret_cast<uint8_t *>(buffer);
+        destination += convertFramesToBytes(framesRead); // point to first byte not set in buffer
         int32_t bytesToZero = convertFramesToBytes(framesLeft);
-        memset(buffer, 0, bytesToZero);
+        memset(destination, 0, bytesToZero);
     }
 
     return framesRead;

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -165,7 +165,7 @@ int32_t FifoBuffer::readNow(void *buffer, int32_t numFrames) {
     if (framesLeft > 0) {
         mUnderrunCount++;
         uint8_t *destination = reinterpret_cast<uint8_t *>(buffer);
-        destination += convertFramesToBytes(framesRead); // point to first byte not set in buffer
+        destination += convertFramesToBytes(framesRead); // point to first byte not set
         int32_t bytesToZero = convertFramesToBytes(framesLeft);
         memset(destination, 0, bytesToZero);
     }

--- a/src/fifo/FifoBuffer.h
+++ b/src/fifo/FifoBuffer.h
@@ -64,7 +64,7 @@ public:
      * @param framesToRead number of frames requested
      * @return number of frames actually read
      */
-    int32_t readNow(void *buffer, int32_t numFrames);
+    int32_t readNow(void *destination, int32_t numFrames);
 
     uint32_t getUnderrunCount() const { return mUnderrunCount; }
 

--- a/src/fifo/FifoBuffer.h
+++ b/src/fifo/FifoBuffer.h
@@ -40,6 +40,12 @@ public:
 
     int32_t convertFramesToBytes(int32_t frames);
 
+    /**
+     * Read framesToRead or, if not enough, then read as many as are available.
+     * @param destination
+     * @param framesToRead number of frames requested
+     * @return number of frames actually read
+     */
     int32_t read(void *destination, int32_t framesToRead);
 
     int32_t write(const void *source, int32_t framesToWrite);
@@ -50,6 +56,14 @@ public:
 
     uint32_t getBufferCapacityInFrames() const;
 
+    /**
+     * Calls read(). If all of the frames cannot be read then the remainder of the buffer
+     * is set to zero and the underruncount is incremented.
+     *
+     * @param destination
+     * @param framesToRead number of frames requested
+     * @return number of frames actually read
+     */
     int32_t readNow(void *buffer, int32_t numFrames);
 
     uint32_t getUnderrunCount() const { return mUnderrunCount; }

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -64,11 +64,11 @@ DataCallbackResult AudioStreamBuffered::onDefaultCallback(void *audioData, int n
     int32_t framesTransferred  = 0;
 
     if (getDirection() == oboe::Direction::Output) {
-        // Read from the FIFO and write to audioData
+        // Read from the FIFO and write to audioData, clear part of buffer if not enough data.
         framesTransferred = mFifoBuffer->readNow(audioData, numFrames);
     } else {
         // Read from audioData and write to the FIFO
-        framesTransferred = mFifoBuffer->write(audioData, numFrames); // FIXME writeNow????
+        framesTransferred = mFifoBuffer->write(audioData, numFrames); // There is no writeNow()
     }
 
     if (framesTransferred < numFrames) {


### PR DESCRIPTION
Was clearing beginning of buffer instead of end of buffer.
Also document read() and readNow().
This affects OpenSL ES blocking writes when un underflow occured.

Fixes: 233
Fixes: 154