### PR TITLE
oboe: fix openSL ES read, write

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -253,9 +253,10 @@ Result AudioInputStreamOpenSLES::requestStart() {
             break;
     }
 
-    if (mStreamCallback != nullptr) { // Was a callback requested?
-        setDataCallbackEnabled(true);
-    }
+    // We use a callback if the user requests one
+    // OR if we have an internal callback to fill the blocking IO buffer.
+    setDataCallbackEnabled(true);
+
     setState(StreamState::Starting);
     Result result = setRecordState(SL_RECORDSTATE_RECORDING);
     if (result == Result::OK) {

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -289,9 +289,10 @@ Result AudioOutputStreamOpenSLES::requestStart() {
             break;
     }
 
-    if (mStreamCallback != nullptr) { // Was a callback requested?
-        setDataCallbackEnabled(true);
-    }
+    // We use a callback if the user requests one
+    // OR if we have an internal callback to read the blocking IO buffer.
+    setDataCallbackEnabled(true);
+
     setState(StreamState::Starting);
     Result result = setPlayState(SL_PLAYSTATE_PLAYING);
     if (result == Result::OK) {


### PR DESCRIPTION
Blocking IO was stopping immediately because of a recent change.
The callback was disabled but blocking IO on OpenSL ES
needs an internal callback to read/write the top level FIFO.

Fixes #370
See bug for repro steps.