### PR TITLE
docs: add restrictions to AudioStreamCallback

### DIFF
--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -282,6 +282,9 @@ public:
     /**
      * Specifies an object to handle data or error related callbacks from the underlying API.
      *
+     * <strong>Important: See AudioStreamCallback for restrictions on what may be called
+     * from the callback methods.</strong>
+     *
      * When an error callback occurs, the associated stream will be stopped and closed in a separate thread.
      *
      * A note on why the streamCallback parameter is a raw pointer rather than a smart pointer:

--- a/include/oboe/Definitions.h
+++ b/include/oboe/Definitions.h
@@ -179,11 +179,17 @@ namespace oboe {
          * This will be the only stream using a particular source or sink.
          * This mode will provide the lowest possible latency.
          * You should close EXCLUSIVE streams immediately when you are not using them.
+         *
+         * If you do not need the lowest possible latency then we recommend using Shared,
+         * which is the default.
          */
         Exclusive = AAUDIO_SHARING_MODE_EXCLUSIVE,
 
         /**
-         * Multiple applications will be mixed by the AAudio Server.
+         * Multiple applications can share the same device.
+         * The data from output streams will be mixed by the audio service.
+         * The data for input streams will be distributed by the audio service.
+         *
          * This will have higher latency than the EXCLUSIVE mode.
          */
         Shared = AAUDIO_SHARING_MODE_SHARED,


### PR DESCRIPTION
For example, do not stop() or write() a stream from the callback.

Some of these docs were borrowed from AAudio.

Issue #32