### PR TITLE
Fixing bug in AudioStreamBuilder causing leak

### DIFF
--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -110,7 +110,8 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
 }
 
 Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
-    auto streamptr = stream.release();
+    stream.reset();
+    AudioStream *streamptr;
     auto result = openStream(&streamptr);
     stream.reset(streamptr);
     return result;


### PR DESCRIPTION
One line fix to properly delete (and close) old ManagedStream objects.