### PR TITLE
Add <atomic> and <mutex> to AudioStream includes

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -19,6 +19,8 @@
 
 #include <cstdint>
 #include <ctime>
+#include <atomic>
+#include <mutex>
 #include "oboe/Definitions.h"
 #include "oboe/ResultWithValue.h"
 #include "oboe/AudioStreamBuilder.h"

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -17,9 +17,9 @@
 #ifndef OBOE_STREAM_H_
 #define OBOE_STREAM_H_
 
+#include <atomic>
 #include <cstdint>
 #include <ctime>
-#include <atomic>
 #include <mutex>
 #include "oboe/Definitions.h"
 #include "oboe/ResultWithValue.h"


### PR DESCRIPTION
`AudioStream.h` uses both `std::atomic` and `std::mutex`. It should have these headers included. Fixes #392 