### PR TITLE
Use uint32_t for frames and bytes in FifoBuffer

### DIFF
--- a/src/fifo/FifoBuffer.h
+++ b/src/fifo/FifoBuffer.h
@@ -38,7 +38,7 @@ public:
 
     ~FifoBuffer();
 
-    int32_t convertFramesToBytes(int32_t frames);
+    uint32_t convertFramesToBytes(uint32_t frames);
 
     /**
      * Read framesToRead or, if not enough, then read as many as are available.

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -134,7 +134,7 @@ ResultWithValue<int32_t> AudioStreamBuffered::transfer(void *buffer,
             result = mFifoBuffer->write(data, framesLeft);
         }
         if (result > 0) {
-            data += mFifoBuffer->convertFramesToBytes(result);
+            data += mFifoBuffer->convertFramesToBytes(static_cast<uint32_t>(result));
             framesLeft -= result;
         }
 


### PR DESCRIPTION
FifoBuffer::convertFramesToBytes() uses signed types, and uses negative
values as a form of error checking.

This CL updates FifoBuffer to used uint32_t when representing frames and
bytes, and changes the error checking to rely on comparisons rather than
negative values.