### PR TITLE
Refactor list of apps into a table

### DIFF
--- a/docs/AppsUsingOboe.md
+++ b/docs/AppsUsingOboe.md
@@ -1,71 +1,17 @@
 # Projects using Oboe or AAudio
 
+| Name | Description | Publisher | Notes |
+|:--|:--|:--|:--|
+| [Best Piano](https://play.google.com/store/apps/details?id=com.netigen.piano) | Piano tutor app  | Netigen | Stream is opened with 44100 Hz so it will not get an MMAP stream on Pixel |
+| [CSound for Android](https://play.google.com/store/apps/details?id=com.csounds.Csound6) | Audio synthesis app, using CSound framework | Irreducible Productions | [Oboe implementation source code](https://github.com/gogins/csound-extended/blob/develop/CsoundForAndroid/CsoundAndroid/jni/csound_oboe.hpp) |
+| [G-Stomper apps](https://play.google.com/store/apps/dev?id=5200192441928542082) | Mobile music production software | planet-h.com | Uses AAudio if you enable it in Settings (Setup->AUD->Audio System->AAudio). |
+| [ktnes](https://github.com/felipecsl/ktnes) | A NES emulator implemented in Kotlin using multiplatform support and Kotlin/Native. | Felipe Lima | | 
+| [Les Talens Lyriques apps](https://play.google.com/store/apps/developer?id=Les+Talens+Lyriques) | Music education apps | Les Talens Lyriques |  Stream opened with 44100 Hz so it will not get an MMAP stream on Pixel |
+| [JUCE](https://juce.com/) | Middleware framework | [ROLI](https://www.roli.com) | Oboe support enabled as experimental feature in Projucer |
+| [Music Speed Changer](https://play.google.com/store/apps/details?id=com.smp.musicspeed) | Play song files while changing the pitch and tempo. | Single Minded Productions |  | 
+| [n-Track Studio](https://play.google.com/store/apps/details?id=com.ntrack.studio.demo) | Mobile audio workstation | n-Track Software | Settings->Select AAudio for input and/or output->OK |
+| [Serial communication via audio](https://davidawehr.com/blog/audioserial/) | | David Wehr |  |
+| Volcano Mobile apps | MIDI synthesizer apps: [FluidSynth](https://play.google.com/store/apps/details?id=net.volcanomobile.fluidsynthmidi), [OPL3 MIDI Synth FM](https://play.google.com/store/apps/details?id=net.volcanomobile.opl3midisynth), [MIDI Sequencer](https://play.google.com/store/apps/details?id=net.volcanomobile.midisequencer) | Volcano Mobile |  MIDI Sequencer app is very handy for testing. |
+
 Want your project added? [Add a comment to issue #214](https://github.com/google/oboe/issues/214) with 
 your project name and Play Store URL. 
-
-## Frameworks
-
-### JUCE
-JUCE has enabled Oboe as an experimental feature.
-[JUCE middleware framework](https://juce.com/)
-
-## Apps and Projects
-In alphabetical order.
-
-### Best Piano
-Learn to play the Piano. Note that they open the stream with 44100 Hz so it will not get an MMAP stream on Pixel.
-
-[App on Play Store](https://play.google.com/store/apps/details?id=com.netigen.piano)
-
-### CSound for Android.
-Uses Oboe.
-
-[App on Play Store](https://play.google.com/store/apps/details?id=com.csounds.Csound6),
-[Source](https://github.com/gogins/csound-extended/blob/develop/CsoundForAndroid/CsoundAndroid/jni/csound_oboe.hpp)
-
-### G-Stomper apps
-Uses AAudio if you enable it in Settings.
-- Click "SETUP" button at far right.
-- Select "AUD" tab.
-- Under "Audio System", select "AAudio".
-- Hit Back icon.
-- You will see a message saying to restart GStomper.
-- Restart GStomper. It should now be using AAudio.
-
-[planet-h.com apps on Play store](https://play.google.com/store/apps/dev?id=5200192441928542082)
-
-### ktnes
-A NES emulator implemented in Kotlin using multiplatform support and Kotlin/Native.
-
-[Source](https://github.com/felipecsl/ktnes)
-
-### Les Talens Lyriques
-A series of music education apps using Oboe. Note that they open the stream with 44100 Hz so it will not get an MMAP stream on Pixel.
-
-[App on Play Store](https://play.google.com/store/apps/developer?id=Les+Talens+Lyriques)
-
-## Music Speed Changer
-Play song files while changing the pitch and tempo.
-
-[App on Play Store](https://play.google.com/store/apps/details?id=com.smp.musicspeed)
-
-### n-Track Studio
-Uses AAudio if you enable it in Settings.
-- Click menu icon at bottom right.
-- Click "Settings".
-- Select AAudio for input and/or output.
-- Scroll down and click "OK".
-
-[App on Play Store](https://play.google.com/store/apps/details?id=com.ntrack.studio.demo)
-
-### Serial communication via audio on Android
-[David Wehr blog](https://davidawehr.com/blog/audioserial/)
-
-### Volcano Mobile
-They have several MIDI synthesizer apps using Oboe.
-
-FluidSynth - [App on Play Store](https://play.google.com/store/apps/details?id=net.volcanomobile.fluidsynthmidi)
-
-OPL3 MIDI Synth FM - [App on Play Store](https://play.google.com/store/apps/details?id=net.volcanomobile.opl3midisynth)
-
-MIDI Sequencer app is very handy for testing. [App on Play Store](https://play.google.com/store/apps/details?id=net.volcanomobile.midisequencer)

--- a/docs/AppsUsingOboe.md
+++ b/docs/AppsUsingOboe.md
@@ -4,6 +4,7 @@
 |:--|:--|:--|:--|
 | [Best Piano](https://play.google.com/store/apps/details?id=com.netigen.piano) | Piano tutor app  | Netigen | Stream is opened with 44100 Hz so it will not get an MMAP stream on Pixel |
 | [CSound for Android](https://play.google.com/store/apps/details?id=com.csounds.Csound6) | Audio synthesis app, using CSound framework | Irreducible Productions | [Oboe implementation source code](https://github.com/gogins/csound-extended/blob/develop/CsoundForAndroid/CsoundAndroid/jni/csound_oboe.hpp) |
+| [Grainstorm](https://play.google.com/store/apps/details?id=me.rocks.grainstorm) | Granular synthesizer app | The Secret Laboratory | |
 | [G-Stomper apps](https://play.google.com/store/apps/dev?id=5200192441928542082) | Mobile music production software | planet-h.com | Uses AAudio if you enable it in Settings (Setup->AUD->Audio System->AAudio). |
 | [ktnes](https://github.com/felipecsl/ktnes) | A NES emulator implemented in Kotlin using multiplatform support and Kotlin/Native. | Felipe Lima | | 
 | [Les Talens Lyriques apps](https://play.google.com/store/apps/developer?id=Les+Talens+Lyriques) | Music education apps | Les Talens Lyriques |  Stream opened with 44100 Hz so it will not get an MMAP stream on Pixel |


### PR DESCRIPTION
The list of apps/frameworks using Oboe was getting quite long. I've refactored it into a table.