### PR TITLE
Refactor Live Effect to use Full Duplex Stream

### DIFF
--- a/samples/LiveEffect/src/main/cpp/CMakeLists.txt
+++ b/samples/LiveEffect/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(${OBOE_DIR} ./oboe-bin)
 add_library(liveEffect
     SHARED
         LiveEffectEngine.cpp
+        FullDuplexStream.cpp
         jni_bridge.cpp
         ${SAMPLE_ROOT_DIR}/debug-utils/trace.cpp)
 target_include_directories(liveEffect

--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -20,11 +20,14 @@
 
 class FullDuplexPass : public FullDuplexStream {
 public:
-    const int BYTES_PER_FRAME = 4;
     virtual oboe::DataCallbackResult
     onBothStreamsReady(const void *inputData, int numInputFrames, void *outputData,
                        int numOutputFrames) {
-        memcpy(outputData, inputData, numInputFrames * BYTES_PER_FRAME);
+        size_t bytesPerFrame = this->getOutputStream()->getBytesPerFrame();
+        size_t bytesToWrite = numInputFrames * bytesPerFrame;
+        size_t bytesToZero = (numOutputFrames - numInputFrames) * bytesPerFrame > 0 ? : 0;
+        memcpy(outputData, inputData, bytesToWrite);
+        memset((u_char*) outputData + bytesToWrite, 0, bytesToZero);
         return oboe::DataCallbackResult::Continue;
     }
 };

--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -20,14 +20,11 @@
 
 class FullDuplexPass : public FullDuplexStream {
 public:
+    const int BYTES_PER_FRAME = 4;
     virtual oboe::DataCallbackResult
     onBothStreamsReady(const void *inputData, int numInputFrames, void *outputData,
                        int numOutputFrames) {
-        int16_t* intIn = (int16_t*) inputData;
-        int16_t* intOut = (int16_t*) outputData;
-        for(int i = 0; i < numOutputFrames; i++){
-            intOut[i] = intIn[i];
-        }
+        memcpy(outputData, inputData, numInputFrames * BYTES_PER_FRAME);
         return oboe::DataCallbackResult::Continue;
     }
 };

--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SAMPLES_FULLDUPLEXPASS_H
+#define SAMPLES_FULLDUPLEXPASS_H
+#include "FullDuplexStream.h"
+
+class FullDuplexPass : public FullDuplexStream {
+public:
+    virtual oboe::DataCallbackResult
+    onBothStreamsReady(const void *inputData, int numInputFrames, void *outputData,
+                       int numOutputFrames) {
+        int16_t* intIn = (int16_t*) inputData;
+        int16_t* intOut = (int16_t*) outputData;
+        for(int i = 0; i < numOutputFrames; i++){
+            intOut[i] = intIn[i];
+        }
+        return oboe::DataCallbackResult::Continue;
+    }
+};
+#endif //SAMPLES_FULLDUPLEXPASS_H

--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -25,7 +25,8 @@ public:
                        int numOutputFrames) {
         size_t bytesPerFrame = this->getOutputStream()->getBytesPerFrame();
         size_t bytesToWrite = numInputFrames * bytesPerFrame;
-        size_t bytesToZero = (numOutputFrames - numInputFrames) * bytesPerFrame > 0 ? : 0;
+        size_t byteDiff = (numOutputFrames - numInputFrames) * bytesPerFrame;
+        size_t bytesToZero = (byteDiff > 0) ? byteDiff : 0;
         memcpy(outputData, inputData, bytesToWrite);
         memset((u_char*) outputData + bytesToWrite, 0, bytesToZero);
         return oboe::DataCallbackResult::Continue;

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
@@ -104,8 +104,13 @@ oboe::Result FullDuplexStream::start() {
 }
 
 oboe::Result FullDuplexStream::stop() {
-    getOutputStream()->requestStop(); // TODO result?
-    return getInputStream()->requestStop();
+    oboe::Result outputResult = getOutputStream()->requestStop();
+    oboe::Result inputResult = getInputStream()->requestStop();
+    if (outputResult != oboe::Result::OK) {
+        return outputResult;
+    } else {
+        return inputResult;
+    }
 }
 
 int32_t FullDuplexStream::getMNumInputBurstsCushion() const {

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FullDuplexStream.h"
+
+oboe::DataCallbackResult FullDuplexStream::onAudioReady(
+        oboe::AudioStream *outputStream,
+        void *audioData,
+        int numFrames) {
+    oboe::DataCallbackResult callbackResult = oboe::DataCallbackResult::Continue;
+    int32_t actualFramesRead = 0;
+
+    // Silence the output.
+    int32_t numBytes = numFrames * outputStream->getBytesPerFrame();
+    memset(audioData, 0 /* value */, numBytes);
+
+    if (mCountCallbacksToDrain > 0) {
+        // Drain the input.
+        int32_t totalFramesRead = 0;
+        do {
+            oboe::ResultWithValue<int32_t> result = getInputStream()->read(mInputBuffer.get(),
+                                                                           numFrames,
+                                                                           0 /* timeout */);
+            if (!result) {
+                // Ignore errors because input stream may not be started yet.
+                break;
+            }
+            actualFramesRead = result.value();
+            totalFramesRead += actualFramesRead;
+        } while (actualFramesRead > 0);
+        // Only counts if we actually got some data.
+        if (totalFramesRead > 0) {
+            mCountCallbacksToDrain--;
+        }
+
+    } else if (mCountInputBurstsCushion > 0) {
+        // Let the input fill up a bit so we are not so close to the write pointer.
+        mCountInputBurstsCushion--;
+
+    } else if (mCountCallbacksToDiscard > 0) {
+        // Ignore. Allow the input to reach to equilibrium with the output.
+        oboe::ResultWithValue<int32_t> result = getInputStream()->read(mInputBuffer.get(),
+                                                                       numFrames,
+                                                                       0 /* timeout */);
+        if (!result) {
+            callbackResult = oboe::DataCallbackResult::Stop;
+        }
+        mCountCallbacksToDiscard--;
+
+    } else {
+        // Read data into input buffer.
+        oboe::ResultWithValue<int32_t> result = getInputStream()->read(mInputBuffer.get(),
+                                                                       numFrames,
+                                                                       0 /* timeout */);
+        if (!result) {
+            callbackResult = oboe::DataCallbackResult::Stop;
+        } else {
+            int32_t framesRead = result.value();
+
+            callbackResult = onBothStreamsReady(
+                    mInputBuffer.get(), framesRead,
+                    audioData, numFrames
+            );
+        }
+    }
+
+    if (callbackResult == oboe::DataCallbackResult::Stop) {
+        getInputStream()->requestStop();
+    }
+
+    return callbackResult;
+}
+
+oboe::Result FullDuplexStream::start() {
+    mCountCallbacksToDrain = kNumCallbacksToDrain;
+    mCountInputBurstsCushion = mNumInputBurstsCushion;
+    mCountCallbacksToDiscard = kNumCallbacksToDiscard;
+
+    // Determine maximum size that could possibly be called.
+    int32_t bufferSize = getOutputStream()->getBufferCapacityInFrames()
+            * getOutputStream()->getChannelCount();
+    if (bufferSize > mBufferSize) {
+        mInputBuffer = std::make_unique<float[]>(bufferSize);
+        mBufferSize = bufferSize;
+    }
+    oboe::Result result = getInputStream()->requestStart();
+    if (result != oboe::Result::OK) {
+        return result;
+    }
+    return getOutputStream()->requestStart();
+}
+
+oboe::Result FullDuplexStream::stop() {
+    getOutputStream()->requestStop(); // TODO result?
+    return getInputStream()->requestStop();
+}
+
+int32_t FullDuplexStream::getMNumInputBurstsCushion() const {
+    return mNumInputBurstsCushion;
+}
+
+void FullDuplexStream::setMNumInputBurstsCushion(int32_t numBursts) {
+    FullDuplexStream::mNumInputBurstsCushion = numBursts;
+}

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
@@ -83,7 +83,7 @@ private:
     static constexpr int32_t kNumCallbacksToDiscard = 30;
 
     // let input fill back up, usually 0 or 1
-    int32_t mNumInputBurstsCushion = 0;
+    int32_t mNumInputBurstsCushion = 1;
 
     // We want to reach a state where the input buffer is empty and
     // the output buffer is full.

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
@@ -83,7 +83,7 @@ private:
     static constexpr int32_t kNumCallbacksToDiscard = 30;
 
     // let input fill back up, usually 0 or 1
-    int32_t mNumInputBurstsCushion =  1;
+    int32_t mNumInputBurstsCushion = 0;
 
     // We want to reach a state where the input buffer is empty and
     // the output buffer is full.

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_FULL_DUPLEX_STREAM_H
+#define OBOE_FULL_DUPLEX_STREAM_H
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#include "oboe/Oboe.h"
+
+class FullDuplexStream : public oboe::AudioStreamCallback {
+public:
+    FullDuplexStream() {}
+    virtual ~FullDuplexStream() = default;
+
+    void setInputStream(oboe::AudioStream *stream) {
+        mInputStream = stream;
+    }
+
+    oboe::AudioStream *getInputStream() {
+        return mInputStream;
+    }
+
+    void setOutputStream(oboe::AudioStream *stream) {
+        mOutputStream = stream;
+    }
+    oboe::AudioStream *getOutputStream() {
+        return mOutputStream;
+    }
+
+    virtual oboe::Result start();
+
+    virtual oboe::Result stop();
+
+    /**
+     * Called when data is available on both streams.
+     * Caller should override this method.
+     */
+    virtual oboe::DataCallbackResult onBothStreamsReady(
+            const void *inputData,
+            int   numInputFrames,
+            void *outputData,
+            int   numOutputFrames
+            ) = 0;
+
+    /**
+     * Called by Oboe when the stream is ready to process audio.
+     */
+    oboe::DataCallbackResult onAudioReady(
+            oboe::AudioStream *audioStream,
+            void *audioData,
+            int numFrames) override;
+
+    int32_t getMNumInputBurstsCushion() const;
+
+    /**
+     * Number of bursts to leave in the input buffer as a cushion.
+     * Typically 0 for latency measurements
+     * or 1 for glitch tests.
+     *
+     * @param mNumInputBurstsCushion
+     */
+    void setMNumInputBurstsCushion(int32_t mNumInputBurstsCushion);
+
+private:
+
+    // TODO add getters and setters
+    static constexpr int32_t kNumCallbacksToDrain   = 20;
+    static constexpr int32_t kNumCallbacksToDiscard = 30;
+
+    // let input fill back up, usually 0 or 1
+    int32_t mNumInputBurstsCushion =  1;
+
+    // We want to reach a state where the input buffer is empty and
+    // the output buffer is full.
+    // These are used in order.
+    // Drain several callback so that input is empty.
+    int32_t              mCountCallbacksToDrain = kNumCallbacksToDrain;
+    // Let the input fill back up slightly so we don't run dry.
+    int32_t              mCountInputBurstsCushion = mNumInputBurstsCushion;
+    // Discard some callbacks so the input and output reach equilibrium.
+    int32_t              mCountCallbacksToDiscard = kNumCallbacksToDiscard;
+
+    oboe::AudioStream   *mInputStream = nullptr;
+    oboe::AudioStream   *mOutputStream = nullptr;
+
+    int32_t              mBufferSize = 0;
+    std::unique_ptr<float[]> mInputBuffer;
+};
+
+
+#endif //OBOE_FULL_DUPLEX_STREAM_H

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -50,14 +50,15 @@ bool LiveEffectEngine::setAudioApi(oboe::AudioApi api) {
     return true;
 }
 void LiveEffectEngine::setEffectOn(bool isOn) {
-    bindStreams();
     if (isOn != mIsEffectOn) {
         mIsEffectOn = isOn;
-
         if (isOn) {
+            bindStreams();
             mFullDuplexPass.start();
         } else {
             mFullDuplexPass.stop();
+            closeStream(mRecordingStream);
+            closeStream(mPlayStream);
         }
     }
 }
@@ -139,6 +140,7 @@ void LiveEffectEngine::closeStream(oboe::AudioStream *stream) {
         if (result != oboe::Result::OK) {
             LOGE("Error closing stream. %s", oboe::convertToText(result));
         }
+        LOGW("Successfully closed streams");
     }
 }
 

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -17,27 +17,18 @@
 #include "LiveEffectEngine.h"
 #include <assert.h>
 #include <logging_macros.h>
-#include <climits>
 
-/**
- * Duplex is not very stable right after starting up:
- *   the callbacks may not be happening at the right times
- * The time to get it stable varies on different systems. Half second
- * is used for this sample, during the time this sample plays silence.
- */
-const float kSystemWarmupTime = 0.5f;
 
 LiveEffectEngine::LiveEffectEngine() {
     assert(mOutputChannelCount == mInputChannelCount);
 }
 
 LiveEffectEngine::~LiveEffectEngine() {
-    stopStream(mPlayStream);
-    stopStream(mRecordingStream);
 
+    mFullDuplexPass.stop();
     closeStream(mPlayStream);
-
     closeStream(mRecordingStream);
+
 }
 
 void LiveEffectEngine::setRecordingDeviceId(int32_t deviceId) {
@@ -59,114 +50,27 @@ bool LiveEffectEngine::setAudioApi(oboe::AudioApi api) {
     return true;
 }
 void LiveEffectEngine::setEffectOn(bool isOn) {
+    bindStreams();
     if (isOn != mIsEffectOn) {
         mIsEffectOn = isOn;
 
         if (isOn) {
-            openAllStreams();
+            mFullDuplexPass.start();
         } else {
-            closeAllStreams();
+            mFullDuplexPass.stop();
         }
     }
 }
-
-void LiveEffectEngine::openAllStreams() {
-    // Note: The order of stream creation is important. We create the playback
-    // stream first, then use properties from the playback stream
-    // (e.g. sample rate) to create the recording stream. By matching the
-    // properties we should get the lowest latency path
-    openPlaybackStream();
-    openRecordingStream();
-    // Now start the recording stream first so that we can read from it during
-    // the playback stream's dataCallback
-    if (mRecordingStream && mPlayStream) {
-        startStream(mRecordingStream);
-        startStream(mPlayStream);
-    } else {
-        LOGE("Failed to create recording (%p) and/or playback (%p) stream",
-             mRecordingStream, mPlayStream);
-        closeAllStreams();
-    }
-}
-
-/**
- * Stops and closes the playback and recording streams.
- */
-void LiveEffectEngine::closeAllStreams() {
-    /**
-     * Note: The order of events is important here.
-     * The playback stream must be closed before the recording stream. If the
-     * recording stream were to be closed first the playback stream's
-     * callback may attempt to read from the recording stream
-     * which would cause the app to crash since the recording stream would be
-     * null.
-     */
-
-    if (mPlayStream != nullptr) {
-        closeStream(mPlayStream);  // Calling close will also stop the stream
-        mPlayStream = nullptr;
-    }
-
-    if (mRecordingStream != nullptr) {
-        closeStream(mRecordingStream);
-        mRecordingStream = nullptr;
-    }
-}
-
-/**
- * Creates an audio stream for recording. The audio device used will depend on
- * mRecordingDeviceId.
- * If the value is set to oboe::Unspecified then the default recording device
- * will be used.
- */
-void LiveEffectEngine::openRecordingStream() {
-    // To create a stream we use a stream builder. This allows us to specify all
-    // the parameters for the stream prior to opening it
-    oboe::AudioStreamBuilder builder;
-
-    setupRecordingStreamParameters(&builder);
-
-    // Now that the parameters are set up we can open the stream
-    oboe::Result result = builder.openStream(&mRecordingStream);
-    if (result == oboe::Result::OK && mRecordingStream) {
-        assert(mRecordingStream->getChannelCount() == mInputChannelCount);
-        assert(mRecordingStream->getSampleRate() == mSampleRate);
-        assert(mRecordingStream->getFormat() == oboe::AudioFormat::I16);
-
-        warnIfNotLowLatency(mRecordingStream);
-    } else {
-        LOGE("Failed to create recording stream. Error: %s",
-             oboe::convertToText(result));
-    }
-}
-
-/**
- * Creates an audio stream for playback. The audio device used will depend on
- * mPlaybackDeviceId.
- * If the value is set to oboe::Unspecified then the default playback device
- * will be used.
- */
-void LiveEffectEngine::openPlaybackStream() {
-    oboe::AudioStreamBuilder builder;
-
-    setupPlaybackStreamParameters(&builder);
-    oboe::Result result = builder.openStream(&mPlayStream);
-    if (result == oboe::Result::OK && mPlayStream) {
-        mSampleRate = mPlayStream->getSampleRate();
-
-        assert(mPlayStream->getFormat() == oboe::AudioFormat::I16);
-        assert(mOutputChannelCount == mPlayStream->getChannelCount());
-
-        mSystemStartupFrames =
-            static_cast<uint64_t>(mSampleRate * kSystemWarmupTime);
-        mProcessedFrameCount = 0;
-
-        warnIfNotLowLatency(mPlayStream);
-
-    } else {
-        LOGE("Failed to create playback stream. Error: %s",
-             oboe::convertToText(result));
-    }
+void LiveEffectEngine::bindStreams() {
+    oboe::AudioStreamBuilder inBuilder, outBuilder;
+    setupRecordingStreamParameters(&inBuilder);
+    inBuilder.openStream(&mRecordingStream);
+    warnIfNotLowLatency(mRecordingStream);
+    setupPlaybackStreamParameters(&outBuilder);
+    outBuilder.openStream(&mPlayStream);
+    warnIfNotLowLatency(mPlayStream);
+    mFullDuplexPass.setInputStream(mRecordingStream);
+    mFullDuplexPass.setOutputStream(mPlayStream);
 }
 
 /**
@@ -221,24 +125,6 @@ oboe::AudioStreamBuilder *LiveEffectEngine::setupCommonStreamParameters(
     return builder;
 }
 
-void LiveEffectEngine::startStream(oboe::AudioStream *stream) {
-    assert(stream);
-    if (stream) {
-        oboe::Result result = stream->requestStart();
-        if (result != oboe::Result::OK) {
-            LOGE("Error starting stream. %s", oboe::convertToText(result));
-        }
-    }
-}
-
-void LiveEffectEngine::stopStream(oboe::AudioStream *stream) {
-    if (stream) {
-        oboe::Result result = stream->stop(0L);
-        if (result != oboe::Result::OK) {
-            LOGE("Error stopping stream. %s", oboe::convertToText(result));
-        }
-    }
-}
 
 /**
  * Close the stream. AudioStream::close() is a blocking call so
@@ -256,28 +142,6 @@ void LiveEffectEngine::closeStream(oboe::AudioStream *stream) {
     }
 }
 
-/**
- * Restart the streams. During the restart operation subsequent calls to this
- * method will output a warning.
- */
-void LiveEffectEngine::restartStreams() {
-    LOGI("Restarting streams");
-
-    if (mRestartingLock.try_lock()) {
-        closeAllStreams();
-        openAllStreams();
-        mRestartingLock.unlock();
-    } else {
-        LOGW(
-            "Restart stream operation already in progress - ignoring this "
-            "request");
-        // We were unable to obtain the restarting lock which means the restart
-        // operation is currently
-        // active. This is probably because we received successive "stream
-        // disconnected" events.
-        // Internal issue b/63087953
-    }
-}
 
 /**
  * Warn in logcat if non-low latency stream is created
@@ -303,47 +167,7 @@ void LiveEffectEngine::warnIfNotLowLatency(oboe::AudioStream *stream) {
  */
 oboe::DataCallbackResult LiveEffectEngine::onAudioReady(
     oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
-    assert(oboeStream == mPlayStream);
-
-    int32_t prevFrameRead = 0, framesRead = 0;
-    if (mProcessedFrameCount < mSystemStartupFrames) {
-        do {
-            // Drain the audio for the starting up period, half second for
-            // this sample.
-            prevFrameRead = framesRead;
-
-            oboe::ResultWithValue<int32_t> status =
-                mRecordingStream->read(audioData, numFrames, 0);
-            framesRead = (!status) ? 0 : status.value();
-            if (framesRead == 0) break;
-
-        } while (framesRead);
-
-        framesRead = prevFrameRead;
-    } else {
-        oboe::ResultWithValue<int32_t> status =
-            mRecordingStream->read(audioData, numFrames, 0);
-        if (!status) {
-            LOGE("input stream read error: %s",
-                 oboe::convertToText(status.error()));
-            return oboe::DataCallbackResult ::Stop;
-        }
-        framesRead = status.value();
-    }
-
-    if (framesRead < numFrames) {
-        int32_t bytesPerFrame = mRecordingStream->getChannelCount() *
-                                oboeStream->getBytesPerSample();
-        uint8_t *padPos =
-            static_cast<uint8_t *>(audioData) + framesRead * bytesPerFrame;
-        memset(padPos, 0, static_cast<size_t>((numFrames - framesRead) * bytesPerFrame));
-    }
-
-    // add your audio processing here
-
-    mProcessedFrameCount += numFrames;
-
-    return oboe::DataCallbackResult::Continue;
+    return mFullDuplexPass.onAudioReady(oboeStream, audioData, numFrames);
 }
 
 /**

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -30,7 +30,7 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     void setRecordingDeviceId(int32_t deviceId);
     void setPlaybackDeviceId(int32_t deviceId);
     void setEffectOn(bool isOn);
-    void bindStreams();
+    void openStreams();
 
     /*
      * oboe::AudioStreamCallback interface implementation

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -21,6 +21,7 @@
 #include <oboe/Oboe.h>
 #include <string>
 #include <thread>
+#include "FullDuplexPass.h"
 
 class LiveEffectEngine : public oboe::AudioStreamCallback {
    public:
@@ -29,6 +30,7 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     void setRecordingDeviceId(int32_t deviceId);
     void setPlaybackDeviceId(int32_t deviceId);
     void setEffectOn(bool isOn);
+    void bindStreams();
 
     /*
      * oboe::AudioStreamCallback interface implementation
@@ -42,9 +44,8 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     bool isAAudioSupported(void);
 
    private:
+    FullDuplexPass mFullDuplexPass;
     bool mIsEffectOn = false;
-    uint64_t mProcessedFrameCount = 0;
-    uint64_t mSystemStartupFrames = 0;
     int32_t mRecordingDeviceId = oboe::kUnspecified;
     int32_t mPlaybackDeviceId = oboe::kUnspecified;
     oboe::AudioFormat mFormat = oboe::AudioFormat::I16;
@@ -53,19 +54,10 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
     oboe::AudioStream *mRecordingStream = nullptr;
     oboe::AudioStream *mPlayStream = nullptr;
-    std::mutex mRestartingLock;
     oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
 
-    void openRecordingStream();
-    void openPlaybackStream();
-
-    void startStream(oboe::AudioStream *stream);
-    void stopStream(oboe::AudioStream *stream);
     void closeStream(oboe::AudioStream *stream);
 
-    void openAllStreams();
-    void closeAllStreams();
-    void restartStreams();
 
     oboe::AudioStreamBuilder *setupCommonStreamParameters(
         oboe::AudioStreamBuilder *builder);


### PR DESCRIPTION
Refactoring Live Effect to use Full Duplex stream. Having a separate effect engine and duplex stream is a little redundant. But, the duplex stream class does not take ownership of stream creating and closure, so a second class is still necessary. 