### PR TITLE
oboe: stop stream if callback requests it

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -371,6 +371,11 @@ public:
         return nullptr;
     }
 
+    /**
+     * Launch a thread that will stop the stream.
+     */
+    void launchStopThread();
+
 protected:
 
     /**
@@ -402,7 +407,7 @@ protected:
      * @return the result of the callback: stop or continue
      *
      */
-    DataCallbackResult fireCallback(void *audioData, int numFrames);
+    DataCallbackResult fireDataCallback(void *audioData, int numFrames);
 
     /**
      * Update mFramesWritten.
@@ -415,7 +420,22 @@ protected:
     virtual void updateFramesRead() = 0;
 
     /**
-     * Number of frames which have been written into the stream.
+     * @return true if callbacks may be called
+     */
+    bool isDataCallbackEnabled() {
+        return mDataCallbackEnabled;
+    }
+
+    /**
+     * This can be set false internally to prevent callbacks
+     * after DataCallbackResult::Stop has been returned.
+     */
+    void setDataCallbackEnabled(bool enabled) {
+        mDataCallbackEnabled = enabled;
+    }
+
+    /**
+     * Number of frames which have been written into the stream
      *
      * This is signed integer to match the counters in AAudio.
      * At audio rates, the counter will overflow in about six million years.
@@ -430,8 +450,12 @@ protected:
      */
     std::atomic<int64_t> mFramesRead{};
 
+    std::mutex           mLock; // for synchronizing start/stop/close
+
 private:
     int                  mPreviousScheduler = -1;
+
+    std::atomic<bool>    mDataCallbackEnabled{};
 
 };
 

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -108,12 +108,14 @@ int AAudioLoader::open() {
                                                  int64_t timeoutNanoseconds)>
             (dlsym(mLibHandle, "AAudioStream_waitForStateChange"));
 
-
     stream_getTimestamp = reinterpret_cast<aaudio_result_t (*)(AAudioStream *stream,
-                                           clockid_t clockid,
-                                           int64_t *framePosition,
-                                           int64_t *timeNanoseconds)>
+                                                               clockid_t clockid,
+                                                               int64_t *framePosition,
+                                                               int64_t *timeNanoseconds)>
             (dlsym(mLibHandle, "AAudioStream_getTimestamp"));
+
+    stream_isMMapUsed = reinterpret_cast<bool (*)(AAudioStream *stream)>
+            (dlsym(mLibHandle, "AAudioStream_isMMapUsed"));
 
     stream_getChannelCount    = load_I_PS("AAudioStream_getChannelCount");
     if (stream_getChannelCount == nullptr) {

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -113,6 +113,9 @@ class AAudioLoader {
                                           int64_t *framePosition,
                                           int64_t *timeNanoseconds);
 
+
+    bool            (*stream_isMMapUsed)(AAudioStream *stream) = nullptr;
+
     signature_I_PS   stream_close = nullptr;
 
     signature_I_PS   stream_getChannelCount = nullptr;

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -282,7 +282,9 @@ Result AudioStreamAAudio::requestStart() {
                 return Result::OK;
             }
         }
-        setDataCallbackEnabled(true);
+        if (mStreamCallback != nullptr) { // Was a callback requested?
+            setDataCallbackEnabled(true);
+        }
         return static_cast<Result>(mLibLoader->stream_requestStart(stream));
     } else {
         return Result::ErrorClosed;

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -38,9 +38,10 @@ static aaudio_data_callback_result_t oboe_aaudio_data_callback_proc(
         int32_t numFrames) {
 
     AudioStreamAAudio *oboeStream = reinterpret_cast<AudioStreamAAudio*>(userData);
-    if (oboeStream != NULL) {
+    if (oboeStream != nullptr) {
         return static_cast<aaudio_data_callback_result_t>(
                 oboeStream->callOnAudioReady(stream, audioData, numFrames));
+
     } else {
         return static_cast<aaudio_data_callback_result_t>(DataCallbackResult::Stop);
     }
@@ -49,7 +50,7 @@ static aaudio_data_callback_result_t oboe_aaudio_data_callback_proc(
 static void oboe_aaudio_error_thread_proc(AudioStreamAAudio *oboeStream,
                                           AAudioStream *stream,
                                           Result error) {
-    if (oboeStream != NULL) {
+    if (oboeStream != nullptr) {
         oboeStream->onErrorInThread(stream, error);
     }
 }
@@ -231,10 +232,28 @@ Result AudioStreamAAudio::close() {
 DataCallbackResult AudioStreamAAudio::callOnAudioReady(AAudioStream *stream,
                                                                  void *audioData,
                                                                  int32_t numFrames) {
-    return mStreamCallback->onAudioReady(
-            this,
-            audioData,
-            numFrames);
+    DataCallbackResult result = fireDataCallback(audioData, numFrames);
+    if (result == DataCallbackResult::Continue) {
+        return result;
+    } else {
+        if (result == DataCallbackResult::Stop) {
+            LOGE("Oboe callback returned DataCallbackResult::Stop");
+        } else {
+            LOGE("Oboe callback returned unexpected value = %d", result);
+        }
+
+        if (getSdkVersion() <= __ANDROID_API_P__) {
+            launchStopThread();
+            if (isMMapUsed()) {
+                return DataCallbackResult::Stop;
+            } else {
+                // Legacy stream <= API_P cannot be restarted after returning Stop.
+                return DataCallbackResult::Continue;
+            }
+        } else {
+            return DataCallbackResult::Stop; // OK >= API_Q
+        }
+    }
 }
 
 void AudioStreamAAudio::onErrorInThread(AAudioStream *stream, Result error) {
@@ -263,6 +282,7 @@ Result AudioStreamAAudio::requestStart() {
                 return Result::OK;
             }
         }
+        setDataCallbackEnabled(true);
         return static_cast<Result>(mLibLoader->stream_requestStart(stream));
     } else {
         return Result::ErrorClosed;
@@ -506,6 +526,15 @@ ResultWithValue<double> AudioStreamAAudio::calculateLatencyMillis() {
     double latencyMillis = latencyNanos / kNanosPerMillisecond;
 
     return ResultWithValue<double>(latencyMillis);
+}
+
+bool AudioStreamAAudio::isMMapUsed() {
+    AAudioStream *stream = mAAudioStream.load();
+    if (stream != nullptr) {
+        return mLibLoader->stream_isMMapUsed(stream);
+    } else {
+        return false;
+    }
 }
 
 } // namespace oboe

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -109,9 +109,10 @@ protected:
 
 private:
 
+    bool                 isMMapUsed();
+
     std::atomic<bool>    mCallbackThreadEnabled;
 
-    std::mutex           mLock; // for synchronizing start/stop/close
     std::atomic<AAudioStream *> mAAudioStream{nullptr};
 
     static AAudioLoader *mLibLoader;

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -234,20 +234,24 @@ error:
 
 Result AudioOutputStreamOpenSLES::onAfterDestroy() {
     OutputMixerOpenSL::getInstance().close();
-
     return Result::OK;
 }
 
 Result AudioOutputStreamOpenSLES::close() {
-
+    mLock.lock();
+    Result result = Result::OK;
     if (mState == StreamState::Closed){
-        return Result::ErrorClosed;
+        result = Result::ErrorClosed;
     } else {
+        mLock.unlock(); // avoid recursive lock
         requestPause();
+        mLock.lock();
         // invalidate any interfaces
         mPlayInterface = NULL;
-        return AudioStreamOpenSLES::close();
+        result = AudioStreamOpenSLES::close();
     }
+    mLock.unlock(); // avoid recursive lock
+    return result;
 }
 
 Result AudioOutputStreamOpenSLES::setPlayState(SLuint32 newState) {
@@ -269,27 +273,53 @@ Result AudioOutputStreamOpenSLES::setPlayState(SLuint32 newState) {
 }
 
 Result AudioOutputStreamOpenSLES::requestStart() {
+    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
 
-    LOGD("AudioOutputStreamOpenSLES(): requestStart()");
+    mLock.lock();
     StreamState initialState = getState();
-    if (initialState == StreamState::Closed) return Result::ErrorClosed;
+    switch (initialState) {
+        case StreamState::Starting:
+        case StreamState::Started:
+            mLock.unlock();
+            return Result::OK;
+        case StreamState::Closed:
+            mLock.unlock();
+            return Result::ErrorClosed;
+        default:
+            break;
+    }
 
+    setDataCallbackEnabled(true);
     setState(StreamState::Starting);
     Result result = setPlayState(SL_PLAYSTATE_PLAYING);
     if (result == Result::OK) {
         setState(StreamState::Started);
+        mLock.unlock();
+        // This could call requestStop() so try to avoid a recursive lock.
         processBufferCallback(mSimpleBufferQueueInterface);
+        mLock.lock();
     } else {
         setState(initialState);
     }
+    LOGD("AudioOutputStreamOpenSLES(): %s() returning %d", __func__, result);
+    mLock.unlock();
     return result;
 }
 
 Result AudioOutputStreamOpenSLES::requestPause() {
+    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
 
-    LOGD("AudioOutputStreamOpenSLES::requestPause()");
+    std::lock_guard<std::mutex> lock(mLock);
     StreamState initialState = getState();
-    if (initialState == StreamState::Closed) return Result::ErrorClosed;
+    switch (initialState) {
+        case StreamState::Pausing:
+        case StreamState::Paused:
+            return Result::OK;
+        case StreamState::Closed:
+            return Result::ErrorClosed;
+        default:
+            break;
+    }
 
     setState(StreamState::Pausing);
     Result result = setPlayState(SL_PLAYSTATE_PAUSED);
@@ -303,6 +333,7 @@ Result AudioOutputStreamOpenSLES::requestPause() {
     } else {
         setState(initialState);
     }
+    LOGD("AudioOutputStreamOpenSLES(): %s() returning %d", __func__, result);
     return result;
 }
 
@@ -310,28 +341,36 @@ Result AudioOutputStreamOpenSLES::requestPause() {
  * Flush/clear the queue buffers
  */
 Result AudioOutputStreamOpenSLES::requestFlush() {
-
-    LOGD("AudioOutputStreamOpenSLES(): requestFlush()");
+    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
     if (getState() == StreamState::Closed) return Result::ErrorClosed;
-
+    Result result = Result::OK;
     if (mPlayInterface == NULL || mSimpleBufferQueueInterface == NULL) {
-        return Result::ErrorInvalidState;
+        result = Result::ErrorInvalidState;
     } else {
-        SLresult result = (*mSimpleBufferQueueInterface)->Clear(mSimpleBufferQueueInterface);
-        if (result == SL_RESULT_SUCCESS){
-            return Result::OK;
-        } else {
+        SLresult slResult = (*mSimpleBufferQueueInterface)->Clear(mSimpleBufferQueueInterface);
+        if (slResult != SL_RESULT_SUCCESS){
             LOGW("Failed to clear buffer queue. OpenSLES error: %d", result);
-            return Result::ErrorInternal;
+            result = Result::ErrorInternal;
         }
     }
+    LOGD("AudioOutputStreamOpenSLES(): %s() returning %d", __func__, result);
+    return result;
 }
 
 Result AudioOutputStreamOpenSLES::requestStop() {
+    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
 
-    LOGD("AudioOutputStreamOpenSLES(): requestStop()");
+    std::lock_guard<std::mutex> lock(mLock);
     StreamState initialState = getState();
-    if (initialState == StreamState::Closed) return Result::ErrorClosed;
+    switch (initialState) {
+        case StreamState::Stopping:
+        case StreamState::Stopped:
+            return Result::OK;
+        case StreamState::Closed:
+            return Result::ErrorClosed;
+        default:
+            break;
+    }
 
     setState(StreamState::Stopping);
 
@@ -352,8 +391,8 @@ Result AudioOutputStreamOpenSLES::requestStop() {
     } else {
         setState(initialState);
     }
+    LOGD("AudioOutputStreamOpenSLES(): %s() returning %d", __func__, result);
     return result;
-
 }
 
 void AudioOutputStreamOpenSLES::setFramesRead(int64_t framesRead) {

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -271,7 +271,6 @@ void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
     }
     if (stopStream) {
         requestStop();
-        // launchStopThread();
     }
 }
 

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -70,12 +70,11 @@ public:
      *
      * This is public, but don't call it directly.
      */
-    SLresult processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
+    void processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
 
     Result waitForStateChange(StreamState currentState,
                               StreamState *nextState,
                               int64_t timeoutNanoseconds) override;
-
 
 protected:
 


### PR DESCRIPTION
Stop in a separate thread for AAudio before Q.
Call stop directly for OpenSL ES.

Possible fix for #277