### PR TITLE
Add atomic increment to FifoControllers

### DIFF
--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -85,7 +85,7 @@ int32_t FifoBuffer::convertFramesToBytes(int32_t frames) {
 }
 
 int32_t FifoBuffer::read(void *buffer, int32_t numFrames) {
-    uint32_t framesAvailable = mFifo->getFullFramesAvailable();
+    int32_t framesAvailable = mFifo->getFullFramesAvailable();
     int32_t framesToRead = numFrames;
     // Is there enough data in the FIFO
     if (framesToRead > framesAvailable) {
@@ -129,7 +129,7 @@ int32_t FifoBuffer::read(void *buffer, int32_t numFrames) {
 }
 
 int32_t FifoBuffer::write(const void *buffer, int32_t framesToWrite) {
-    uint32_t framesAvailable = mFifo->getEmptyFramesAvailable();
+    int32_t framesAvailable = mFifo->getEmptyFramesAvailable();
     if (framesToWrite > framesAvailable) {
         framesToWrite = framesAvailable;
     }

--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -85,7 +85,7 @@ int32_t FifoBuffer::convertFramesToBytes(int32_t frames) {
 }
 
 int32_t FifoBuffer::read(void *buffer, int32_t numFrames) {
-    int32_t framesAvailable = mFifo->getFullFramesAvailable();
+    uint32_t framesAvailable = mFifo->getFullFramesAvailable();
     int32_t framesToRead = numFrames;
     // Is there enough data in the FIFO
     if (framesToRead > framesAvailable) {
@@ -129,7 +129,7 @@ int32_t FifoBuffer::read(void *buffer, int32_t numFrames) {
 }
 
 int32_t FifoBuffer::write(const void *buffer, int32_t framesToWrite) {
-    int32_t framesAvailable = mFifo->getEmptyFramesAvailable();
+    uint32_t framesAvailable = mFifo->getEmptyFramesAvailable();
     if (framesToWrite > framesAvailable) {
         framesToWrite = framesAvailable;
     }

--- a/src/fifo/FifoController.h
+++ b/src/fifo/FifoController.h
@@ -32,6 +32,7 @@ public:
     FifoController(uint32_t bufferSize, uint32_t threshold);
     virtual ~FifoController() = default;
 
+    // TODO review use atomics or memory barriers
     virtual uint64_t getReadCounter() const override {
         return mReadCounter.load(std::memory_order_acquire);
     }

--- a/src/fifo/FifoController.h
+++ b/src/fifo/FifoController.h
@@ -32,18 +32,23 @@ public:
     FifoController(uint32_t bufferSize, uint32_t threshold);
     virtual ~FifoController() = default;
 
-    // TODO review use atomics or memory barriers
     virtual uint64_t getReadCounter() const override {
         return mReadCounter.load(std::memory_order_acquire);
     }
     virtual void setReadCounter(uint64_t n) override {
         mReadCounter.store(n, std::memory_order_release);
     }
+    virtual void incrementReadCounter(uint64_t n) override {
+        mReadCounter.fetch_add(n, std::memory_order_acq_rel);
+    }
     virtual uint64_t getWriteCounter() const override {
         return mWriteCounter.load(std::memory_order_acquire);
     }
     virtual void setWriteCounter(uint64_t n) override {
         mWriteCounter.store(n, std::memory_order_release);
+    }
+    virtual void incrementWriteCounter(uint64_t n) override {
+        mWriteCounter.fetch_add(n, std::memory_order_acq_rel);
     }
 
 private:

--- a/src/fifo/FifoControllerBase.cpp
+++ b/src/fifo/FifoControllerBase.cpp
@@ -16,7 +16,7 @@
 
 #include "FifoControllerBase.h"
 
-#include <assert.h>
+#include <cassert>
 #include <sys/types.h>
 #include "FifoControllerBase.h"
 

--- a/src/fifo/FifoControllerBase.cpp
+++ b/src/fifo/FifoControllerBase.cpp
@@ -16,7 +16,7 @@
 
 #include "FifoControllerBase.h"
 
-#include <cassert>
+#include <assert.h>
 #include <sys/types.h>
 #include "FifoControllerBase.h"
 
@@ -30,22 +30,22 @@ FifoControllerBase::FifoControllerBase(uint32_t totalFrames, uint32_t threshold)
 {
 }
 
-int32_t FifoControllerBase::getFullFramesAvailable() const {
-    return static_cast<int32_t>(getWriteCounter() - getReadCounter());
+uint32_t FifoControllerBase::getFullFramesAvailable() const {
+    int64_t framesAvailable = getWriteCounter() - getReadCounter();
+    return (framesAvailable < 0) ? 0 : static_cast<uint32_t>(framesAvailable);
 }
 
 uint32_t FifoControllerBase::getReadIndex() const {
     return static_cast<uint32_t>(getReadCounter() % mTotalFrames);
 }
 
-void FifoControllerBase::advanceReadIndex(int numFrames) {
-    setReadCounter(getReadCounter() + numFrames);
+void FifoControllerBase::advanceReadIndex(uint32_t numFrames) {
+    incrementReadCounter(numFrames);
 }
 
-int32_t FifoControllerBase::getEmptyFramesAvailable() const {
-    int32_t fullFramesAvailable = getFullFramesAvailable();
-    int32_t available = static_cast<int32_t>(mThreshold - fullFramesAvailable);
-    return available;
+uint32_t FifoControllerBase::getEmptyFramesAvailable() const {
+    uint32_t fullFramesAvailable = getFullFramesAvailable();
+    return (fullFramesAvailable > mThreshold) ? 0 : (mThreshold - fullFramesAvailable);
 }
 
 uint32_t FifoControllerBase::getWriteIndex() const {
@@ -53,10 +53,11 @@ uint32_t FifoControllerBase::getWriteIndex() const {
 }
 
 void FifoControllerBase::advanceWriteIndex(uint32_t numFrames) {
-    setWriteCounter(getWriteCounter() + numFrames);
+    incrementWriteCounter(numFrames);
 }
 
 void FifoControllerBase::setThreshold(uint32_t threshold) {
+    assert(threshold < mTotalFrames);
     mThreshold = threshold;
 }
 

--- a/src/fifo/FifoControllerBase.cpp
+++ b/src/fifo/FifoControllerBase.cpp
@@ -30,9 +30,8 @@ FifoControllerBase::FifoControllerBase(uint32_t totalFrames, uint32_t threshold)
 {
 }
 
-uint32_t FifoControllerBase::getFullFramesAvailable() const {
-    int64_t framesAvailable = getWriteCounter() - getReadCounter();
-    return (framesAvailable < 0) ? 0 : static_cast<uint32_t>(framesAvailable);
+int32_t FifoControllerBase::getFullFramesAvailable() const {
+    return static_cast<int32_t>(getWriteCounter() - getReadCounter());
 }
 
 uint32_t FifoControllerBase::getReadIndex() const {
@@ -43,9 +42,10 @@ void FifoControllerBase::advanceReadIndex(uint32_t numFrames) {
     incrementReadCounter(numFrames);
 }
 
-uint32_t FifoControllerBase::getEmptyFramesAvailable() const {
-    uint32_t fullFramesAvailable = getFullFramesAvailable();
-    return (fullFramesAvailable > mThreshold) ? 0 : (mThreshold - fullFramesAvailable);
+int32_t FifoControllerBase::getEmptyFramesAvailable() const {
+    int32_t fullFramesAvailable = getFullFramesAvailable();
+    int32_t available = static_cast<int32_t>(mThreshold - fullFramesAvailable);
+    return available;
 }
 
 uint32_t FifoControllerBase::getWriteIndex() const {
@@ -57,7 +57,6 @@ void FifoControllerBase::advanceWriteIndex(uint32_t numFrames) {
 }
 
 void FifoControllerBase::setThreshold(uint32_t threshold) {
-    assert(threshold < mTotalFrames);
     mThreshold = threshold;
 }
 

--- a/src/fifo/FifoControllerBase.h
+++ b/src/fifo/FifoControllerBase.h
@@ -44,9 +44,10 @@ public:
     virtual ~FifoControllerBase() = default;
 
     /**
+     * This may be negative if an unthrottled reader has read beyond the available data.
      * @return number of valid frames available to read. Never read more than this.
      */
-    uint32_t getFullFramesAvailable() const;
+    int32_t getFullFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to read.
@@ -61,7 +62,7 @@ public:
     /**
      * @return number of frames that can be written. Never write more than this.
      */
-    uint32_t getEmptyFramesAvailable() const;
+    int32_t getEmptyFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to write.

--- a/src/fifo/FifoControllerBase.h
+++ b/src/fifo/FifoControllerBase.h
@@ -44,10 +44,9 @@ public:
     virtual ~FifoControllerBase() = default;
 
     /**
-     * This may be negative if an unthrottled reader has read beyond the available data.
      * @return number of valid frames available to read. Never read more than this.
      */
-    int32_t getFullFramesAvailable() const;
+    uint32_t getFullFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to read.
@@ -57,12 +56,12 @@ public:
     /**
      * @param numFrames number of frames to advance the read index
      */
-    void advanceReadIndex(int numFrames);
+    void advanceReadIndex(uint32_t numFrames);
 
     /**
      * @return number of frames that can be written. Never write more than this.
      */
-    int32_t getEmptyFramesAvailable() const;
+    uint32_t getEmptyFramesAvailable() const;
 
     /**
      * The index in a circular buffer of the next frame to write.
@@ -82,8 +81,10 @@ public:
 
     virtual uint64_t getReadCounter() const = 0;
     virtual void setReadCounter(uint64_t n) = 0;
+    virtual void incrementReadCounter(uint64_t n) = 0;
     virtual uint64_t getWriteCounter() const = 0;
     virtual void setWriteCounter(uint64_t n) = 0;
+    virtual void incrementWriteCounter(uint64_t n) = 0;
 
 private:
     uint32_t mTotalFrames;

--- a/src/fifo/FifoControllerIndirect.h
+++ b/src/fifo/FifoControllerIndirect.h
@@ -34,12 +34,14 @@ public:
                            int64_t * writeCounterAddress);
     virtual ~FifoControllerIndirect() = default;
 
-    // TODO review use of memory barriers, probably incorrect
     virtual uint64_t getReadCounter() const override {
         return mReadCounterAddress->load(std::memory_order_acquire);
     }
     virtual void setReadCounter(uint64_t n) override {
         mReadCounterAddress->store(n, std::memory_order_release);
+    }
+    virtual void incrementReadCounter(uint64_t n) override {
+        mReadCounterAddress->fetch_add(n, std::memory_order_acq_rel);
     }
     virtual uint64_t getWriteCounter() const override {
         return mWriteCounterAddress->load(std::memory_order_acquire);
@@ -47,9 +49,11 @@ public:
     virtual void setWriteCounter(uint64_t n) override {
         mWriteCounterAddress->store(n, std::memory_order_release);
     }
+    virtual void incrementWriteCounter(uint64_t n) override {
+        mWriteCounterAddress->fetch_add(n, std::memory_order_acq_rel);
+    }
 
 private:
-
     std::atomic<uint64_t> * mReadCounterAddress;
     std::atomic<uint64_t> * mWriteCounterAddress;
 

--- a/src/fifo/FifoControllerIndirect.h
+++ b/src/fifo/FifoControllerIndirect.h
@@ -34,6 +34,7 @@ public:
                            int64_t * writeCounterAddress);
     virtual ~FifoControllerIndirect() = default;
 
+    // TODO review use of memory barriers, probably incorrect
     virtual uint64_t getReadCounter() const override {
         return mReadCounterAddress->load(std::memory_order_acquire);
     }
@@ -54,6 +55,7 @@ public:
     }
 
 private:
+
     std::atomic<uint64_t> * mReadCounterAddress;
     std::atomic<uint64_t> * mWriteCounterAddress;
 


### PR DESCRIPTION
This CL adds an increment counter methods that allow for atomically
incrementing the read/write indexes, rather than geting the current
index, adding to it and setting it.

Also, getFullFramesAvailable() and getEmptyFramesAvailable() now clamp
negative values to 0.