### PR TITLE
OboeTester: increase frequency of sine waves

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -281,7 +281,7 @@ void ActivityTestOutput::configureForStart() {
 
     oboe::AudioStream *outputStream = getOutputStream();
     {
-        double frequency = 440.0;
+        double frequency = 660.0;
         for (int i = 0; i < mChannelCount; i++) {
             sineOscillators[i].setSampleRate(outputStream->getSampleRate());
             sineOscillators[i].frequency.setValue(frequency);


### PR DESCRIPTION
The low channel was hard to hear.
Bumped from 440 to 660 for base frequency.