### PR TITLE
Use int32_t in AudioStreamBase.h

### DIFF
--- a/include/oboe/AudioStreamBase.h
+++ b/include/oboe/AudioStreamBase.h
@@ -48,7 +48,7 @@ public:
     /**
      * @return number of channels, for example 2 for stereo, or kUnspecified
      */
-    int getChannelCount() const { return mChannelCount; }
+    int32_t getChannelCount() const { return mChannelCount; }
 
     /**
      * @return Direction::Input or Direction::Output
@@ -63,7 +63,7 @@ public:
     /**
      * @return the number of frames in each callback or kUnspecified.
      */
-    int getFramesPerCallback() const { return mFramesPerCallback; }
+    int32_t getFramesPerCallback() const { return mFramesPerCallback; }
 
     /**
      * @return the audio sample format (e.g. Float or I16)

--- a/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/PlayAudioEngine.cpp
@@ -72,7 +72,7 @@ void PlayAudioEngine::createPlaybackStream() {
         mSampleRate = mPlayStream->getSampleRate();
         mFramesPerBurst = mPlayStream->getFramesPerBurst();
 
-        int channelCount = mPlayStream->getChannelCount();
+        int32_t channelCount = mPlayStream->getChannelCount();
         if (channelCount != mChannelCount){
             LOGW("Requested %d channels but received %d", mChannelCount, channelCount);
         }


### PR DESCRIPTION
for getChannelCount() and getFramesPerCallback().
