### PR TITLE
oboetester: add per channel enables for output

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/AudioProcessorBase.cpp
+++ b/apps/OboeTester/app/src/main/cpp/AudioProcessorBase.cpp
@@ -32,7 +32,7 @@ AudioPort::AudioPort(AudioProcessorBase &parent, int samplesPerFrame)
 AudioFloatPort::AudioFloatPort(AudioProcessorBase &parent, int samplesPerFrame)
         : AudioPort(parent, samplesPerFrame), mFloatBuffer(NULL) {
     int numFloats = MAX_BLOCK_SIZE * mSamplesPerFrame;
-    mFloatBuffer = new float[numFloats];
+    mFloatBuffer = new float[numFloats]{};
 }
 
 AudioFloatPort::~AudioFloatPort() {

--- a/apps/OboeTester/app/src/main/cpp/FifoProcessor.h
+++ b/apps/OboeTester/app/src/main/cpp/FifoProcessor.h
@@ -44,7 +44,7 @@ public:
 
     AudioResult onProcess(
             uint64_t framePosition,
-            int numFrames) {
+            int numFrames)  override {
         float *buffer = output.getFloatBuffer(numFrames);
         return mFifoBuffer.readNow(buffer, numFrames);
     }

--- a/apps/OboeTester/app/src/main/cpp/ManyToMultiConverter.cpp
+++ b/apps/OboeTester/app/src/main/cpp/ManyToMultiConverter.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unistd.h>
+#include "AudioProcessorBase.h"
+#include "ManyToMultiConverter.h"
+
+ManyToMultiConverter::ManyToMultiConverter(int32_t channelCount)
+        : inputs(channelCount)
+        , output(*this, channelCount) {
+    for (int i = 0; i < channelCount; i++) {
+        inputs[i] = std::make_unique<AudioInputPort>(*this, 1);
+    }
+}
+
+AudioResult ManyToMultiConverter::onProcess(
+        uint64_t framePosition,
+        int numFrames) {
+    int32_t channelCount = output.getSamplesPerFrame();
+
+    for (int i = 0; i < channelCount; i++) {
+        inputs[i]->pullData(framePosition, numFrames);
+    }
+
+
+    for (int ch = 0; ch < channelCount; ch++) {
+        const float *inputBuffer = inputs[ch]->getFloatBuffer(numFrames);
+        float *outputBuffer = output.getFloatBuffer(numFrames) + ch;
+
+        for (int i = 0; i < numFrames; i++) {
+            // read one, write into the proper interleaved output channel
+            float sample = *inputBuffer++;
+            *outputBuffer = sample;
+            outputBuffer += channelCount; // advance to next multichannel frame
+        }
+    }
+    return AUDIO_RESULT_SUCCESS;
+}
+

--- a/apps/OboeTester/app/src/main/cpp/ManyToMultiConverter.h
+++ b/apps/OboeTester/app/src/main/cpp/ManyToMultiConverter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Android Open Source Project
+ * Copyright 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef OBOETESTER_MONO_TO_MULTI_CONVERTER_H
-#define OBOETESTER_MONO_TO_MULTI_CONVERTER_H
+#ifndef OBOETESTER_MANY_TO_MULTI_CONVERTER_H
+#define OBOETESTER_MANY_TO_MULTI_CONVERTER_H
 
 #include <unistd.h>
 #include <sys/types.h>
+#include <vector>
 
 #include "AudioProcessorBase.h"
 
 /**
- * Duplicate a single mono input across multiple channels of output.
+ * Combine multiple mono inputs into one multi-channel output.
  */
-class MonoToMultiConverter : AudioProcessorBase {
+class ManyToMultiConverter : public AudioProcessorBase {
 public:
-    explicit MonoToMultiConverter(int32_t channelCount);
+    explicit ManyToMultiConverter(int32_t channelCount);
 
-    virtual ~MonoToMultiConverter() = default;
+    virtual ~ManyToMultiConverter() = default;
 
     AudioResult onProcess(
             uint64_t framePosition,
@@ -37,10 +38,10 @@ public:
 
     void setEnabled(bool enabled) {};
 
-    AudioInputPort input;
+    std::vector<std::unique_ptr<AudioInputPort> > inputs;
     AudioOutputPort output;
 
 private:
 };
 
-#endif //OBOETESTER_MONO_TO_MULTI_CONVERTER_H
+#endif //OBOETESTER_MANY_TO_MULTI_CONVERTER_H

--- a/apps/OboeTester/app/src/main/cpp/MonoToMultiConverter.cpp
+++ b/apps/OboeTester/app/src/main/cpp/MonoToMultiConverter.cpp
@@ -23,8 +23,6 @@ MonoToMultiConverter::MonoToMultiConverter(int32_t channelCount)
         , output(*this, channelCount) {
 }
 
-MonoToMultiConverter::~MonoToMultiConverter() { }
-
 AudioResult MonoToMultiConverter::onProcess(
         uint64_t framePosition,
         int numFrames) {

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -392,4 +392,10 @@ Java_com_google_sample_oboe_manualtest_OboeAudioOutputStream_setAmplitude(
 
 }
 
+JNIEXPORT void JNICALL
+Java_com_google_sample_oboe_manualtest_OboeAudioOutputStream_setChannelEnabled(
+        JNIEnv *env, jobject, jint channelIndex, jboolean enabled) {
+    engine.setChannelEnabled(channelIndex, enabled);
+}
+
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioOutputTester.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioOutputTester.java
@@ -61,4 +61,7 @@ public class AudioOutputTester extends AudioStreamTester {
         mCurrentAudioStream.setAmplitude(amplitude);
     }
 
+    public void setChannelEnabled(int channelIndex, boolean enabled)  {
+        mOboeAudioOutputStream.setChannelEnabled(channelIndex, enabled);
+    }
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioOutputStream.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioOutputStream.java
@@ -31,11 +31,12 @@ public class OboeAudioOutputStream extends OboeAudioStream {
         return false;
     }
 
-    public native void setToneEnabled(boolean b);
+    public native void setToneEnabled(boolean enabled);
 
     public native void setToneType(int index);
 
     @Override
     public native void setAmplitude(double amplitude);
 
+    public native void setChannelEnabled(int channelIndex, boolean enabled);
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivity.java
@@ -17,13 +17,18 @@
 package com.google.sample.oboe.manualtest;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.CheckBox;
 
 import com.google.sample.oboe.manualtest.R;
 
 /**
  * Base class for output test activities
  */
-public class TestOutputActivity extends TestOutputActivityBase {
+public final class TestOutputActivity extends TestOutputActivityBase {
+
+    public static final int MAX_CHANNEL_BOXES = 8;
+    private CheckBox[] mChannelBoxes;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,6 +39,31 @@ public class TestOutputActivity extends TestOutputActivityBase {
         updateEnabledWidgets();
 
         mAudioStreamTester = mAudioOutTester = AudioOutputTester.getInstance();
+
+        mChannelBoxes = new CheckBox[MAX_CHANNEL_BOXES];
+        int ic = 0;
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox0);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox1);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox2);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox3);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox4);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox5);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox6);
+        mChannelBoxes[ic++] = (CheckBox) findViewById(R.id.channelBox7);
+        configureChannelBoxes(0);
+    }
+
+    public void openAudio() {
+        super.openAudio();
+        int channelCount = mAudioOutTester.getCurrentAudioStream().getChannelCount();
+        configureChannelBoxes(channelCount);
+    }
+
+    private void configureChannelBoxes(int channelCount) {
+        for (int i = 0; i < mChannelBoxes.length; i++) {
+            mChannelBoxes[i].setChecked(i < channelCount);
+            mChannelBoxes[i].setEnabled(i < channelCount);
+        }
     }
 
     public void startAudio() {
@@ -47,4 +77,15 @@ public class TestOutputActivity extends TestOutputActivityBase {
         super.stopAudio();
     }
 
+    public void closeAudio() {
+        configureChannelBoxes(0);
+        super.closeAudio();
+    }
+
+    public void onChannelBoxClicked(View view) {
+        CheckBox checkBox = (CheckBox) view;
+        String text = (String) checkBox.getText();
+        int channelIndex = Integer.parseInt(text);
+        mAudioOutTester.setChannelEnabled(channelIndex, checkBox.isChecked());
+    }
 }

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_output.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_output.xml
@@ -12,4 +12,72 @@
 
     <include layout="@layout/merge_audio_common"/>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/channelText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Channels:" />
+
+        <CheckBox
+            android:id="@+id/channelBox0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="0" />
+
+        <CheckBox
+            android:id="@+id/channelBox1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="1" />
+
+        <CheckBox
+            android:id="@+id/channelBox2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="2" />
+
+        <CheckBox
+            android:id="@+id/channelBox3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="3" />
+
+        <CheckBox
+            android:id="@+id/channelBox4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="4" />
+
+        <CheckBox
+            android:id="@+id/channelBox5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="5" />
+
+        <CheckBox
+            android:id="@+id/channelBox6"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="6" />
+
+        <CheckBox
+            android:id="@+id/channelBox7"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onChannelBoxClicked"
+            android:text="7" />
+
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Added check boxes for turning sine waves on and off.
This will help us test the paths to the speakers.