### PR TITLE
oboe: do not use error callback when no data callback

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -158,8 +158,10 @@ Result AudioStreamAAudio::open() {
     if (mStreamCallback != nullptr) {
         mLibLoader->builder_setDataCallback(aaudioBuilder, oboe_aaudio_data_callback_proc, this);
         mLibLoader->builder_setFramesPerDataCallback(aaudioBuilder, getFramesPerCallback());
+        // If the data callback is not being used then the write method will return an error
+        // and the app can stop and close the stream.
+        mLibLoader->builder_setErrorCallback(aaudioBuilder, oboe_aaudio_error_callback_proc, this);
     }
-    mLibLoader->builder_setErrorCallback(aaudioBuilder, oboe_aaudio_error_callback_proc, this);
 
     // ============= OPEN THE STREAM ================
     {


### PR DESCRIPTION
That can close a stream that is in use by the app thread
that is writing the stream.
See issue #359