### PR TITLE
AAudioLoader: cleanup destructor, logging

### DIFF
--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -23,7 +23,10 @@
 namespace oboe {
 
 AAudioLoader::~AAudioLoader() {
-    close(); // TODO dangerous from a destructor, require caller to close()
+    if (mLibHandle != nullptr) {
+        dlclose(mLibHandle);
+        mLibHandle = nullptr;
+    }
 }
 
 AAudioLoader* AAudioLoader::getInstance() {
@@ -151,19 +154,9 @@ int AAudioLoader::open() {
     return 0;
 }
 
-int AAudioLoader::close() {
-    if (mLibHandle != nullptr) {
-        dlclose(mLibHandle);
-        mLibHandle = nullptr;
-    }
-    return 0;
-}
-
 static void AAudioLoader_check(void *proc, const char *functionName) {
     if (proc == nullptr) {
-        LOGE("AAudioLoader could not find %s", functionName);
-    } else {
-        LOGV("AAudioLoader(): dlsym(%s) succeeded.", functionName);
+        LOGW("AAudioLoader could not find %s", functionName);
     }
 }
 

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -54,21 +54,11 @@ class AAudioLoader {
      * This can be called multiple times.
      * It should only be called from one thread.
      *
+     * The destructor will clean up after the open.
+     *
      * @return 0 if successful or negative error.
      */
     int open();
-
-    /**
-     * Close the AAudio shared library.
-     * This can be called multiple times.
-     * It should only be called from one thread.
-     *
-     * The open() and close() do not nest. Calling close() once will always close the library.
-     * The destructor will call close() so you don't need to.
-     *
-     * @return 0 if successful or negative error.
-     */
-    int close();
 
     // Function pointers into the AAudio shared library.
     aaudio_result_t (*createStreamBuilder)(AAudioStreamBuilder **builder);


### PR DESCRIPTION
remove close()
remove some logging
reduced ERROR to WARNING for dlsym() when function not found