### PR TITLE
oboe: fix broken build AudioStream.cpp

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -63,7 +63,9 @@ public:
      *
      * @return
      */
-    virtual Result open() = 0;
+    virtual Result open() {
+        return Result::OK; // Called by subclasses. Might do more in the future.
+    }
 
     /**
      * Close the stream and deallocate any resources from the open() call.


### PR DESCRIPTION
An abstract method was breaking the linker stage.

Fixes #582