### PR TITLE
Log enqueueResult in OpenSL ES

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -259,7 +259,7 @@ void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
         // Pass the data to OpenSLES.
         SLresult enqueueResult = enqueueCallbackBuffer(bq);
         if (enqueueResult != SL_RESULT_SUCCESS) {
-            LOGE("enqueueCallbackBuffer %d", result);
+            LOGE("enqueueCallbackBuffer() returned %d", enqueueResult);
             stopStream = true;
         }
     } else if (result == DataCallbackResult::Stop) {


### PR DESCRIPTION
Was logging DataCallbackResult.

This problem was reported by xdaimon here:  
https://github.com/google/oboe/commit/41816f55fcc32a7968f9475013413c29e50369f0#commitcomment-31848378
