### PR TITLE
Adding stricter compile error flags to make Oboe compatible with JUCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(oboe STATIC ${oboe_sources})
 
 # Specify directories which the compiler should look for headers
 target_include_directories(oboe
-                           PRIVATE src 
+                           PRIVATE src
                            PUBLIC include)
 
 # Compile Flags:
@@ -37,6 +37,8 @@ target_compile_options(oboe
     -std=c++11
     -Wall
     -Wextra-semi
+	-Wshadow
+	-Wshadow-field
     -Ofast
     "$<$<CONFIG:DEBUG>:-Werror>")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,12 @@ target_include_directories(oboe
 #     Enable -Werror when building debug config
 #     Enable -Ofast
 target_compile_options(oboe
-    PRIVATE -std=c++11 -Wall "$<$<CONFIG:DEBUG>:-Werror>" -Ofast)
+    PRIVATE
+    -std=c++11
+    -Wall
+    -Wextra-semi
+    -Ofast
+    "$<$<CONFIG:DEBUG>:-Werror>")
 
 # Enable logging for debug builds
 target_compile_definitions(oboe PUBLIC "$<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ target_compile_options(oboe
     -std=c++11
     -Wall
     -Wextra-semi
-	-Wshadow
-	-Wshadow-field
+    -Wshadow
+    -Wshadow-field
     -Ofast
     "$<$<CONFIG:DEBUG>:-Werror>")
 

--- a/include/oboe/AudioStreamBase.h
+++ b/include/oboe/AudioStreamBase.h
@@ -76,7 +76,7 @@ public:
      *
      * @return buffer size
      */
-    virtual int32_t getBufferSizeInFrames() { return mBufferSizeInFrames; };
+    virtual int32_t getBufferSizeInFrames() { return mBufferSizeInFrames; }
 
     /**
      * @return capacityInFrames or kUnspecified

--- a/src/common/MonotonicCounter.h
+++ b/src/common/MonotonicCounter.h
@@ -30,8 +30,8 @@
 class MonotonicCounter {
 
 public:
-    MonotonicCounter() {};
-    virtual ~MonotonicCounter() {};
+    MonotonicCounter() {}
+    virtual ~MonotonicCounter() {}
 
     /**
      * @return current value of the counter

--- a/src/opensles/AudioStreamBuffered.h
+++ b/src/opensles/AudioStreamBuffered.h
@@ -64,7 +64,7 @@ protected:
     // If there is no callback then we need a FIFO between the App and OpenSL ES.
     bool usingFIFO() const { return getCallback() == nullptr; }
 
-    virtual Result updateServiceFrameCounter() { return Result::OK; };
+    virtual Result updateServiceFrameCounter() { return Result::OK; }
 
     void updateFramesRead() override;
     void updateFramesWritten() override;

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -81,8 +81,8 @@ protected:
 
     SLuint32 channelCountToChannelMaskDefault(int channelCount);
 
-    virtual Result onBeforeDestroy() { return Result::OK; };
-    virtual Result onAfterDestroy() { return Result::OK; };
+    virtual Result onBeforeDestroy() { return Result::OK; }
+    virtual Result onAfterDestroy() { return Result::OK; }
 
     static SLuint32 getDefaultByteOrder();
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -113,7 +113,6 @@ protected:
 
     uint8_t              *mCallbackBuffer = nullptr;
     int32_t               mBytesPerCallback = oboe::kUnspecified;
-    int32_t               mFramesPerBurst = DefaultStreamValues::FramesPerBurst;
     StreamState           mState = StreamState::Uninitialized;
 
     MonotonicCounter      mPositionMillis; // for tracking OpenSL ES service position


### PR DESCRIPTION
Currently Oboe doesn't work with the JUCE DemoRunner project because it uses [stricter compile flags](https://github.com/WeAreROLI/JUCE/blob/master/examples/DemoRunner/DemoRunner.jucer#L96) causing errors when building Oboe.

This change adds some stricter compile flags and fixes the code which subsequently breaks - mainly where we  were comparing `int32_t` to `uint32_t`. 