### PR TITLE
remove isPlaying() from header since there is no implementation anymore.

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -200,13 +200,6 @@ public:
     virtual int32_t getFramesPerBurst() = 0;
 
     /**
-     * Indicates whether the audio stream is playing.
-     *
-     * @deprecated check the stream state directly using `AudioStream::getState`.
-     */
-    bool isPlaying();
-
-    /**
      * Get the number of bytes in each audio frame. This is calculated using the channel count
      * and the sample format. For example, a 2 channel floating point stream will have
      * 2 * 4 = 8 bytes per frame.


### PR DESCRIPTION
The `isPlaying()` definition feels lonely without an implementation, so I removed.