### PR TITLE
Improve CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_options(oboe
         "$<$<CONFIG:DEBUG>:-Werror>")
 
 # Enable logging for debug builds
-target_compile_definitions(oboe PUBLIC "$<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>")
+target_compile_definitions(oboe PUBLIC $<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>)
 
 target_link_libraries(oboe PRIVATE log OpenSLES)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
+project(oboe)
 
 set (oboe_sources
         src/aaudio/AAudioLoader.cpp
@@ -38,15 +39,21 @@ add_library(oboe ${oboe_sources})
 
 # Specify directories which the compiler should look for headers
 target_include_directories(oboe
-        PRIVATE src
-        PUBLIC include)
+  PRIVATE src
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+set_target_properties(oboe PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS NO)
 
 # Compile Flags:
 #     Enable -Werror when building debug config
 #     Enable -Ofast
 target_compile_options(oboe
         PRIVATE
-        -std=c++14
         -Wall
         -Wextra-semi
         -Wshadow
@@ -55,6 +62,16 @@ target_compile_options(oboe
         "$<$<CONFIG:DEBUG>:-Werror>")
 
 # Enable logging for debug builds
-target_compile_definitions(oboe PUBLIC "$<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>")
+target_compile_definitions(oboe
+  PUBLIC $<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>)
 
-target_link_libraries(oboe PRIVATE log OpenSLES)
+target_link_libraries(oboe
+  PRIVATE log OpenSLES)
+
+include(GNUInstallDirs)
+install(TARGETS oboe
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY include/oboe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,10 @@ target_compile_definitions(oboe PUBLIC "$<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>
 
 target_link_libraries(oboe PRIVATE log OpenSLES)
 
-# TODO: Explain why are these necessary for the `ExternalProject_Add` approach
-include(GNUInstallDirs)
+# When installing oboe put the libraries in the lib/<ABI> folder e.g. lib/arm64-v8a
 install(TARGETS oboe
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        LIBRARY DESTINATION lib/${ANDROID_ABI}
+        ARCHIVE DESTINATION lib/${ANDROID_ABI})
 
-install(DIRECTORY include/oboe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# Also install the headers
+install(DIRECTORY include/oboe DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.4.1)
+
+# Set the name of the project and store it in PROJECT_NAME. Also set the following variables:
+# PROJECT_SOURCE_DIR (usually the root directory where Oboe has been cloned e.g.)
+# PROJECT_BINARY_DIR (usually the containing project's binary directory,
+# e.g. ${OBOE_HOME}/samples/RhythmGame/.externalNativeBuild/cmake/ndkExtractorDebug/x86/oboe-bin)
 project(oboe)
 
 set (oboe_sources
@@ -39,21 +44,15 @@ add_library(oboe ${oboe_sources})
 
 # Specify directories which the compiler should look for headers
 target_include_directories(oboe
-  PRIVATE src
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
-
-set_target_properties(oboe PROPERTIES
-  CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED YES
-  CXX_EXTENSIONS NO)
+        PRIVATE src
+        PUBLIC include)
 
 # Compile Flags:
 #     Enable -Werror when building debug config
 #     Enable -Ofast
 target_compile_options(oboe
         PRIVATE
+        -std=c++14
         -Wall
         -Wextra-semi
         -Wshadow
@@ -62,12 +61,11 @@ target_compile_options(oboe
         "$<$<CONFIG:DEBUG>:-Werror>")
 
 # Enable logging for debug builds
-target_compile_definitions(oboe
-  PUBLIC $<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>)
+target_compile_definitions(oboe PUBLIC "$<$<CONFIG:DEBUG>:OBOE_ENABLE_LOGGING=1>")
 
-target_link_libraries(oboe
-  PRIVATE log OpenSLES)
+target_link_libraries(oboe PRIVATE log OpenSLES)
 
+# TODO: Explain why are these necessary for the `ExternalProject_Add` approach
 include(GNUInstallDirs)
 install(TARGETS oboe
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Allows Oboe to be included as an external project using CMake's `ExternalProject_Add` function. Also adding install targets which places binaries and headers in the following directory structure: 

    CMAKE_INSTALL_PREFIX/
        lib/
             arm64-v8a/liboboe.a
             armeabi-v7a/liboboe.a
             x86/liboboe.a
             x86_64/liboboe.a
        include/
             oboe/<all headers>
             

