### PR TITLE
Eliminate need for AAudio.h

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/LatencyAnalyzer.h
@@ -478,12 +478,12 @@ public:
 
     virtual int save(const char *fileName) {
         (void) fileName;
-        return AAUDIO_ERROR_UNIMPLEMENTED;
+        return -1;
     }
 
     virtual int load(const char *fileName) {
         (void) fileName;
-        return AAUDIO_ERROR_UNIMPLEMENTED;
+        return -1;
     }
 
     virtual void setSampleRate(int32_t sampleRate) {

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -63,6 +63,8 @@
 #define LIB_AAUDIO_NAME          "libaaudio.so"
 #define FUNCTION_IS_MMAP         "AAudioStream_isMMapUsed"
 
+typedef struct AAudioStreamStruct         AAudioStream;
+
 /**
  * Abstract base class that corresponds to a test at the Java level.
  */

--- a/include/oboe/Definitions.h
+++ b/include/oboe/Definitions.h
@@ -17,8 +17,19 @@
 #ifndef OBOE_DEFINITIONS_H
 #define OBOE_DEFINITIONS_H
 
+// If the NDK is before P then do not include AAudio.h
+#ifndef OBOE_INCLUDE_AAUDIO
+#if __ANDROID_API_LEVEL__ >= __ANDROID_API_P__
+#define OBOE_INCLUDE_AAUDIO 1
+#else
+#define OBOE_INCLUDE_AAUDIO 0
+#endif
+#endif // OBOE_INCLUDE_AAUDIO
+
 #include <cstdint>
 #include <type_traits>
+
+#if (OBOE_INCLUDE_AAUDIO == 1)
 #include <aaudio/AAudio.h>
 
 // Ensure that all AAudio primitive data types are int32_t
@@ -32,6 +43,24 @@ ASSERT_INT32(aaudio_data_callback_result_t);
 ASSERT_INT32(aaudio_result_t);
 ASSERT_INT32(aaudio_sharing_mode_t);
 ASSERT_INT32(aaudio_performance_mode_t);
+#else
+// Define missing types from AAudio.h
+typedef int32_t aaudio_stream_state_t;
+typedef int32_t aaudio_direction_t;
+typedef int32_t aaudio_format_t;
+typedef int32_t aaudio_data_callback_result_t;
+typedef int32_t aaudio_result_t;
+typedef int32_t aaudio_sharing_mode_t;
+typedef int32_t aaudio_performance_mode_t;
+// These were defined in P
+typedef int32_t aaudio_usage_t;
+typedef int32_t aaudio_content_type_t;
+typedef int32_t aaudio_input_preset_t;
+typedef int32_t aaudio_session_id_t;
+#endif
+
+// Oboe needs to be able to build on old NDKs so we use hard coded constants.
+// The correctness of these constants is verified in "aaudio/AAudioLoader.cpp".
 
 namespace oboe {
 
@@ -65,20 +94,20 @@ namespace oboe {
      * The state of the audio stream.
      */
     enum class StreamState : aaudio_stream_state_t {
-        Uninitialized = AAUDIO_STREAM_STATE_UNINITIALIZED,
-        Unknown = AAUDIO_STREAM_STATE_UNKNOWN,
-        Open = AAUDIO_STREAM_STATE_OPEN,
-        Starting = AAUDIO_STREAM_STATE_STARTING,
-        Started = AAUDIO_STREAM_STATE_STARTED,
-        Pausing = AAUDIO_STREAM_STATE_PAUSING,
-        Paused = AAUDIO_STREAM_STATE_PAUSED,
-        Flushing = AAUDIO_STREAM_STATE_FLUSHING,
-        Flushed = AAUDIO_STREAM_STATE_FLUSHED,
-        Stopping = AAUDIO_STREAM_STATE_STOPPING,
-        Stopped = AAUDIO_STREAM_STATE_STOPPED,
-        Closing = AAUDIO_STREAM_STATE_CLOSING,
-        Closed = AAUDIO_STREAM_STATE_CLOSED,
-        Disconnected = AAUDIO_STREAM_STATE_DISCONNECTED,
+        Uninitialized = 0, // AAUDIO_STREAM_STATE_UNINITIALIZED,
+        Unknown = 1, // AAUDIO_STREAM_STATE_UNKNOWN,
+        Open = 2, // AAUDIO_STREAM_STATE_OPEN,
+        Starting = 3, // AAUDIO_STREAM_STATE_STARTING,
+        Started = 4, // AAUDIO_STREAM_STATE_STARTED,
+        Pausing = 5, // AAUDIO_STREAM_STATE_PAUSING,
+        Paused = 6, // AAUDIO_STREAM_STATE_PAUSED,
+        Flushing = 7, // AAUDIO_STREAM_STATE_FLUSHING,
+        Flushed = 8, // AAUDIO_STREAM_STATE_FLUSHED,
+        Stopping = 9, // AAUDIO_STREAM_STATE_STOPPING,
+        Stopped = 10, // AAUDIO_STREAM_STATE_STOPPED,
+        Closing = 11, // AAUDIO_STREAM_STATE_CLOSING,
+        Closed = 12, // AAUDIO_STREAM_STATE_CLOSED,
+        Disconnected = 13, // AAUDIO_STREAM_STATE_DISCONNECTED,
     };
 
     /**
@@ -89,12 +118,12 @@ namespace oboe {
         /**
          * Used for playback.
          */
-        Output = AAUDIO_DIRECTION_OUTPUT,
+        Output = 0, // AAUDIO_DIRECTION_OUTPUT,
 
         /**
          * Used for recording.
          */
-        Input = AAUDIO_DIRECTION_INPUT,
+        Input = 1, // AAUDIO_DIRECTION_INPUT,
     };
 
     /**
@@ -104,22 +133,22 @@ namespace oboe {
         /**
          * Invalid format.
          */
-        Invalid = AAUDIO_FORMAT_INVALID,
+        Invalid = -1, // AAUDIO_FORMAT_INVALID,
 
         /**
          * Unspecified format. Format will be decided by Oboe.
          */
-        Unspecified = AAUDIO_FORMAT_UNSPECIFIED,
+        Unspecified = 0, // AAUDIO_FORMAT_UNSPECIFIED,
 
         /**
          * Signed 16-bit integers.
          */
-        I16 = AAUDIO_FORMAT_PCM_I16,
+        I16 = 1, // AAUDIO_FORMAT_PCM_I16,
 
         /**
          * Single precision floating points.
          */
-        Float = AAUDIO_FORMAT_PCM_FLOAT,
+        Float = 2, // AAUDIO_FORMAT_PCM_FLOAT,
     };
 
     /**
@@ -127,10 +156,10 @@ namespace oboe {
      */
     enum class DataCallbackResult : aaudio_data_callback_result_t {
         // Indicates to the caller that the callbacks should continue.
-        Continue = AAUDIO_CALLBACK_RESULT_CONTINUE,
+        Continue = 0, // AAUDIO_CALLBACK_RESULT_CONTINUE,
 
         // Indicates to the caller that the callbacks should stop immediately.
-        Stop = AAUDIO_CALLBACK_RESULT_STOP,
+        Stop = 1, // AAUDIO_CALLBACK_RESULT_STOP,
     };
 
     /**
@@ -138,24 +167,24 @@ namespace oboe {
      * The `Result` can be converted into a human readable string using `convertToText`.
      */
     enum class Result : aaudio_result_t {
-        OK,
-        ErrorBase = AAUDIO_ERROR_BASE,
-        ErrorDisconnected = AAUDIO_ERROR_DISCONNECTED,
-        ErrorIllegalArgument = AAUDIO_ERROR_ILLEGAL_ARGUMENT,
-        ErrorInternal = AAUDIO_ERROR_INTERNAL,
-        ErrorInvalidState = AAUDIO_ERROR_INVALID_STATE,
-        ErrorInvalidHandle = AAUDIO_ERROR_INVALID_HANDLE,
-        ErrorUnimplemented = AAUDIO_ERROR_UNIMPLEMENTED,
-        ErrorUnavailable = AAUDIO_ERROR_UNAVAILABLE,
-        ErrorNoFreeHandles = AAUDIO_ERROR_NO_FREE_HANDLES,
-        ErrorNoMemory = AAUDIO_ERROR_NO_MEMORY,
-        ErrorNull = AAUDIO_ERROR_NULL,
-        ErrorTimeout = AAUDIO_ERROR_TIMEOUT,
-        ErrorWouldBlock = AAUDIO_ERROR_WOULD_BLOCK,
-        ErrorInvalidFormat = AAUDIO_ERROR_INVALID_FORMAT,
-        ErrorOutOfRange = AAUDIO_ERROR_OUT_OF_RANGE,
-        ErrorNoService = AAUDIO_ERROR_NO_SERVICE,
-        ErrorInvalidRate = AAUDIO_ERROR_INVALID_RATE,
+        OK = 0, // AAUDIO_OK
+        ErrorBase = -900, // AAUDIO_ERROR_BASE,
+        ErrorDisconnected = -899, // AAUDIO_ERROR_DISCONNECTED,
+        ErrorIllegalArgument = -898, // AAUDIO_ERROR_ILLEGAL_ARGUMENT,
+        ErrorInternal = -896, // AAUDIO_ERROR_INTERNAL,
+        ErrorInvalidState = -895, // AAUDIO_ERROR_INVALID_STATE,
+        ErrorInvalidHandle = -892, // AAUDIO_ERROR_INVALID_HANDLE,
+        ErrorUnimplemented = -890, // AAUDIO_ERROR_UNIMPLEMENTED,
+        ErrorUnavailable = -889, // AAUDIO_ERROR_UNAVAILABLE,
+        ErrorNoFreeHandles = -888, // AAUDIO_ERROR_NO_FREE_HANDLES,
+        ErrorNoMemory = -887, // AAUDIO_ERROR_NO_MEMORY,
+        ErrorNull = -886, // AAUDIO_ERROR_NULL,
+        ErrorTimeout = -885, // AAUDIO_ERROR_TIMEOUT,
+        ErrorWouldBlock = -884, // AAUDIO_ERROR_WOULD_BLOCK,
+        ErrorInvalidFormat = -883, // AAUDIO_ERROR_INVALID_FORMAT,
+        ErrorOutOfRange = -882, // AAUDIO_ERROR_OUT_OF_RANGE,
+        ErrorNoService = -881, // AAUDIO_ERROR_NO_SERVICE,
+        ErrorInvalidRate = -880, // AAUDIO_ERROR_INVALID_RATE,
         // Reserved for future AAudio result types
         Reserved1,
         Reserved2,
@@ -183,7 +212,7 @@ namespace oboe {
          * If you do not need the lowest possible latency then we recommend using Shared,
          * which is the default.
          */
-        Exclusive = AAUDIO_SHARING_MODE_EXCLUSIVE,
+        Exclusive = 0, // AAUDIO_SHARING_MODE_EXCLUSIVE,
 
         /**
          * Multiple applications can share the same device.
@@ -192,7 +221,7 @@ namespace oboe {
          *
          * This will have higher latency than the EXCLUSIVE mode.
          */
-        Shared = AAUDIO_SHARING_MODE_SHARED,
+        Shared = 1, // AAUDIO_SHARING_MODE_SHARED,
     };
 
     /**
@@ -203,17 +232,17 @@ namespace oboe {
         /**
          * No particular performance needs. Default.
          */
-        None = AAUDIO_PERFORMANCE_MODE_NONE,
+        None = 10, // AAUDIO_PERFORMANCE_MODE_NONE,
 
         /**
          * Extending battery life is most important.
          */
-        PowerSaving = AAUDIO_PERFORMANCE_MODE_POWER_SAVING,
+        PowerSaving = 11, // AAUDIO_PERFORMANCE_MODE_POWER_SAVING,
 
         /**
          * Reducing latency is most important.
          */
-        LowLatency = AAUDIO_PERFORMANCE_MODE_LOW_LATENCY
+        LowLatency = 12, // AAUDIO_PERFORMANCE_MODE_LOW_LATENCY
     };
 
     /**
@@ -236,13 +265,6 @@ namespace oboe {
         AAudio
     };
 
-// Hard code constants so they can be compiled with versions of the NDK before P.
-#if __ANDROID_API_LEVEL__ >= __ANDROID_API_P__
-#define CONSTANT_API_P(hard_constant, soft_constant) (soft_constant)
-#else
-#define CONSTANT_API_P(hard_constant, soft_constant) (hard_constant)
-#endif
-
     /**
      * The Usage attribute expresses *why* you are playing a sound, what is this sound used for.
      * This information is used by certain platforms or routing policies
@@ -256,65 +278,63 @@ namespace oboe {
         /**
          * Use this for streaming media, music performance, video, podcasts, etcetera.
          */
-        Media = CONSTANT_API_P(1, AAUDIO_USAGE_MEDIA),
+        Media =  1, // AAUDIO_USAGE_MEDIA
 
         /**
          * Use this for voice over IP, telephony, etcetera.
          */
-        VoiceCommunication = CONSTANT_API_P(2, AAUDIO_USAGE_VOICE_COMMUNICATION),
+        VoiceCommunication = 2, // AAUDIO_USAGE_VOICE_COMMUNICATION
 
         /**
          * Use this for sounds associated with telephony such as busy tones, DTMF, etcetera.
          */
-        VoiceCommunicationSignalling = CONSTANT_API_P(3,
-                                                      AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING),
+        VoiceCommunicationSignalling = 3, // AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING
 
         /**
          * Use this to demand the users attention.
          */
-        Alarm = CONSTANT_API_P(4, AAUDIO_USAGE_ALARM),
+        Alarm = 4, // AAUDIO_USAGE_ALARM
 
         /**
          * Use this for notifying the user when a message has arrived or some
          * other background event has occured.
          */
-        Notification = CONSTANT_API_P(5, AAUDIO_USAGE_NOTIFICATION),
+        Notification = 5, // AAUDIO_USAGE_NOTIFICATION
 
         /**
          * Use this when the phone rings.
          */
-        NotificationRingtone = CONSTANT_API_P(6, AAUDIO_USAGE_NOTIFICATION_RINGTONE),
+        NotificationRingtone = 6, // AAUDIO_USAGE_NOTIFICATION_RINGTONE
 
         /**
          * Use this to attract the users attention when, for example, the battery is low.
          */
-        NotificationEvent = CONSTANT_API_P(10, AAUDIO_USAGE_NOTIFICATION_EVENT),
+        NotificationEvent = 10, // AAUDIO_USAGE_NOTIFICATION_EVENT
 
         /**
          * Use this for screen readers, etcetera.
          */
-        AssistanceAccessibility = CONSTANT_API_P(11, AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY),
+        AssistanceAccessibility = 11, // AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY
 
         /**
          * Use this for driving or navigation directions.
          */
-        AssistanceNavigationGuidance = CONSTANT_API_P(12,
-                                                      AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE),
+        AssistanceNavigationGuidance = 12, // AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE
 
         /**
          * Use this for user interface sounds, beeps, etcetera.
          */
-        AssistanceSonification = CONSTANT_API_P(13, AAUDIO_USAGE_ASSISTANCE_SONIFICATION),
+        AssistanceSonification = 13, // AAUDIO_USAGE_ASSISTANCE_SONIFICATION
 
         /**
          * Use this for game audio and sound effects.
          */
-        Game = CONSTANT_API_P(14, AAUDIO_USAGE_GAME),
+        Game = 14, // AAUDIO_USAGE_GAME
 
         /**
          * Use this for audio responses to user queries, audio instructions or help utterances.
          */
-        Assistant = CONSTANT_API_P(16, AAUDIO_USAGE_ASSISTANT),
+        Assistant = 16, // AAUDIO_USAGE_ASSISTANT
     };
 
 
@@ -335,23 +355,23 @@ namespace oboe {
         /**
          * Use this for spoken voice, audio books, etcetera.
          */
-        Speech = CONSTANT_API_P(1, AAUDIO_CONTENT_TYPE_SPEECH),
+        Speech = 1, // AAUDIO_CONTENT_TYPE_SPEECH
 
         /**
          * Use this for pre-recorded or live music.
          */
-        Music = CONSTANT_API_P(2, AAUDIO_CONTENT_TYPE_MUSIC),
+        Music = 2, // AAUDIO_CONTENT_TYPE_MUSIC
 
         /**
          * Use this for a movie or video soundtrack.
          */
-        Movie = CONSTANT_API_P(3, AAUDIO_CONTENT_TYPE_MOVIE),
+        Movie = 3, // AAUDIO_CONTENT_TYPE_MOVIE
 
         /**
          * Use this for sound is designed to accompany a user action,
          * such as a click or beep sound made when the user presses a button.
          */
-        Sonification = CONSTANT_API_P(4, AAUDIO_CONTENT_TYPE_SONIFICATION),
+        Sonification = 4, // AAUDIO_CONTENT_TYPE_SONIFICATION
     };
 
     /**
@@ -367,29 +387,29 @@ namespace oboe {
         /**
          * Use this preset when other presets do not apply.
          */
-        Generic = CONSTANT_API_P(1, AAUDIO_INPUT_PRESET_GENERIC),
+        Generic = 1, // AAUDIO_INPUT_PRESET_GENERIC
 
         /**
          * Use this preset when recording video.
          */
-        Camcorder = CONSTANT_API_P(5, AAUDIO_INPUT_PRESET_CAMCORDER),
+        Camcorder = 5, // AAUDIO_INPUT_PRESET_CAMCORDER
 
         /**
          * Use this preset when doing speech recognition.
          */
-        VoiceRecognition = CONSTANT_API_P(6, AAUDIO_INPUT_PRESET_VOICE_RECOGNITION),
+        VoiceRecognition = 6, // AAUDIO_INPUT_PRESET_VOICE_RECOGNITION
 
         /**
          * Use this preset when doing telephony or voice messaging.
          */
-        VoiceCommunication = CONSTANT_API_P(7, AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION),
+        VoiceCommunication = 7, // AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION
 
         /**
          * Use this preset to obtain an input with no effects.
          * Note that this input will not have automatic gain control
          * so the recorded volume may be very low.
          */
-        Unprocessed = CONSTANT_API_P(9, AAUDIO_INPUT_PRESET_UNPROCESSED),
+        Unprocessed = 9, // AAUDIO_INPUT_PRESET_UNPROCESSED
     };
 
     /**
@@ -403,7 +423,7 @@ namespace oboe {
          * Effects cannot be used with this stream.
          * Default.
          */
-         None = CONSTANT_API_P(-1, AAUDIO_SESSION_ID_NONE),
+         None = -1, // AAUDIO_SESSION_ID_NONE
 
         /**
          * Allocate a session ID that can be used to attach and control
@@ -412,7 +432,7 @@ namespace oboe {
          *
          * Note that this matches the value of AudioManager.AUDIO_SESSION_ID_GENERATE.
          */
-         Allocate = CONSTANT_API_P(0, AAUDIO_SESSION_ID_ALLOCATE),
+         Allocate = 0, // AAUDIO_SESSION_ID_ALLOCATE
     };
 
     /**
@@ -441,8 +461,6 @@ namespace oboe {
        */
       Stereo = 2,
     };
-
-#undef CONSTANT_API_P
 
     /**
      * On API 16 to 26 OpenSL ES will be used. When using OpenSL ES the optimal values for sampleRate and
@@ -482,7 +500,6 @@ namespace oboe {
         int64_t position; // in frames
         int64_t timestamp; // in nanoseconds
     };
-
 
 } // namespace oboe
 

--- a/include/oboe/Definitions.h
+++ b/include/oboe/Definitions.h
@@ -17,47 +17,9 @@
 #ifndef OBOE_DEFINITIONS_H
 #define OBOE_DEFINITIONS_H
 
-// If the NDK is before P then do not include AAudio.h
-#ifndef OBOE_INCLUDE_AAUDIO
-#if __ANDROID_API_LEVEL__ >= __ANDROID_API_P__
-#define OBOE_INCLUDE_AAUDIO 1
-#else
-#define OBOE_INCLUDE_AAUDIO 0
-#endif
-#endif // OBOE_INCLUDE_AAUDIO
 
 #include <cstdint>
 #include <type_traits>
-
-#if (OBOE_INCLUDE_AAUDIO == 1)
-#include <aaudio/AAudio.h>
-
-// Ensure that all AAudio primitive data types are int32_t
-#define ASSERT_INT32(type) static_assert(std::is_same<int32_t, type>::value, \
-#type" must be int32_t")
-
-ASSERT_INT32(aaudio_stream_state_t);
-ASSERT_INT32(aaudio_direction_t);
-ASSERT_INT32(aaudio_format_t);
-ASSERT_INT32(aaudio_data_callback_result_t);
-ASSERT_INT32(aaudio_result_t);
-ASSERT_INT32(aaudio_sharing_mode_t);
-ASSERT_INT32(aaudio_performance_mode_t);
-#else
-// Define missing types from AAudio.h
-typedef int32_t aaudio_stream_state_t;
-typedef int32_t aaudio_direction_t;
-typedef int32_t aaudio_format_t;
-typedef int32_t aaudio_data_callback_result_t;
-typedef int32_t aaudio_result_t;
-typedef int32_t aaudio_sharing_mode_t;
-typedef int32_t aaudio_performance_mode_t;
-// These were defined in P
-typedef int32_t aaudio_usage_t;
-typedef int32_t aaudio_content_type_t;
-typedef int32_t aaudio_input_preset_t;
-typedef int32_t aaudio_session_id_t;
-#endif
 
 // Oboe needs to be able to build on old NDKs so we use hard coded constants.
 // The correctness of these constants is verified in "aaudio/AAudioLoader.cpp".
@@ -93,7 +55,7 @@ namespace oboe {
     /**
      * The state of the audio stream.
      */
-    enum class StreamState : aaudio_stream_state_t {
+    enum class StreamState : int32_t { // aaudio_stream_state_t
         Uninitialized = 0, // AAUDIO_STREAM_STATE_UNINITIALIZED,
         Unknown = 1, // AAUDIO_STREAM_STATE_UNKNOWN,
         Open = 2, // AAUDIO_STREAM_STATE_OPEN,
@@ -113,7 +75,7 @@ namespace oboe {
     /**
      * The direction of the stream.
      */
-    enum class Direction : aaudio_direction_t {
+    enum class Direction : int32_t { // aaudio_direction_t
 
         /**
          * Used for playback.
@@ -129,7 +91,7 @@ namespace oboe {
     /**
      * The format of audio samples.
      */
-    enum class AudioFormat : aaudio_format_t {
+    enum class AudioFormat : int32_t { // aaudio_format_t
         /**
          * Invalid format.
          */
@@ -154,7 +116,7 @@ namespace oboe {
     /**
      * The result of an audio callback.
      */
-    enum class DataCallbackResult : aaudio_data_callback_result_t {
+    enum class DataCallbackResult : int32_t { // aaudio_data_callback_result_t
         // Indicates to the caller that the callbacks should continue.
         Continue = 0, // AAUDIO_CALLBACK_RESULT_CONTINUE,
 
@@ -166,7 +128,7 @@ namespace oboe {
      * The result of an operation. All except the `OK` result indicates that an error occurred.
      * The `Result` can be converted into a human readable string using `convertToText`.
      */
-    enum class Result : aaudio_result_t {
+    enum class Result : int32_t { // aaudio_result_t
         OK = 0, // AAUDIO_OK
         ErrorBase = -900, // AAUDIO_ERROR_BASE,
         ErrorDisconnected = -899, // AAUDIO_ERROR_DISCONNECTED,
@@ -202,7 +164,7 @@ namespace oboe {
     /**
      * The sharing mode of the audio stream.
      */
-    enum class SharingMode : aaudio_sharing_mode_t {
+    enum class SharingMode : int32_t { // aaudio_sharing_mode_t
 
         /**
          * This will be the only stream using a particular source or sink.
@@ -227,7 +189,7 @@ namespace oboe {
     /**
      * The performance mode of the audio stream.
      */
-    enum class PerformanceMode : aaudio_performance_mode_t {
+    enum class PerformanceMode : int32_t { // aaudio_performance_mode_t
 
         /**
          * No particular performance needs. Default.
@@ -274,7 +236,7 @@ namespace oboe {
      *
      * This attribute only has an effect on Android API 28+.
      */
-    enum class Usage : aaudio_usage_t {
+    enum class Usage : int32_t { // aaudio_usage_t
         /**
          * Use this for streaming media, music performance, video, podcasts, etcetera.
          */
@@ -350,7 +312,7 @@ namespace oboe {
      *
      * This attribute only has an effect on Android API 28+.
      */
-    enum ContentType : aaudio_content_type_t {
+    enum ContentType : int32_t { // aaudio_content_type_t
 
         /**
          * Use this for spoken voice, audio books, etcetera.
@@ -383,7 +345,7 @@ namespace oboe {
      *
      * This attribute only has an effect on Android API 28+.
      */
-    enum InputPreset : aaudio_input_preset_t {
+    enum InputPreset : int32_t { // aaudio_input_preset_t
         /**
          * Use this preset when other presets do not apply.
          */

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -229,4 +229,62 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
     return reinterpret_cast<signature_I_PSKPLPL>(proc);
 }
 
+// These asserts help verify that the Oboe definitions match the equivalent AAudio definitions.
+// This code is in this .cpp file so it only gets tested once.
+#if (OBOE_INCLUDE_AAUDIO == 1)
+    #define SAMSG "Oboe constants must match AAudio constants."
+    static_assert((int32_t)StreamState::Uninitialized == AAUDIO_STREAM_STATE_UNINITIALIZED, SAMSG);
+    static_assert((int32_t)StreamState::Unknown == AAUDIO_STREAM_STATE_UNKNOWN, SAMSG);
+    static_assert((int32_t)StreamState::Open == AAUDIO_STREAM_STATE_OPEN, SAMSG);
+    static_assert((int32_t)StreamState::Starting == AAUDIO_STREAM_STATE_STARTING, SAMSG);
+    static_assert((int32_t)StreamState::Started == AAUDIO_STREAM_STATE_STARTED, SAMSG);
+    static_assert((int32_t)StreamState::Pausing == AAUDIO_STREAM_STATE_PAUSING, SAMSG);
+    static_assert((int32_t)StreamState::Paused == AAUDIO_STREAM_STATE_PAUSED, SAMSG);
+    static_assert((int32_t)StreamState::Flushing == AAUDIO_STREAM_STATE_FLUSHING, SAMSG);
+    static_assert((int32_t)StreamState::Flushed == AAUDIO_STREAM_STATE_FLUSHED, SAMSG);
+    static_assert((int32_t)StreamState::Stopping == AAUDIO_STREAM_STATE_STOPPING, SAMSG);
+    static_assert((int32_t)StreamState::Stopped == AAUDIO_STREAM_STATE_STOPPED, SAMSG);
+    static_assert((int32_t)StreamState::Closing == AAUDIO_STREAM_STATE_CLOSING, SAMSG);
+    static_assert((int32_t)StreamState::Closed == AAUDIO_STREAM_STATE_CLOSED, SAMSG);
+    static_assert((int32_t)StreamState::Disconnected == AAUDIO_STREAM_STATE_DISCONNECTED, SAMSG);
+
+    static_assert((int32_t)Direction::Output == AAUDIO_DIRECTION_OUTPUT, SAMSG);
+    static_assert((int32_t)Direction::Input == AAUDIO_DIRECTION_INPUT, SAMSG);
+
+    static_assert((int32_t)AudioFormat::Invalid == AAUDIO_FORMAT_INVALID, SAMSG);
+    static_assert((int32_t)AudioFormat::Unspecified == AAUDIO_FORMAT_UNSPECIFIED, SAMSG);
+    static_assert((int32_t)AudioFormat::I16 == AAUDIO_FORMAT_PCM_I16, SAMSG);
+    static_assert((int32_t)AudioFormat::Float == AAUDIO_FORMAT_PCM_FLOAT, SAMSG);
+
+    static_assert((int32_t)DataCallbackResult::Continue == AAUDIO_CALLBACK_RESULT_CONTINUE, SAMSG);
+    static_assert((int32_t)DataCallbackResult::Stop == AAUDIO_CALLBACK_RESULT_STOP, SAMSG);
+
+    static_assert((int32_t)Result::OK == AAUDIO_OK, SAMSG);
+    static_assert((int32_t)Result::ErrorBase == AAUDIO_ERROR_BASE, SAMSG);
+    static_assert((int32_t)Result::ErrorDisconnected == AAUDIO_ERROR_DISCONNECTED, SAMSG);
+    static_assert((int32_t)Result::ErrorIllegalArgument == AAUDIO_ERROR_ILLEGAL_ARGUMENT, SAMSG);
+    static_assert((int32_t)Result::ErrorInternal == AAUDIO_ERROR_INTERNAL, SAMSG);
+    static_assert((int32_t)Result::ErrorInvalidState == AAUDIO_ERROR_INVALID_STATE, SAMSG);
+    static_assert((int32_t)Result::ErrorInvalidHandle == AAUDIO_ERROR_INVALID_HANDLE, SAMSG);
+    static_assert((int32_t)Result::ErrorUnimplemented == AAUDIO_ERROR_UNIMPLEMENTED, SAMSG);
+    static_assert((int32_t)Result::ErrorUnavailable == AAUDIO_ERROR_UNAVAILABLE, SAMSG);
+    static_assert((int32_t)Result::ErrorNoFreeHandles == AAUDIO_ERROR_NO_FREE_HANDLES, SAMSG);
+    static_assert((int32_t)Result::ErrorNoMemory == AAUDIO_ERROR_NO_MEMORY, SAMSG);
+    static_assert((int32_t)Result::ErrorNull == AAUDIO_ERROR_NULL, SAMSG);
+    static_assert((int32_t)Result::ErrorTimeout == AAUDIO_ERROR_TIMEOUT, SAMSG);
+    static_assert((int32_t)Result::ErrorWouldBlock == AAUDIO_ERROR_WOULD_BLOCK, SAMSG);
+    static_assert((int32_t)Result::ErrorInvalidFormat == AAUDIO_ERROR_INVALID_FORMAT, SAMSG);
+    static_assert((int32_t)Result::ErrorOutOfRange == AAUDIO_ERROR_OUT_OF_RANGE, SAMSG);
+    static_assert((int32_t)Result::ErrorNoService == AAUDIO_ERROR_NO_SERVICE, SAMSG);
+    static_assert((int32_t)Result::ErrorInvalidRate == AAUDIO_ERROR_INVALID_RATE, SAMSG);
+
+    static_assert((int32_t)SharingMode::Exclusive == AAUDIO_SHARING_MODE_EXCLUSIVE, SAMSG);
+    static_assert((int32_t)SharingMode::Shared == AAUDIO_SHARING_MODE_SHARED, SAMSG);
+
+    static_assert((int32_t)PerformanceMode::None == AAUDIO_PERFORMANCE_MODE_NONE, SAMSG);
+    static_assert((int32_t)PerformanceMode::PowerSaving == AAUDIO_PERFORMANCE_MODE_POWER_SAVING, SAMSG);
+    static_assert((int32_t)PerformanceMode::LowLatency == AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, SAMSG);
+    // TODO test P constants
+#endif
+
 } // namespace oboe

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -229,10 +229,24 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
     return reinterpret_cast<signature_I_PSKPLPL>(proc);
 }
 
+// Ensure that all AAudio primitive data types are int32_t
+#define ASSERT_INT32(type) static_assert(std::is_same<int32_t, type>::value, \
+#type" must be int32_t")
+
+#define SAMSG "Oboe constants must match AAudio constants."
+
 // These asserts help verify that the Oboe definitions match the equivalent AAudio definitions.
 // This code is in this .cpp file so it only gets tested once.
-#if (OBOE_INCLUDE_AAUDIO == 1)
-    #define SAMSG "Oboe constants must match AAudio constants."
+#ifdef AAUDIO_AAUDIO_H
+
+    ASSERT_INT32(aaudio_stream_state_t);
+    ASSERT_INT32(aaudio_direction_t);
+    ASSERT_INT32(aaudio_format_t);
+    ASSERT_INT32(aaudio_data_callback_result_t);
+    ASSERT_INT32(aaudio_result_t);
+    ASSERT_INT32(aaudio_sharing_mode_t);
+    ASSERT_INT32(aaudio_performance_mode_t);
+
     static_assert((int32_t)StreamState::Uninitialized == AAUDIO_STREAM_STATE_UNINITIALIZED, SAMSG);
     static_assert((int32_t)StreamState::Unknown == AAUDIO_STREAM_STATE_UNKNOWN, SAMSG);
     static_assert((int32_t)StreamState::Open == AAUDIO_STREAM_STATE_OPEN, SAMSG);
@@ -284,7 +298,41 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
     static_assert((int32_t)PerformanceMode::None == AAUDIO_PERFORMANCE_MODE_NONE, SAMSG);
     static_assert((int32_t)PerformanceMode::PowerSaving == AAUDIO_PERFORMANCE_MODE_POWER_SAVING, SAMSG);
     static_assert((int32_t)PerformanceMode::LowLatency == AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, SAMSG);
-    // TODO test P constants
+#endif
+
+// These were added in P.
+#if __NDK_MAJOR__ >= 17
+
+    ASSERT_INT32(aaudio_usage_t);
+    ASSERT_INT32(aaudio_content_type_t);
+    ASSERT_INT32(aaudio_input_preset_t);
+
+    static_assert((int32_t)Usage::Media == AAUDIO_USAGE_MEDIA, SAMSG);
+    static_assert((int32_t)Usage::VoiceCommunication == AAUDIO_USAGE_VOICE_COMMUNICATION, SAMSG);
+    static_assert((int32_t)Usage::VoiceCommunicationSignalling == AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING, SAMSG);
+    static_assert((int32_t)Usage::Alarm == AAUDIO_USAGE_ALARM, SAMSG);
+    static_assert((int32_t)Usage::Notification == AAUDIO_USAGE_NOTIFICATION, SAMSG);
+    static_assert((int32_t)Usage::NotificationRingtone == AAUDIO_USAGE_NOTIFICATION_RINGTONE, SAMSG);
+    static_assert((int32_t)Usage::NotificationEvent == AAUDIO_USAGE_NOTIFICATION_EVENT, SAMSG);
+    static_assert((int32_t)Usage::AssistanceAccessibility == AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY, SAMSG);
+    static_assert((int32_t)Usage::AssistanceNavigationGuidance == AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE, SAMSG);
+    static_assert((int32_t)Usage::AssistanceSonification == AAUDIO_USAGE_ASSISTANCE_SONIFICATION, SAMSG);
+    static_assert((int32_t)Usage::Game == AAUDIO_USAGE_GAME, SAMSG);
+    static_assert((int32_t)Usage::Assistant == AAUDIO_USAGE_ASSISTANT, SAMSG);
+
+    static_assert((int32_t)ContentType::Speech == AAUDIO_CONTENT_TYPE_SPEECH, SAMSG);
+    static_assert((int32_t)ContentType::Music == AAUDIO_CONTENT_TYPE_MUSIC, SAMSG);
+    static_assert((int32_t)ContentType::Movie == AAUDIO_CONTENT_TYPE_MOVIE, SAMSG);
+    static_assert((int32_t)ContentType::Sonification == AAUDIO_CONTENT_TYPE_SONIFICATION, SAMSG);
+
+    static_assert((int32_t)InputPreset::Generic == AAUDIO_INPUT_PRESET_GENERIC, SAMSG);
+    static_assert((int32_t)InputPreset::Camcorder == AAUDIO_INPUT_PRESET_CAMCORDER, SAMSG);
+    static_assert((int32_t)InputPreset::VoiceRecognition == AAUDIO_INPUT_PRESET_VOICE_RECOGNITION, SAMSG);
+    static_assert((int32_t)InputPreset::VoiceCommunication == AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION, SAMSG);
+    static_assert((int32_t)InputPreset::Unprocessed == AAUDIO_INPUT_PRESET_UNPROCESSED, SAMSG);
+
+    static_assert((int32_t)SessionId::None == AAUDIO_SESSION_ID_NONE, SAMSG);
+    static_assert((int32_t)SessionId::Allocate == AAUDIO_SESSION_ID_ALLOCATE, SAMSG);
 #endif
 
 } // namespace oboe

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -233,7 +233,7 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
 #define ASSERT_INT32(type) static_assert(std::is_same<int32_t, type>::value, \
 #type" must be int32_t")
 
-#define SAMSG "Oboe constants must match AAudio constants."
+#define ERRMSG "Oboe constants must match AAudio constants."
 
 // These asserts help verify that the Oboe definitions match the equivalent AAudio definitions.
 // This code is in this .cpp file so it only gets tested once.
@@ -247,92 +247,98 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
     ASSERT_INT32(aaudio_sharing_mode_t);
     ASSERT_INT32(aaudio_performance_mode_t);
 
-    static_assert((int32_t)StreamState::Uninitialized == AAUDIO_STREAM_STATE_UNINITIALIZED, SAMSG);
-    static_assert((int32_t)StreamState::Unknown == AAUDIO_STREAM_STATE_UNKNOWN, SAMSG);
-    static_assert((int32_t)StreamState::Open == AAUDIO_STREAM_STATE_OPEN, SAMSG);
-    static_assert((int32_t)StreamState::Starting == AAUDIO_STREAM_STATE_STARTING, SAMSG);
-    static_assert((int32_t)StreamState::Started == AAUDIO_STREAM_STATE_STARTED, SAMSG);
-    static_assert((int32_t)StreamState::Pausing == AAUDIO_STREAM_STATE_PAUSING, SAMSG);
-    static_assert((int32_t)StreamState::Paused == AAUDIO_STREAM_STATE_PAUSED, SAMSG);
-    static_assert((int32_t)StreamState::Flushing == AAUDIO_STREAM_STATE_FLUSHING, SAMSG);
-    static_assert((int32_t)StreamState::Flushed == AAUDIO_STREAM_STATE_FLUSHED, SAMSG);
-    static_assert((int32_t)StreamState::Stopping == AAUDIO_STREAM_STATE_STOPPING, SAMSG);
-    static_assert((int32_t)StreamState::Stopped == AAUDIO_STREAM_STATE_STOPPED, SAMSG);
-    static_assert((int32_t)StreamState::Closing == AAUDIO_STREAM_STATE_CLOSING, SAMSG);
-    static_assert((int32_t)StreamState::Closed == AAUDIO_STREAM_STATE_CLOSED, SAMSG);
-    static_assert((int32_t)StreamState::Disconnected == AAUDIO_STREAM_STATE_DISCONNECTED, SAMSG);
+    static_assert((int32_t)StreamState::Uninitialized == AAUDIO_STREAM_STATE_UNINITIALIZED, ERRMSG);
+    static_assert((int32_t)StreamState::Unknown == AAUDIO_STREAM_STATE_UNKNOWN, ERRMSG);
+    static_assert((int32_t)StreamState::Open == AAUDIO_STREAM_STATE_OPEN, ERRMSG);
+    static_assert((int32_t)StreamState::Starting == AAUDIO_STREAM_STATE_STARTING, ERRMSG);
+    static_assert((int32_t)StreamState::Started == AAUDIO_STREAM_STATE_STARTED, ERRMSG);
+    static_assert((int32_t)StreamState::Pausing == AAUDIO_STREAM_STATE_PAUSING, ERRMSG);
+    static_assert((int32_t)StreamState::Paused == AAUDIO_STREAM_STATE_PAUSED, ERRMSG);
+    static_assert((int32_t)StreamState::Flushing == AAUDIO_STREAM_STATE_FLUSHING, ERRMSG);
+    static_assert((int32_t)StreamState::Flushed == AAUDIO_STREAM_STATE_FLUSHED, ERRMSG);
+    static_assert((int32_t)StreamState::Stopping == AAUDIO_STREAM_STATE_STOPPING, ERRMSG);
+    static_assert((int32_t)StreamState::Stopped == AAUDIO_STREAM_STATE_STOPPED, ERRMSG);
+    static_assert((int32_t)StreamState::Closing == AAUDIO_STREAM_STATE_CLOSING, ERRMSG);
+    static_assert((int32_t)StreamState::Closed == AAUDIO_STREAM_STATE_CLOSED, ERRMSG);
+    static_assert((int32_t)StreamState::Disconnected == AAUDIO_STREAM_STATE_DISCONNECTED, ERRMSG);
 
-    static_assert((int32_t)Direction::Output == AAUDIO_DIRECTION_OUTPUT, SAMSG);
-    static_assert((int32_t)Direction::Input == AAUDIO_DIRECTION_INPUT, SAMSG);
+    static_assert((int32_t)Direction::Output == AAUDIO_DIRECTION_OUTPUT, ERRMSG);
+    static_assert((int32_t)Direction::Input == AAUDIO_DIRECTION_INPUT, ERRMSG);
 
-    static_assert((int32_t)AudioFormat::Invalid == AAUDIO_FORMAT_INVALID, SAMSG);
-    static_assert((int32_t)AudioFormat::Unspecified == AAUDIO_FORMAT_UNSPECIFIED, SAMSG);
-    static_assert((int32_t)AudioFormat::I16 == AAUDIO_FORMAT_PCM_I16, SAMSG);
-    static_assert((int32_t)AudioFormat::Float == AAUDIO_FORMAT_PCM_FLOAT, SAMSG);
+    static_assert((int32_t)AudioFormat::Invalid == AAUDIO_FORMAT_INVALID, ERRMSG);
+    static_assert((int32_t)AudioFormat::Unspecified == AAUDIO_FORMAT_UNSPECIFIED, ERRMSG);
+    static_assert((int32_t)AudioFormat::I16 == AAUDIO_FORMAT_PCM_I16, ERRMSG);
+    static_assert((int32_t)AudioFormat::Float == AAUDIO_FORMAT_PCM_FLOAT, ERRMSG);
 
-    static_assert((int32_t)DataCallbackResult::Continue == AAUDIO_CALLBACK_RESULT_CONTINUE, SAMSG);
-    static_assert((int32_t)DataCallbackResult::Stop == AAUDIO_CALLBACK_RESULT_STOP, SAMSG);
+    static_assert((int32_t)DataCallbackResult::Continue == AAUDIO_CALLBACK_RESULT_CONTINUE, ERRMSG);
+    static_assert((int32_t)DataCallbackResult::Stop == AAUDIO_CALLBACK_RESULT_STOP, ERRMSG);
 
-    static_assert((int32_t)Result::OK == AAUDIO_OK, SAMSG);
-    static_assert((int32_t)Result::ErrorBase == AAUDIO_ERROR_BASE, SAMSG);
-    static_assert((int32_t)Result::ErrorDisconnected == AAUDIO_ERROR_DISCONNECTED, SAMSG);
-    static_assert((int32_t)Result::ErrorIllegalArgument == AAUDIO_ERROR_ILLEGAL_ARGUMENT, SAMSG);
-    static_assert((int32_t)Result::ErrorInternal == AAUDIO_ERROR_INTERNAL, SAMSG);
-    static_assert((int32_t)Result::ErrorInvalidState == AAUDIO_ERROR_INVALID_STATE, SAMSG);
-    static_assert((int32_t)Result::ErrorInvalidHandle == AAUDIO_ERROR_INVALID_HANDLE, SAMSG);
-    static_assert((int32_t)Result::ErrorUnimplemented == AAUDIO_ERROR_UNIMPLEMENTED, SAMSG);
-    static_assert((int32_t)Result::ErrorUnavailable == AAUDIO_ERROR_UNAVAILABLE, SAMSG);
-    static_assert((int32_t)Result::ErrorNoFreeHandles == AAUDIO_ERROR_NO_FREE_HANDLES, SAMSG);
-    static_assert((int32_t)Result::ErrorNoMemory == AAUDIO_ERROR_NO_MEMORY, SAMSG);
-    static_assert((int32_t)Result::ErrorNull == AAUDIO_ERROR_NULL, SAMSG);
-    static_assert((int32_t)Result::ErrorTimeout == AAUDIO_ERROR_TIMEOUT, SAMSG);
-    static_assert((int32_t)Result::ErrorWouldBlock == AAUDIO_ERROR_WOULD_BLOCK, SAMSG);
-    static_assert((int32_t)Result::ErrorInvalidFormat == AAUDIO_ERROR_INVALID_FORMAT, SAMSG);
-    static_assert((int32_t)Result::ErrorOutOfRange == AAUDIO_ERROR_OUT_OF_RANGE, SAMSG);
-    static_assert((int32_t)Result::ErrorNoService == AAUDIO_ERROR_NO_SERVICE, SAMSG);
-    static_assert((int32_t)Result::ErrorInvalidRate == AAUDIO_ERROR_INVALID_RATE, SAMSG);
+    static_assert((int32_t)Result::OK == AAUDIO_OK, ERRMSG);
+    static_assert((int32_t)Result::ErrorBase == AAUDIO_ERROR_BASE, ERRMSG);
+    static_assert((int32_t)Result::ErrorDisconnected == AAUDIO_ERROR_DISCONNECTED, ERRMSG);
+    static_assert((int32_t)Result::ErrorIllegalArgument == AAUDIO_ERROR_ILLEGAL_ARGUMENT, ERRMSG);
+    static_assert((int32_t)Result::ErrorInternal == AAUDIO_ERROR_INTERNAL, ERRMSG);
+    static_assert((int32_t)Result::ErrorInvalidState == AAUDIO_ERROR_INVALID_STATE, ERRMSG);
+    static_assert((int32_t)Result::ErrorInvalidHandle == AAUDIO_ERROR_INVALID_HANDLE, ERRMSG);
+    static_assert((int32_t)Result::ErrorUnimplemented == AAUDIO_ERROR_UNIMPLEMENTED, ERRMSG);
+    static_assert((int32_t)Result::ErrorUnavailable == AAUDIO_ERROR_UNAVAILABLE, ERRMSG);
+    static_assert((int32_t)Result::ErrorNoFreeHandles == AAUDIO_ERROR_NO_FREE_HANDLES, ERRMSG);
+    static_assert((int32_t)Result::ErrorNoMemory == AAUDIO_ERROR_NO_MEMORY, ERRMSG);
+    static_assert((int32_t)Result::ErrorNull == AAUDIO_ERROR_NULL, ERRMSG);
+    static_assert((int32_t)Result::ErrorTimeout == AAUDIO_ERROR_TIMEOUT, ERRMSG);
+    static_assert((int32_t)Result::ErrorWouldBlock == AAUDIO_ERROR_WOULD_BLOCK, ERRMSG);
+    static_assert((int32_t)Result::ErrorInvalidFormat == AAUDIO_ERROR_INVALID_FORMAT, ERRMSG);
+    static_assert((int32_t)Result::ErrorOutOfRange == AAUDIO_ERROR_OUT_OF_RANGE, ERRMSG);
+    static_assert((int32_t)Result::ErrorNoService == AAUDIO_ERROR_NO_SERVICE, ERRMSG);
+    static_assert((int32_t)Result::ErrorInvalidRate == AAUDIO_ERROR_INVALID_RATE, ERRMSG);
 
-    static_assert((int32_t)SharingMode::Exclusive == AAUDIO_SHARING_MODE_EXCLUSIVE, SAMSG);
-    static_assert((int32_t)SharingMode::Shared == AAUDIO_SHARING_MODE_SHARED, SAMSG);
+    static_assert((int32_t)SharingMode::Exclusive == AAUDIO_SHARING_MODE_EXCLUSIVE, ERRMSG);
+    static_assert((int32_t)SharingMode::Shared == AAUDIO_SHARING_MODE_SHARED, ERRMSG);
 
-    static_assert((int32_t)PerformanceMode::None == AAUDIO_PERFORMANCE_MODE_NONE, SAMSG);
-    static_assert((int32_t)PerformanceMode::PowerSaving == AAUDIO_PERFORMANCE_MODE_POWER_SAVING, SAMSG);
-    static_assert((int32_t)PerformanceMode::LowLatency == AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, SAMSG);
+    static_assert((int32_t)PerformanceMode::None == AAUDIO_PERFORMANCE_MODE_NONE, ERRMSG);
+    static_assert((int32_t)PerformanceMode::PowerSaving
+            == AAUDIO_PERFORMANCE_MODE_POWER_SAVING, ERRMSG);
+    static_assert((int32_t)PerformanceMode::LowLatency
+            == AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, ERRMSG);
 #endif
 
-// These were added in P.
+// The aaudio_ usage, content and input_preset types were added in NDK 17,
+// which is the first version to support Android Pie (API 28).
 #if __NDK_MAJOR__ >= 17
 
     ASSERT_INT32(aaudio_usage_t);
     ASSERT_INT32(aaudio_content_type_t);
     ASSERT_INT32(aaudio_input_preset_t);
 
-    static_assert((int32_t)Usage::Media == AAUDIO_USAGE_MEDIA, SAMSG);
-    static_assert((int32_t)Usage::VoiceCommunication == AAUDIO_USAGE_VOICE_COMMUNICATION, SAMSG);
-    static_assert((int32_t)Usage::VoiceCommunicationSignalling == AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING, SAMSG);
-    static_assert((int32_t)Usage::Alarm == AAUDIO_USAGE_ALARM, SAMSG);
-    static_assert((int32_t)Usage::Notification == AAUDIO_USAGE_NOTIFICATION, SAMSG);
-    static_assert((int32_t)Usage::NotificationRingtone == AAUDIO_USAGE_NOTIFICATION_RINGTONE, SAMSG);
-    static_assert((int32_t)Usage::NotificationEvent == AAUDIO_USAGE_NOTIFICATION_EVENT, SAMSG);
-    static_assert((int32_t)Usage::AssistanceAccessibility == AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY, SAMSG);
-    static_assert((int32_t)Usage::AssistanceNavigationGuidance == AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE, SAMSG);
-    static_assert((int32_t)Usage::AssistanceSonification == AAUDIO_USAGE_ASSISTANCE_SONIFICATION, SAMSG);
-    static_assert((int32_t)Usage::Game == AAUDIO_USAGE_GAME, SAMSG);
-    static_assert((int32_t)Usage::Assistant == AAUDIO_USAGE_ASSISTANT, SAMSG);
+    static_assert((int32_t)Usage::Media == AAUDIO_USAGE_MEDIA, ERRMSG);
+    static_assert((int32_t)Usage::VoiceCommunication == AAUDIO_USAGE_VOICE_COMMUNICATION, ERRMSG);
+    static_assert((int32_t)Usage::VoiceCommunicationSignalling
+            == AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING, ERRMSG);
+    static_assert((int32_t)Usage::Alarm == AAUDIO_USAGE_ALARM, ERRMSG);
+    static_assert((int32_t)Usage::Notification == AAUDIO_USAGE_NOTIFICATION, ERRMSG);
+    static_assert((int32_t)Usage::NotificationRingtone == AAUDIO_USAGE_NOTIFICATION_RINGTONE, ERRMSG);
+    static_assert((int32_t)Usage::NotificationEvent == AAUDIO_USAGE_NOTIFICATION_EVENT, ERRMSG);
+    static_assert((int32_t)Usage::AssistanceAccessibility == AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY, ERRMSG);
+    static_assert((int32_t)Usage::AssistanceNavigationGuidance
+            == AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE, ERRMSG);
+    static_assert((int32_t)Usage::AssistanceSonification == AAUDIO_USAGE_ASSISTANCE_SONIFICATION, ERRMSG);
+    static_assert((int32_t)Usage::Game == AAUDIO_USAGE_GAME, ERRMSG);
+    static_assert((int32_t)Usage::Assistant == AAUDIO_USAGE_ASSISTANT, ERRMSG);
 
-    static_assert((int32_t)ContentType::Speech == AAUDIO_CONTENT_TYPE_SPEECH, SAMSG);
-    static_assert((int32_t)ContentType::Music == AAUDIO_CONTENT_TYPE_MUSIC, SAMSG);
-    static_assert((int32_t)ContentType::Movie == AAUDIO_CONTENT_TYPE_MOVIE, SAMSG);
-    static_assert((int32_t)ContentType::Sonification == AAUDIO_CONTENT_TYPE_SONIFICATION, SAMSG);
+    static_assert((int32_t)ContentType::Speech == AAUDIO_CONTENT_TYPE_SPEECH, ERRMSG);
+    static_assert((int32_t)ContentType::Music == AAUDIO_CONTENT_TYPE_MUSIC, ERRMSG);
+    static_assert((int32_t)ContentType::Movie == AAUDIO_CONTENT_TYPE_MOVIE, ERRMSG);
+    static_assert((int32_t)ContentType::Sonification == AAUDIO_CONTENT_TYPE_SONIFICATION, ERRMSG);
 
-    static_assert((int32_t)InputPreset::Generic == AAUDIO_INPUT_PRESET_GENERIC, SAMSG);
-    static_assert((int32_t)InputPreset::Camcorder == AAUDIO_INPUT_PRESET_CAMCORDER, SAMSG);
-    static_assert((int32_t)InputPreset::VoiceRecognition == AAUDIO_INPUT_PRESET_VOICE_RECOGNITION, SAMSG);
-    static_assert((int32_t)InputPreset::VoiceCommunication == AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION, SAMSG);
-    static_assert((int32_t)InputPreset::Unprocessed == AAUDIO_INPUT_PRESET_UNPROCESSED, SAMSG);
+    static_assert((int32_t)InputPreset::Generic == AAUDIO_INPUT_PRESET_GENERIC, ERRMSG);
+    static_assert((int32_t)InputPreset::Camcorder == AAUDIO_INPUT_PRESET_CAMCORDER, ERRMSG);
+    static_assert((int32_t)InputPreset::VoiceRecognition == AAUDIO_INPUT_PRESET_VOICE_RECOGNITION, ERRMSG);
+    static_assert((int32_t)InputPreset::VoiceCommunication
+            == AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION, ERRMSG);
+    static_assert((int32_t)InputPreset::Unprocessed == AAUDIO_INPUT_PRESET_UNPROCESSED, ERRMSG);
 
-    static_assert((int32_t)SessionId::None == AAUDIO_SESSION_ID_NONE, SAMSG);
-    static_assert((int32_t)SessionId::Allocate == AAUDIO_SESSION_ID_ALLOCATE, SAMSG);
+    static_assert((int32_t)SessionId::None == AAUDIO_SESSION_ID_NONE, ERRMSG);
+    static_assert((int32_t)SessionId::Allocate == AAUDIO_SESSION_ID_ALLOCATE, ERRMSG);
 #endif
 
 } // namespace oboe

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -20,9 +20,24 @@
 #include <unistd.h>
 #include "oboe/Definitions.h"
 
-#include "aaudio/AAudio.h"
+#if (OBOE_INCLUDE_AAUDIO == 0)
+typedef struct AAudioStreamStruct         AAudioStream;
+typedef struct AAudioStreamBuilderStruct  AAudioStreamBuilder;
+
+typedef aaudio_data_callback_result_t (*AAudioStream_dataCallback)(
+        AAudioStream *stream,
+        void *userData,
+        void *audioData,
+        int32_t numFrames);
+
+typedef void (*AAudioStream_errorCallback)(
+        AAudioStream *stream,
+        void *userData,
+        aaudio_result_t error);
+#endif
 
 namespace oboe {
+
 
 /**
  * The AAudio API was not available in early versions of Android.

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -20,7 +20,19 @@
 #include <unistd.h>
 #include "oboe/Definitions.h"
 
-#if (OBOE_INCLUDE_AAUDIO == 0)
+// If the NDK is before O then define this in your build
+// so that AAudio.h will not be included.
+#ifdef OBOE_NO_INCLUDE_AAUDIO
+
+// Define missing types from AAudio.h
+typedef int32_t aaudio_stream_state_t;
+typedef int32_t aaudio_direction_t;
+typedef int32_t aaudio_format_t;
+typedef int32_t aaudio_data_callback_result_t;
+typedef int32_t aaudio_result_t;
+typedef int32_t aaudio_sharing_mode_t;
+typedef int32_t aaudio_performance_mode_t;
+
 typedef struct AAudioStreamStruct         AAudioStream;
 typedef struct AAudioStreamBuilderStruct  AAudioStreamBuilder;
 
@@ -34,6 +46,19 @@ typedef void (*AAudioStream_errorCallback)(
         AAudioStream *stream,
         void *userData,
         aaudio_result_t error);
+
+// These were defined in P
+typedef int32_t aaudio_usage_t;
+typedef int32_t aaudio_content_type_t;
+typedef int32_t aaudio_input_preset_t;
+typedef int32_t aaudio_session_id_t;
+#else
+#include <aaudio/AAudio.h>
+#include <android/ndk-version.h>
+#endif
+
+#ifndef __NDK_MAJOR__
+#define __NDK_MAJOR__ 0
 #endif
 
 namespace oboe {

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -483,7 +483,7 @@ ResultWithValue<FrameTimestamp> AudioStreamAAudio::getTimestamp(clockid_t clockI
         aaudio_result_t result = mLibLoader->stream_getTimestamp(stream, clockId,
                                                                  &frame.position,
                                                                  &frame.timestamp);
-        if (result == (aaudio_result_t)Result::OK){
+        if (result == static_cast<aaudio_result_t>(Result::OK)){
             return ResultWithValue<FrameTimestamp>(frame);
         } else {
             return ResultWithValue<FrameTimestamp>(static_cast<Result>(result));

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -483,7 +483,7 @@ ResultWithValue<FrameTimestamp> AudioStreamAAudio::getTimestamp(clockid_t clockI
         aaudio_result_t result = mLibLoader->stream_getTimestamp(stream, clockId,
                                                                  &frame.position,
                                                                  &frame.timestamp);
-        if (result == AAUDIO_OK){
+        if (result == (aaudio_result_t)Result::OK){
             return ResultWithValue<FrameTimestamp>(frame);
         } else {
             return ResultWithValue<FrameTimestamp>(static_cast<Result>(result));

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -21,15 +21,12 @@
 #include <mutex>
 #include <thread>
 
-#include "aaudio/AAudio.h"
-
 #include "oboe/AudioStreamBuilder.h"
 #include "oboe/AudioStream.h"
 #include "oboe/Definitions.h"
+#include "AAudioLoader.h"
 
 namespace oboe {
-
-class AAudioLoader;
 
 /**
  * Implementation of OboeStream that uses AAudio.


### PR DESCRIPTION
This allows Oboe to be compiled with old NDK.