### PR TITLE
synchronize with close() to avoid crashes when headset plugs in/out

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -373,9 +373,9 @@ ResultWithValue<int32_t>   AudioStreamAAudio::read(void *buffer,
 Result AudioStreamAAudio::waitForStateChange(StreamState currentState,
                                         StreamState *nextState,
                                         int64_t timeoutNanoseconds) {
+    std::lock_guard<std::mutex> lock(mLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-
         aaudio_stream_state_t aaudioNextState;
         aaudio_result_t result = mLibLoader->stream_waitForStateChange(
                         mAAudioStream,


### PR DESCRIPTION
Fixes the issue i created recently https://github.com/google/oboe/issues/406
But also uses locks inside `waitForStateTransition`. 
I did not dig into the code very deeply, but I can't see a reason not to use locks here. `close()` already uses a lock for the very same reason.
Does that make sense?

