### PR TITLE
Mark Fifo getters as consts

### DIFF
--- a/src/fifo/FifoController.cpp
+++ b/src/fifo/FifoController.cpp
@@ -28,8 +28,5 @@ FifoController::FifoController(uint32_t numFrames, uint32_t threshold)
     setWriteCounter(0);
 }
 
-FifoController::~FifoController() {
-}
-
 } // namespace oboe
 

--- a/src/fifo/FifoController.h
+++ b/src/fifo/FifoController.h
@@ -30,16 +30,16 @@ class FifoController : public FifoControllerBase
 {
 public:
     FifoController(uint32_t bufferSize, uint32_t threshold);
-    virtual ~FifoController();
+    virtual ~FifoController() = default;
 
     // TODO review use atomics or memory barriers
-    virtual uint64_t getReadCounter() override {
+    virtual uint64_t getReadCounter() const override {
         return mReadCounter.load(std::memory_order_acquire);
     }
     virtual void setReadCounter(uint64_t n) override {
         mReadCounter.store(n, std::memory_order_release);
     }
-    virtual uint64_t getWriteCounter() override {
+    virtual uint64_t getWriteCounter() const override {
         return mWriteCounter.load(std::memory_order_acquire);
     }
     virtual void setWriteCounter(uint64_t n) override {

--- a/src/fifo/FifoControllerBase.cpp
+++ b/src/fifo/FifoControllerBase.cpp
@@ -30,14 +30,11 @@ FifoControllerBase::FifoControllerBase(uint32_t totalFrames, uint32_t threshold)
 {
 }
 
-FifoControllerBase::~FifoControllerBase() {
-}
-
-int32_t FifoControllerBase::getFullFramesAvailable() {
+int32_t FifoControllerBase::getFullFramesAvailable() const {
     return static_cast<int32_t>(getWriteCounter() - getReadCounter());
 }
 
-uint32_t FifoControllerBase::getReadIndex() {
+uint32_t FifoControllerBase::getReadIndex() const {
     return static_cast<uint32_t>(getReadCounter() % mTotalFrames);
 }
 
@@ -45,13 +42,13 @@ void FifoControllerBase::advanceReadIndex(int numFrames) {
     setReadCounter(getReadCounter() + numFrames);
 }
 
-int32_t FifoControllerBase::getEmptyFramesAvailable() {
+int32_t FifoControllerBase::getEmptyFramesAvailable() const {
     int32_t fullFramesAvailable = getFullFramesAvailable();
     int32_t available = static_cast<int32_t>(mThreshold - fullFramesAvailable);
     return available;
 }
 
-uint32_t FifoControllerBase::getWriteIndex() {
+uint32_t FifoControllerBase::getWriteIndex() const {
     return static_cast<uint32_t>(getWriteCounter() % mTotalFrames); // % works with non-power of two sizes
 }
 

--- a/src/fifo/FifoControllerBase.h
+++ b/src/fifo/FifoControllerBase.h
@@ -41,18 +41,18 @@ public:
      */
     FifoControllerBase(uint32_t totalFrames, uint32_t threshold);
 
-    virtual ~FifoControllerBase();
+    virtual ~FifoControllerBase() = default;
 
     /**
      * This may be negative if an unthrottled reader has read beyond the available data.
      * @return number of valid frames available to read. Never read more than this.
      */
-    int32_t getFullFramesAvailable();
+    int32_t getFullFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to read.
      */
-    uint32_t getReadIndex();
+    uint32_t getReadIndex() const;
 
     /**
      * @param numFrames number of frames to advance the read index
@@ -62,12 +62,12 @@ public:
     /**
      * @return number of frames that can be written. Never write more than this.
      */
-    int32_t getEmptyFramesAvailable();
+    int32_t getEmptyFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to write.
      */
-    uint32_t getWriteIndex();
+    uint32_t getWriteIndex() const;
 
     /**
      * @param numFrames number of frames to advance the write index
@@ -80,9 +80,9 @@ public:
 
     uint32_t getFrameCapacity() const { return mTotalFrames; }
 
-    virtual uint64_t getReadCounter() = 0;
+    virtual uint64_t getReadCounter() const = 0;
     virtual void setReadCounter(uint64_t n) = 0;
-    virtual uint64_t getWriteCounter() = 0;
+    virtual uint64_t getWriteCounter() const = 0;
     virtual void setWriteCounter(uint64_t n) = 0;
 
 private:

--- a/src/fifo/FifoControllerIndirect.cpp
+++ b/src/fifo/FifoControllerIndirect.cpp
@@ -29,7 +29,4 @@ FifoControllerIndirect::FifoControllerIndirect(uint32_t numFrames,
 {
 }
 
-FifoControllerIndirect::~FifoControllerIndirect() {
-}
-
 }

--- a/src/fifo/FifoControllerIndirect.h
+++ b/src/fifo/FifoControllerIndirect.h
@@ -32,16 +32,16 @@ public:
                            uint32_t threshold,
                            int64_t * readCounterAddress,
                            int64_t * writeCounterAddress);
-    virtual ~FifoControllerIndirect();
+    virtual ~FifoControllerIndirect() = default;
 
     // TODO review use of memory barriers, probably incorrect
-    virtual uint64_t getReadCounter() override {
+    virtual uint64_t getReadCounter() const override {
         return mReadCounterAddress->load(std::memory_order_acquire);
     }
     virtual void setReadCounter(uint64_t n) override {
         mReadCounterAddress->store(n, std::memory_order_release);
     }
-    virtual uint64_t getWriteCounter() override {
+    virtual uint64_t getWriteCounter() const override {
         return mWriteCounterAddress->load(std::memory_order_acquire);
     }
     virtual void setWriteCounter(uint64_t n) override {


### PR DESCRIPTION
This addresses some of the comments in #352. It makes
FifoControllerBase's getters consts, and it uses default destructors.