### PR TITLE
OboeTester: fix "callback returns STOP" box

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -31,7 +31,6 @@ static oboe::AudioApi convertNativeApiToAudioApi(int nativeApi) {
 }
 
 bool ActivityContext::useCallback = true;
-bool ActivityContext::callbackReturnStop = false;
 int  ActivityContext::callbackSize = 0;
 
 oboe::AudioStream * ActivityContext::getOutputStream() {

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -165,7 +165,6 @@ public:
     virtual void setChannelEnabled(int channelIndex, bool enabled) {}
 
     static bool   useCallback;
-    static bool   callbackReturnStop;
     static int    callbackSize;
 
 

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
@@ -17,6 +17,8 @@
 #include "common/OboeDebug.h"
 #include "OboeStreamCallbackProxy.h"
 
+bool OboeStreamCallbackProxy::mCallbackReturnStop = false;
+
 OboeStreamCallbackProxy::~OboeStreamCallbackProxy() {
 }
 

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
@@ -32,7 +32,7 @@ public:
         setCallbackCount(0);
     }
 
-    void setCallbackReturnStop(bool b) {
+    static void setCallbackReturnStop(bool b) {
         mCallbackReturnStop = b;
     }
 
@@ -57,9 +57,9 @@ public:
     void onErrorAfterClose(oboe::AudioStream *audioStream, oboe::Result error) override;
 
 private:
-    oboe::AudioStreamCallback *mCallback = nullptr;
 
-    bool                       mCallbackReturnStop = false;
+    oboe::AudioStreamCallback *mCallback = nullptr;
+    static bool                mCallbackReturnStop;
     int64_t                    mCallbackCount = 0;
 };
 

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -368,7 +368,7 @@ Java_com_google_sample_oboe_manualtest_OboeAudioStream_setUseCallback(JNIEnv *en
 JNIEXPORT void JNICALL
 Java_com_google_sample_oboe_manualtest_OboeAudioStream_setCallbackReturnStop(JNIEnv *env, jclass type,
                                                                       jboolean b) {
-    ActivityContext::callbackReturnStop = b;
+    OboeStreamCallbackProxy::setCallbackReturnStop(b);
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
It was setting the wrong variable.
This broke a few weeks ago.

Fixes #428