### PR TITLE
oboe: return invalid from getTimestamp when stopped

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -441,6 +441,9 @@ Result AudioStreamAAudio::getTimestamp(clockid_t clockId,
                                    int64_t *timeNanoseconds) {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
+        if (getState() != StreamState::Started) {
+            return Result::ErrorInvalidState;
+        }
         return static_cast<Result>(mLibLoader->stream_getTimestamp(stream, clockId,
                                                framePosition, timeNanoseconds));
     } else {


### PR DESCRIPTION
AAudio is not returning INVALID_STATE when it should.

Fixes #322