### PR TITLE
oboe: log version number in openStream()

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -35,7 +35,7 @@
 #define OBOE_VERSION_MINOR 0
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 0
+#define OBOE_VERSION_PATCH 1
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -75,6 +75,9 @@ AudioStream *AudioStreamBuilder::build() {
 }
 
 Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
+    LOGD("%s() %s -------- Oboe version " OBOE_VERSION_TEXT " --------",
+         __func__, getDirection() == Direction::Input ? "INPUT" : "OUTPUT");
+
     if (streamPP == nullptr) {
         return Result::ErrorNull;
     }


### PR DESCRIPTION
Also bump version to 1.0.1 to avoid confusion with stable 1.0.0 release.

Fixes #304 
