### PR TITLE
tests: sleep between close and open

### DIFF
--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -21,7 +21,7 @@ using namespace oboe;
 
 // Sleep between close and open to avoid a race condition inside Android Audio.
 // On a Pixel 2 emulator on a fast Linux host, the minimum value is around 16 msec.
-#define OBOE_CLOSE_OPEN_SLEEP_MSEC  100
+constexpr int kOboeOpenCloseSleepMSec = 100;
 
 class StreamStates : public ::testing::Test {
 
@@ -119,7 +119,7 @@ protected:
         // The underlying API should stop the stream.
         closeStream();
 
-        usleep(OBOE_CLOSE_OPEN_SLEEP_MSEC * 1000); // avoid race condition in emulator
+        usleep(kOboeOpenCloseSleepMSec * 1000); // avoid race condition in emulator
 
         openInputStream();
         r = mStream->requestStart();

--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -19,6 +19,10 @@
 
 using namespace oboe;
 
+// Sleep between close and open to avoid a race condition inside Android Audio.
+// On a Pixel 2 emulator on a fast Linux host, the minimum value is around 16 msec.
+#define OBOE_CLOSE_OPEN_SLEEP_MSEC  100
+
 class StreamStates : public ::testing::Test {
 
 protected:
@@ -114,6 +118,8 @@ protected:
         // It should be safe to close without stopping.
         // The underlying API should stop the stream.
         closeStream();
+
+        usleep(OBOE_CLOSE_OPEN_SLEEP_MSEC * 1000); // avoid race condition in emulator
 
         openInputStream();
         r = mStream->requestStart();


### PR DESCRIPTION
This is to prevent a race condition on the emulator from
causing some tests to fail.

Fixes #425