### PR TITLE
OboeTester: add screen wake locks

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.google.sample.oboe.manualtest"
         minSdkVersion 26
         targetSdkVersion 26
-        versionCode 11
-        versionName "1.4.02"
+        versionCode 12
+        versionName "1.4.03"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="10=1"
-    android:versionName="1.4.02">
+    android:versionCode="12"
+    android:versionName="1.4.03">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AutoGlitchActivity.java
@@ -39,7 +39,6 @@ public class AutoGlitchActivity extends GlitchActivity implements Runnable {
     public static final String TEXT_FAIL = "FAIL !!!!";
 
     private TextView mAutoTextView;
-    private Button mButtonShare;
 
     private Thread mAutoThread;
     private volatile boolean mThreadEnabled = false;
@@ -71,9 +70,6 @@ public class AutoGlitchActivity extends GlitchActivity implements Runnable {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mButtonShare = (Button) findViewById(R.id.button_share);
-        mButtonShare.setEnabled(false);
-
         mAutoTextView = (TextView) findViewById(R.id.text_auto_result);
         mAutoTextView.setMovementMethod(new ScrollingMovementMethod());
 
@@ -93,14 +89,6 @@ public class AutoGlitchActivity extends GlitchActivity implements Runnable {
     }
 
     public void startAudioTest() {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mButtonShare.setEnabled(false);
-                // Keep screen on because the test takes a while and sleep might cause glitches.
-                getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-            }
-        });
         mThreadEnabled = true;
         mAutoThread = new Thread(this);
         mAutoThread.start();
@@ -109,8 +97,6 @@ public class AutoGlitchActivity extends GlitchActivity implements Runnable {
     // Only call from UI thread.
     @Override
     public void onTestFinished() {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        mButtonShare.setEnabled(true);
         super.onTestFinished();
     }
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/EchoActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/EchoActivity.java
@@ -103,6 +103,7 @@ public class EchoActivity extends TestInputActivity {
         setDelayTime(mDelayTime);
         mStartButton.setEnabled(false);
         mStopButton.setEnabled(true);
+        keepScreenOn(true);
     }
 
     public void onStopEcho(View view) {
@@ -110,6 +111,7 @@ public class EchoActivity extends TestInputActivity {
         closeAudio();
         mStartButton.setEnabled(true);
         mStopButton.setEnabled(false);
+        keepScreenOn(false);
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/GlitchActivity.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -215,6 +216,7 @@ public class GlitchActivity extends AnalyzerActivity {
         mStartButton.setEnabled(false);
         mStopButton.setEnabled(true);
         mShareButton.setEnabled(false);
+        keepScreenOn(true);
     }
 
     public void startAudioTest() {
@@ -232,6 +234,7 @@ public class GlitchActivity extends AnalyzerActivity {
     public void onStopAudioTest(View view) {
         stopAudioTest();
         onTestFinished();
+        keepScreenOn(false);
     }
 
     // Must be called on UI thread.

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
@@ -24,6 +24,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.Toast;
@@ -310,14 +311,25 @@ abstract class TestAudioActivity extends Activity {
     public void startAudio(View view) {
         Log.i(TAG, "startAudio() called =======================================");
         startAudio();
+        keepScreenOn(true);
+    }
+
+    protected void keepScreenOn(boolean on) {
+        if (on) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        } else {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
     }
 
     public void stopAudio(View view) {
         stopAudio();
+        keepScreenOn(false);
     }
 
     public void pauseAudio(View view) {
         pauseAudio();
+        keepScreenOn(false);
     }
 
     public void closeAudio(View view) {


### PR DESCRIPTION
Use KEEP_SCREEN_ON to allow tests to run overnight.
Keep the phone plugged in.