### PR TITLE
OboeTester: fix display of buffer size

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
@@ -100,7 +100,7 @@ abstract class TestAudioActivity extends Activity {
             if (status.bufferSize < 0 || status.framesWritten < 0) {
                 return;
             }
-            int numBuffers = -1;
+            int numBuffers = 0;
             if (status.bufferSize > 0 && mFramesPerBurst > 0) {
                 numBuffers = status.bufferSize / mFramesPerBurst;
             }


### PR DESCRIPTION
When size was zero it displayed "0 = -1 * 96".
Now it will display "0 = 0 * 96".