### PR TITLE
Fix build errors

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/LatencyAnalyzer.h
@@ -647,8 +647,10 @@ public:
                                     getSampleRate(),
                                     &mLatencyReport);
 
+#if OBOE_ENABLE_LOGGING
             double latencyMillis = kMillisPerSecond * (double) mLatencyReport.latencyInFrames
                                    / getSampleRate();
+#endif
             LOGD(LOOPBACK_RESULT_TAG "latency.frames         = %8.2f",
                    mLatencyReport.latencyInFrames);
             LOGD(LOOPBACK_RESULT_TAG "latency.msec           = %8.2f",

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -101,7 +101,9 @@ public:
     virtual void close(int32_t streamIndex);
 
     void printScheduler() {
+#if OBOE_ENABLE_LOGGING
         int scheduler = audioStreamGateway.getScheduler();
+#endif
         LOGI("scheduler = 0x%08x, SCHED_FIFO = 0x%08X\n", scheduler, SCHED_FIFO);
     }
 


### PR DESCRIPTION
oboe/apps/OboeTester/app/src/main/cpp/LatencyAnalyzer.h:650:20: error: unused variable 'latencyMillis' [-Werror,-Wunused-variable]
            double latencyMillis = kMillisPerSecond * (double) mLatencyReport.latencyInFrames
                   ^
oboe/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h:104:13: error: unused variable 'scheduler' [-Werror,-Wunused-variable]
        int scheduler = audioStreamGateway.getScheduler();
            ^