### PR TITLE
Remove isPlaying from AudioStream header

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -200,13 +200,6 @@ public:
     virtual int32_t getFramesPerBurst() = 0;
 
     /**
-     * Indicates whether the audio stream is playing.
-     *
-     * @deprecated check the stream state directly using `AudioStream::getState`.
-     */
-    bool isPlaying();
-
-    /**
      * Get the number of bytes in each audio frame. This is calculated using the channel count
      * and the sample format. For example, a 2 channel floating point stream will have
      * 2 * 4 = 8 bytes per frame.


### PR DESCRIPTION
Since https://github.com/google/oboe/pull/213/commits/6437f5aa224330fbdf77ecc161cc868be663a974, `isPlaying` is no longer part of Oboe's API.

Looks like we forgot to remove the function definition from the header file which made it a pure `virtual` function with no implementation that will error out when called.