### PR TITLE
oboe: cleanup aaudio wrapper

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -415,18 +415,20 @@ protected:
     virtual void updateFramesRead() = 0;
 
     /**
-     * Number of frames which have been written into the stream
+     * Number of frames which have been written into the stream.
      *
-     * TODO these should be atomic like in AAudio
+     * This is signed integer to match the counters in AAudio.
+     * At audio rates, the counter will overflow in about six million years.
      */
-    int64_t              mFramesWritten = 0;
+    std::atomic<int64_t> mFramesWritten{};
 
     /**
-     * Number of frames which have been read from the stream
+     * Number of frames which have been read from the stream.
      *
-     * TODO these should be atomic like in AAudio
+     * This is signed integer to match the counters in AAudio.
+     * At audio rates, the counter will overflow in about six million years.
      */
-    int64_t              mFramesRead = 0;
+    std::atomic<int64_t> mFramesRead{};
 
 private:
     int                  mPreviousScheduler = -1;

--- a/include/oboe/Utilities.h
+++ b/include/oboe/Utilities.h
@@ -42,7 +42,7 @@ void convertFloatToPcm16(const float *source, int16_t *destination, int32_t numS
 void convertPcm16ToFloat(const int16_t *source, float *destination, int32_t numSamples);
 
 /**
- * @return the size of a sample of the given format in bytes or OBOE_ERROR_ILLEGAL_ARGUMENT
+ * @return the size of a sample of the given format in bytes or 0 if format is invalid
  */
 int32_t convertFormatToSizeInBytes(AudioFormat format);
 

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -125,7 +125,6 @@ int AAudioLoader::open() {
 
     stream_getBufferSize      = load_I_PS("AAudioStream_getBufferSizeInFrames");
     stream_getDeviceId        = load_I_PS("AAudioStream_getDeviceId");
-    stream_getDirection       = load_I_PS("AAudioStream_getDirection");
     stream_getBufferCapacity  = load_I_PS("AAudioStream_getBufferCapacityInFrames");
     stream_getFramesPerBurst  = load_I_PS("AAudioStream_getFramesPerBurst");
     stream_getFramesRead      = load_L_PS("AAudioStream_getFramesRead");
@@ -144,7 +143,6 @@ int AAudioLoader::open() {
     stream_setBufferSize      = load_I_PSI("AAudioStream_setBufferSizeInFrames");
 
     convertResultToText       = load_PC_I("AAudio_convertResultToText");
-    convertStreamStateToText  = load_PC_I("AAudio_convertStreamStateToText");
 
     stream_getUsage           = load_I_PS("AAudioStream_getUsage");
     stream_getContentType     = load_I_PS("AAudioStream_getContentType");

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -66,20 +66,20 @@ class AAudioLoader {
     aaudio_result_t  (*builder_openStream)(AAudioStreamBuilder *builder,
                                            AAudioStream **stream);
 
-    signature_V_PBI builder_setBufferCapacityInFrames;
-    signature_V_PBI builder_setChannelCount;
-    signature_V_PBI builder_setDeviceId;
-    signature_V_PBI builder_setDirection;
-    signature_V_PBI builder_setFormat;
-    signature_V_PBI builder_setFramesPerDataCallback;
-    signature_V_PBI builder_setPerformanceMode;
-    signature_V_PBI builder_setSampleRate;
-    signature_V_PBI builder_setSharingMode;
+    signature_V_PBI builder_setBufferCapacityInFrames = nullptr;
+    signature_V_PBI builder_setChannelCount = nullptr;
+    signature_V_PBI builder_setDeviceId = nullptr;
+    signature_V_PBI builder_setDirection = nullptr;
+    signature_V_PBI builder_setFormat = nullptr;
+    signature_V_PBI builder_setFramesPerDataCallback = nullptr;
+    signature_V_PBI builder_setPerformanceMode = nullptr;
+    signature_V_PBI builder_setSampleRate = nullptr;
+    signature_V_PBI builder_setSharingMode = nullptr;
 
-    signature_V_PBI builder_setUsage;
-    signature_V_PBI builder_setContentType;
-    signature_V_PBI builder_setInputPreset;
-    signature_V_PBI builder_setSessionId;
+    signature_V_PBI builder_setUsage = nullptr;
+    signature_V_PBI builder_setContentType = nullptr;
+    signature_V_PBI builder_setInputPreset = nullptr;
+    signature_V_PBI builder_setSessionId = nullptr;
 
     void (*builder_setDataCallback)(AAudioStreamBuilder *builder,
                                     AAudioStream_dataCallback callback,
@@ -89,7 +89,7 @@ class AAudioLoader {
                                     AAudioStream_errorCallback callback,
                                     void *userData);
 
-    signature_I_PB  builder_delete;
+    signature_I_PB  builder_delete = nullptr;
 
     aaudio_format_t (*stream_getFormat)(AAudioStream *stream);
 
@@ -113,36 +113,35 @@ class AAudioLoader {
                                           int64_t *framePosition,
                                           int64_t *timeNanoseconds);
 
-    signature_I_PS   stream_close;
+    signature_I_PS   stream_close = nullptr;
 
-    signature_I_PS   stream_getChannelCount;
-    signature_I_PS   stream_getDeviceId;
-    signature_I_PS   stream_getDirection;
-    signature_I_PS   stream_getBufferSize;
-    signature_I_PS   stream_getBufferCapacity;
-    signature_I_PS   stream_getFramesPerBurst;
-    signature_I_PS   stream_getState;
-    signature_I_PS   stream_getPerformanceMode;
-    signature_I_PS   stream_getSampleRate;
-    signature_I_PS   stream_getSharingMode;
-    signature_I_PS   stream_getXRunCount;
+    signature_I_PS   stream_getChannelCount = nullptr;
+    signature_I_PS   stream_getDeviceId = nullptr;
 
-    signature_I_PSI  stream_setBufferSize;
-    signature_I_PS   stream_requestStart;
-    signature_I_PS   stream_requestPause;
-    signature_I_PS   stream_requestFlush;
-    signature_I_PS   stream_requestStop;
+    signature_I_PS   stream_getBufferSize = nullptr;
+    signature_I_PS   stream_getBufferCapacity = nullptr;
+    signature_I_PS   stream_getFramesPerBurst = nullptr;
+    signature_I_PS   stream_getState = nullptr;
+    signature_I_PS   stream_getPerformanceMode = nullptr;
+    signature_I_PS   stream_getSampleRate = nullptr;
+    signature_I_PS   stream_getSharingMode = nullptr;
+    signature_I_PS   stream_getXRunCount = nullptr;
 
-    signature_L_PS   stream_getFramesRead;
-    signature_L_PS   stream_getFramesWritten;
+    signature_I_PSI  stream_setBufferSize = nullptr;
+    signature_I_PS   stream_requestStart = nullptr;
+    signature_I_PS   stream_requestPause = nullptr;
+    signature_I_PS   stream_requestFlush = nullptr;
+    signature_I_PS   stream_requestStop = nullptr;
 
-    signature_PC_I   convertResultToText;
-    signature_PC_I   convertStreamStateToText;
+    signature_L_PS   stream_getFramesRead = nullptr;
+    signature_L_PS   stream_getFramesWritten = nullptr;
 
-    signature_I_PS   stream_getUsage;
-    signature_I_PS   stream_getContentType;
-    signature_I_PS   stream_getInputPreset;
-    signature_I_PS   stream_getSessionId;
+    signature_PC_I   convertResultToText = nullptr;
+
+    signature_I_PS   stream_getUsage = nullptr;
+    signature_I_PS   stream_getContentType = nullptr;
+    signature_I_PS   stream_getInputPreset = nullptr;
+    signature_I_PS   stream_getSessionId = nullptr;
 
   private:
     AAudioLoader() {}

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -75,17 +75,10 @@ namespace oboe {
  */
 AudioStreamAAudio::AudioStreamAAudio(const AudioStreamBuilder &builder)
     : AudioStream(builder)
-    , mFloatCallbackBuffer(nullptr)
-    , mShortCallbackBuffer(nullptr)
     , mAAudioStream(nullptr) {
     mCallbackThreadEnabled.store(false);
     LOGD("AudioStreamAAudio() call isSupported()");
     isSupported();
-}
-
-AudioStreamAAudio::~AudioStreamAAudio() {
-    delete[] mFloatCallbackBuffer;
-    delete[] mShortCallbackBuffer;
 }
 
 bool AudioStreamAAudio::isSupported() {

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -42,7 +42,7 @@ public:
     AudioStreamAAudio();
     explicit AudioStreamAAudio(const AudioStreamBuilder &builder);
 
-    ~AudioStreamAAudio();
+    virtual ~AudioStreamAAudio() = default;
 
     /**
      *
@@ -96,8 +96,6 @@ public:
                                                    void *audioData,
                                                    int32_t numFrames);
 
-    void onErrorCallback(AAudioStream *stream, Result error);
-
     void onErrorInThread(AAudioStream *stream, Result error);
 
 
@@ -111,10 +109,7 @@ protected:
 
 private:
 
-    float               *mFloatCallbackBuffer;
-    int16_t             *mShortCallbackBuffer;
     std::atomic<bool>    mCallbackThreadEnabled;
-    std::thread         *mErrorHandlingThread = nullptr;
 
     std::mutex           mLock; // for synchronizing start/stop/close
     std::atomic<AAudioStream *> mAAudioStream{nullptr};

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -30,7 +30,7 @@ AudioStream::AudioStream(const AudioStreamBuilder &builder)
 }
 
 Result AudioStream::open() {
-    // TODO validate parameters or let underlying API validate them?
+    // Parameters are validated by the underlying API.
     return Result::OK;
 }
 
@@ -69,19 +69,19 @@ Result AudioStream::waitForStateTransition(StreamState startingState,
     StreamState state = getState();
     if (state == StreamState::Closed) {
         return Result::ErrorClosed;
+    }
+
+    StreamState nextState = state;
+    if (state == startingState && state != endingState) {
+        Result result = waitForStateChange(state, &nextState, timeoutNanoseconds);
+        if (result != Result::OK) {
+            return result;
+        }
+    }
+    if (nextState != endingState) {
+        return Result::ErrorInvalidState;
     } else {
-        StreamState nextState = state;
-        if (state == startingState && state != endingState) {
-            Result result = waitForStateChange(state, &nextState, timeoutNanoseconds);
-            if (result != Result::OK) {
-                return result;
-            }
-        }
-        if (nextState != endingState) {
-            return Result::ErrorInvalidState;
-        } else {
-            return Result::OK;
-        }
+        return Result::OK;
     }
 }
 

--- a/src/fifo/FifoControllerBase.h
+++ b/src/fifo/FifoControllerBase.h
@@ -80,7 +80,7 @@ public:
 
     uint32_t getFrameCapacity() const { return mTotalFrames; }
 
-    virtual uint64_t getReadCounter() = 0;  // TODO use int64_t?
+    virtual uint64_t getReadCounter() = 0;
     virtual void setReadCounter(uint64_t n) = 0;
     virtual uint64_t getWriteCounter() = 0;
     virtual void setWriteCounter(uint64_t n) = 0;


### PR DESCRIPTION
Initialize some variables.
Use atomic counters in FIFO.

Partial fix for #293 