### PR TITLE
opensles: fix getBufferSizeInFrames()

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -118,6 +118,7 @@ Result AudioStreamOpenSLES::open() {
 
     if (!usingFIFO()) {
         mBufferCapacityInFrames = mFramesPerBurst * kBufferQueueLength;
+        mBufferSizeInFrames = mBufferCapacityInFrames;
     }
 
     return Result::OK;


### PR DESCRIPTION
Return the BufferCapacityInFrames instead of zero.

Fixes #285