### PR TITLE
Add support to easily use unique pointers for AudioStream

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -456,7 +456,10 @@ private:
     std::atomic<bool>    mDataCallbackEnabled{};
 
 };
-
+/**
+ * This struct is a stateless functor which closes a audiostream prior to its deletion.
+ * This means it can be used to safely delete a smart pointer referring to an open stream.
+ */
 struct streamDeleterFunctor {
     void operator()(AudioStream  *audioStream) {
         if (audioStream) {

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -457,6 +457,14 @@ private:
 
 };
 
+struct streamDeleterFunctor {
+    void operator()(AudioStream  *audioStream) {
+        if (audioStream) {
+            audioStream->close();
+        }
+        delete audioStream;
+    }
+};
 } // namespace oboe
 
 #endif /* OBOE_STREAM_H_ */

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -22,6 +22,8 @@
 
 namespace oboe {
 
+    struct streamDeleterFunctor; // This depends on AudioStream, so we use forward declaration
+    using ManagedStream = std::unique_ptr<AudioStream, streamDeleterFunctor>;
 /**
  * Factory class for an audio Stream.
  */
@@ -321,6 +323,8 @@ public:
      * @return OBOE_OK if successful or a negative error code
      */
     Result openStream(AudioStream **stream);
+
+    Result openManagedStream(ManagedStream &stream);
 
 protected:
 

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -21,8 +21,8 @@
 #include "oboe/AudioStreamBase.h"
 
 namespace oboe {
-
-    struct streamDeleterFunctor; // This depends on AudioStream, so we use forward declaration
+    // This depends on AudioStream, so we use forward declaration, it will close and delete the stream
+    struct streamDeleterFunctor;
     using ManagedStream = std::unique_ptr<AudioStream, streamDeleterFunctor>;
 /**
  * Factory class for an audio Stream.
@@ -326,6 +326,15 @@ public:
      */
     Result openStream(AudioStream **stream);
 
+    /**
+     * Create and open a ManagedStream object based on the current builder state.
+     *
+     * The caller must create a unique ptr, and pass by reference so it can be
+     * modified to point to an opened stream. The caller owns the unique ptr,
+     * and it will be automatically closed and cleaned up upon going out of scope.
+     * @param stream Reference to the ManagedStream (uniqueptr) used to keep track of stream
+     * @return OBOE_OK if successful or a negative error code.
+     */
     Result openManagedStream(ManagedStream &stream);
 
 protected:

--- a/samples/hello-oboe/src/main/cpp/PlayAudioEngine.h
+++ b/samples/hello-oboe/src/main/cpp/PlayAudioEngine.h
@@ -17,11 +17,7 @@
 #ifndef OBOE_HELLOOBOE_PLAYAUDIOENGINE_H
 #define OBOE_HELLOOBOE_PLAYAUDIOENGINE_H
 
-#include <thread>
-#include <array>
 #include <oboe/Oboe.h>
-
-#include "shared/Mixer.h"
 
 #include "SoundGenerator.h"
 
@@ -31,8 +27,6 @@ class PlayAudioEngine : oboe::AudioStreamCallback {
 
 public:
     PlayAudioEngine();
-
-    ~PlayAudioEngine();
 
     void setAudioApi(oboe::AudioApi audioApi);
 
@@ -57,7 +51,6 @@ public:
 
 
 private:
-    oboe::AudioStream *mPlayStream;
     double mCurrentOutputLatencyMillis = 0;
     int32_t mBufferSizeSelection = kBufferSizeAutomatic; // Used to keep track if we are auto tuning
     bool mIsLatencyDetectionSupported = false;
@@ -68,12 +61,11 @@ private:
 
     void createPlaybackStream(oboe::AudioStreamBuilder *builder);
 
-    void closeOutputStream();
-
     void restartStream(oboe::AudioStreamBuilder *builder);
 
     oboe::Result calculateCurrentOutputLatencyMillis(oboe::AudioStream *stream, double *latencyMillis);
 
+    oboe::ManagedStream playstream_;
 };
 
 #endif //OBOE_HELLOOBOE_PLAYAUDIOENGINE_H

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -167,4 +167,11 @@ void AudioStream::launchStopThread() {
     t.detach();
 }
 
+Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
+    auto streamptr = stream.get();
+    auto result = openStream(&streamptr);
+    stream.reset(streamptr);
+    return result;
+}
+
 } // namespace oboe


### PR DESCRIPTION
Added a ManagedStream typedef which is an alias for a unique ptr of AudioStream with a custom destructor that closes the stream.

This allows for easy creation of a ManagedStream object, that can be modified with reset semantics, safely closing and deleting the old stream object.

Additionally, the ManagedStream is automatic, and when the enclosing class goes out of scope, it is safely deleted, preventing memory leaks and the necessity of overriding the enclosing class' destructor to close the stream.