### PR TITLE
oboe_opensles: lock requestFlush()

### DIFF
--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -58,6 +58,8 @@ private:
 
     Result onAfterDestroy() override;
 
+    Result requestFlush_l();
+
     /**
      * Set OpenSL ES PLAYSTATE.
      *


### PR DESCRIPTION
Add _l version to prevent recursive lock from requestStop().