### PR TITLE
CMakeLists.txt: make it possible to build shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set (oboe_sources
 		src/common/Trace.cpp
         )
 
-add_library(oboe STATIC ${oboe_sources})
+add_library(oboe ${oboe_sources})
 
 # Specify directories which the compiler should look for headers
 target_include_directories(oboe


### PR DESCRIPTION
In cmake manner, building shared library is easily doable by specifying
BUILD_SHARED_LIBS option (with `-D` command line argument),
but this explicit `STATIC` specification prevents that.

Since STATIC build is the default, it can be simply removed.