### PR TITLE
OboeTester: fix double open in RT LATENCY test

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.google.sample.oboe.manualtest"
         minSdkVersion 26
         targetSdkVersion 26
-        versionCode 7
-        versionName "1.3.03"
+        versionCode 8
+        versionName "1.3.04"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="7"
-    android:versionName="1.3.03">
+    android:versionCode="8"
+    android:versionName="1.3.04">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
@@ -117,7 +117,6 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         mCancelButton = (Button) findViewById(R.id.button_cancel);
         mAnalyzerView = (TextView) findViewById(R.id.text_analyzer_result);
         updateEnabledWidgets();
-        mAudioOutTester = addAudioOutputTester();
 
         hideSettingsViews();
     }


### PR DESCRIPTION
Was causing a leaked stream.
Also bumped to 1.3.04