### PR TITLE
Adding ManagedStream type

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -461,7 +461,7 @@ private:
  * This struct is a stateless functor which closes a audiostream prior to its deletion.
  * This means it can be used to safely delete a smart pointer referring to an open stream.
  */
-    struct streamDeleterFunctor {
+    struct StreamDeleterFunctor {
         void operator()(AudioStream  *audioStream) {
             if (audioStream) {
                 audioStream->close();

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -457,6 +457,18 @@ private:
 
 };
 
+/**
+ * This struct is a stateless functor which closes a audiostream prior to its deletion.
+ * This means it can be used to safely delete a smart pointer referring to an open stream.
+ */
+    struct streamDeleterFunctor {
+        void operator()(AudioStream  *audioStream) {
+            if (audioStream) {
+                audioStream->close();
+            }
+            delete audioStream;
+        }
+    };
 } // namespace oboe
 
 #endif /* OBOE_STREAM_H_ */

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -22,6 +22,9 @@
 
 namespace oboe {
 
+    // This depends on AudioStream, so we use forward declaration, it will close and delete the stream
+    struct streamDeleterFunctor;
+    using ManagedStream = std::unique_ptr<AudioStream, streamDeleterFunctor>;
 /**
  * Factory class for an audio Stream.
  */
@@ -323,6 +326,18 @@ public:
      * @return OBOE_OK if successful or a negative error code
      */
     Result openStream(AudioStream **stream);
+
+    /**
+     * Create and open a ManagedStream object based on the current builder state.
+     *
+     * The caller must create a unique ptr, and pass by reference so it can be
+     * modified to point to an opened stream. The caller owns the unique ptr,
+     * and it will be automatically closed and cleaned up upon going out of scope.
+     * @param stream Reference to the ManagedStream (uniqueptr) used to keep track of stream
+     * @return OBOE_OK if successful or a negative error code.
+     */
+    Result openManagedStream(ManagedStream &stream);
+
 
 protected:
 

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -23,8 +23,8 @@
 namespace oboe {
 
     // This depends on AudioStream, so we use forward declaration, it will close and delete the stream
-    struct streamDeleterFunctor;
-    using ManagedStream = std::unique_ptr<AudioStream, streamDeleterFunctor>;
+    struct StreamDeleterFunctor;
+    using ManagedStream = std::unique_ptr<AudioStream, StreamDeleterFunctor>;
 /**
  * Factory class for an audio Stream.
  */
@@ -332,7 +332,7 @@ public:
      *
      * The caller must create a unique ptr, and pass by reference so it can be
      * modified to point to an opened stream. The caller owns the unique ptr,
-     * and it will be automatically closed and cleaned up upon going out of scope.
+     * and it will be automatically closed and deleted when going out of scope.
      * @param stream Reference to the ManagedStream (uniqueptr) used to keep track of stream
      * @return OBOE_OK if successful or a negative error code.
      */

--- a/samples/hello-oboe/src/main/cpp/PlayAudioEngine.h
+++ b/samples/hello-oboe/src/main/cpp/PlayAudioEngine.h
@@ -17,11 +17,7 @@
 #ifndef OBOE_HELLOOBOE_PLAYAUDIOENGINE_H
 #define OBOE_HELLOOBOE_PLAYAUDIOENGINE_H
 
-#include <thread>
-#include <array>
 #include <oboe/Oboe.h>
-
-#include "shared/Mixer.h"
 
 #include "SoundGenerator.h"
 
@@ -32,7 +28,6 @@ class PlayAudioEngine : oboe::AudioStreamCallback {
 public:
     PlayAudioEngine();
 
-    ~PlayAudioEngine();
 
     void setAudioApi(oboe::AudioApi audioApi);
 
@@ -57,7 +52,7 @@ public:
 
 
 private:
-    oboe::AudioStream *mPlayStream;
+    oboe::ManagedStream mPlayStream;
     double mCurrentOutputLatencyMillis = 0;
     int32_t mBufferSizeSelection = kBufferSizeAutomatic; // Used to keep track if we are auto tuning
     bool mIsLatencyDetectionSupported = false;
@@ -67,8 +62,6 @@ private:
     // We will handle conversion to avoid getting kicked off the fast track as penalty
 
     void createPlaybackStream(oboe::AudioStreamBuilder *builder);
-
-    void closeOutputStream();
 
     void restartStream(oboe::AudioStreamBuilder *builder);
 

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -167,4 +167,11 @@ void AudioStream::launchStopThread() {
     t.detach();
 }
 
+Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
+    auto streamptr = stream.get();
+    auto result = openStream(&streamptr);
+    stream.reset(streamptr);
+    return result;
+}
+
 } // namespace oboe

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -167,11 +167,4 @@ void AudioStream::launchStopThread() {
     t.detach();
 }
 
-Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
-    auto streamptr = stream.get();
-    auto result = openStream(&streamptr);
-    stream.reset(streamptr);
-    return result;
-}
-
 } // namespace oboe

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -109,4 +109,11 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
     return result;
 }
 
+Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
+    auto streamptr = stream.release();
+    auto result = openStream(&streamptr);
+    stream.reset(streamptr);
+    return result;
+}
+
 } // namespace oboe


### PR DESCRIPTION
Adding easy support for uniqueptrs of AudioStreams via a ManagedStream type. This type has a custom deleter which closes the AudioStream to safely delete it. ManagedStream can be treated as a generic object, with AudioStreamBuilder safely repopulating a ManagedStream with the openManagedStream method. (This assumes close() is thread safe/safe to repeat).

Also refactoring Hello-Oboe to use this type. (This assumes onErrorAfterClose is safe).