### PR TITLE
oboe: prevent onError callback from causing an assert

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -381,7 +381,9 @@ protected:
      * These were bugs in some versions of Android that caused multiple error callbacks.
      * Internal bug b/63087953
      *
-     * @return true if the error callback was already called, otherwise false
+     * Calling this sets an atomic<bool> true and returns the previous value.
+     *
+     * @return false on first call, true on subsequent calls
      */
     bool wasErrorCallbackCalled() {
         return mErrorCallbackCalled.exchange(true);

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -374,6 +374,17 @@ public:
      */
     void launchStopThread();
 
+    /**
+     * This can be called to prevent handling more than one error callback from a stream.
+     * These were bugs in some versions of Android that caused multiple error callbacks.
+     * Internal bug b/63087953
+     *
+     * @return true if the error callback was already called, otherwise false
+     */
+    bool wasErrorCallbackCalled() {
+        return mErrorCallbackCalled.exchange(true);
+    }
+
 protected:
 
     /**
@@ -453,7 +464,8 @@ protected:
 private:
     int                  mPreviousScheduler = -1;
 
-    std::atomic<bool>    mDataCallbackEnabled{};
+    std::atomic<bool>    mDataCallbackEnabled{false};
+    std::atomic<bool>    mErrorCallbackCalled{false};
 
 };
 

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -374,8 +374,10 @@ public:
      */
     void launchStopThread();
 
+protected:
+
     /**
-     * This can be called to prevent handling more than one error callback from a stream.
+     * This is used to detect more than one error callback from a stream.
      * These were bugs in some versions of Android that caused multiple error callbacks.
      * Internal bug b/63087953
      *
@@ -384,8 +386,6 @@ public:
     bool wasErrorCallbackCalled() {
         return mErrorCallbackCalled.exchange(true);
     }
-
-protected:
 
     /**
      * Wait for a transition from one state to another.

--- a/include/oboe/AudioStreamCallback.h
+++ b/include/oboe/AudioStreamCallback.h
@@ -94,6 +94,9 @@ public:
      * The underlying stream will already be stopped by Oboe but not yet closed.
      * So the stream can be queried.
      *
+     * Do not close or delete the stream in this method because it will be
+     * closed after this method returns.
+     *
      * @param oboeStream pointer to the associated stream
      * @param error
      */
@@ -101,10 +104,12 @@ public:
 
     /**
      * This will be called when an error occurs on a stream or when the stream is disconnected.
-     * The underlying stream will already be stopped AND closed by Oboe.
-     * So the underlyng stream cannot be referenced.
+     * The underlying AAudio or OpenSL ES stream will already be stopped AND closed by Oboe.
+     * So the underlying stream cannot be referenced.
+     * But you can still query most parameters.
      *
      * This callback could be used to reopen a new stream on another device.
+     * You can safely delete the old AudioStream in this method.
      *
      * @param oboeStream pointer to the associated stream
      * @param error

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -93,8 +93,6 @@ public:
                                                    void *audioData,
                                                    int32_t numFrames);
 
-    void onErrorInThread(AAudioStream *stream, Result error);
-
 
     void *getUnderlyingStream() const override {
         return mAAudioStream.load();

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -93,12 +93,16 @@ public:
                                                    void *audioData,
                                                    int32_t numFrames);
 
+protected:
+    static void internalErrorCallback(
+            AAudioStream *stream,
+            void *userData,
+            aaudio_result_t error);
 
     void *getUnderlyingStream() const override {
         return mAAudioStream.load();
     }
 
-protected:
     void updateFramesRead() override;
     void updateFramesWritten() override;
 


### PR DESCRIPTION
There was a race that could be caused by multiple onErrorCallbacks.
There should only be one callback.
We now check to make sure that only the first callback is handled.

Fixes #519