### PR TITLE
oboe: use shared_ptr to manage the AAudio stream pointer

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -37,24 +37,8 @@ void NativeAudioContext::close() {
 }
 
 bool NativeAudioContext::isMMapUsed() {
-    if (oboeStream != nullptr && oboeStream->usesAAudio()) {
-        if (mAAudioStream_isMMap == nullptr) {
-            mLibHandle = dlopen(LIB_AAUDIO_NAME, 0);
-            if (mLibHandle == nullptr) {
-                LOGI("%s() could not find " LIB_AAUDIO_NAME, __func__);
-                return false;
-            }
-
-            mAAudioStream_isMMap = (bool (*)(AAudioStream *stream))
-                    dlsym(mLibHandle, FUNCTION_IS_MMAP);
-
-            if(mAAudioStream_isMMap == nullptr) {
-                LOGI("%s() could not find " FUNCTION_IS_MMAP, __func__);
-                return false;
-            }
-        }
-        AAudioStream *aaudioStream = (AAudioStream *) oboeStream->getUnderlyingStream();
-        return mAAudioStream_isMMap(aaudioStream);
+    if (oboeStream != nullptr) {
+        return oboeStream->usesMMap();
     }
     return false;
 }

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -284,9 +284,6 @@ private:
 
     PlayRecordingCallback        mPlayRecordingCallback;
 
-    bool                       (*mAAudioStream_isMMap)(AAudioStream *stream) = nullptr;
-    void                        *mLibHandle = nullptr;
-
 };
 
 #endif //NATIVEOBOE_NATIVEAUDIOCONTEXT_H

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -360,15 +360,12 @@ public:
     }
 
     /**
-     * Only for debugging. Do not use in production.
-     * If you need to call this method something is wrong.
-     * If you think you need it for production then please let us know
-     * so we can modify Oboe so that you don't need this.
+     * This should only be used for debugging.
      *
-     * @return nullptr or a pointer to a stream from the system API
+     * @return true if the stream uses the AAudio MMAP data path;
      */
-    virtual void *getUnderlyingStream() const {
-        return nullptr;
+    virtual bool usesMMap() {
+        return false;
     }
 
     /**


### PR DESCRIPTION
Use an owner class to contain the raw 'C' pointer.