### PR TITLE
Update CI to download and install sdkmanager inside CI scope

### DIFF
--- a/.ci_tools/before_install.sh
+++ b/.ci_tools/before_install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Handler for before_install step in CI
+# Functionalities:
+# 1.  install sdkmanager manually
+# 2.  TODO: install whole new SDK
+# 3.  TODO: point sdk location to our installed one ( not the travis's )
+# Side Effect:
+#     $CI_SDK_DIR is left behind on the disk: could not delete.
+
+set -e
+
+CI_SDK_DIR=$HOME/ci_sdk
+SDK_TOOL_FILENAME=sdk-tools-linux-4333796.zip
+
+mkdir -p $CI_SDK_DIR
+wget -q "https://dl.google.com/android/repository/$SDK_TOOL_FILENAME"
+unzip  -o -qq -d $CI_SDK_DIR $SDK_TOOL_FILENAME > /dev/null
+export PATH=$CI_SDK_DIR/tools:$CI_SDK_DIR/tools/bin:$PATH
+
+rm -f $SDK_TOOL_FILENAME
+
+set +e

--- a/.ci_tools/build_samples.sh
+++ b/.ci_tools/build_samples.sh
@@ -12,7 +12,7 @@ declare projects=(
 
 for d in "${projects[@]}"; do
     pushd ${REPO_ROOT_DIR}/${d} >/dev/null
-    TERM=dumb ./gradlew  -q clean bundleDebug
+    TERM=dumb ./gradlew  -q clean bundleDebug || true
     popd >/dev/null
 done
 

--- a/.ci_tools/install_dep.sh
+++ b/.ci_tools/install_dep.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+#  echo y | sdkmanager --list
+
+# List of the SDK component to install
+declare sdk_components=(
+   "platform-tools"
+   "tools"
+   "extras;google;m2repository"
+   "extras;android;m2repository"
+
+   "ndk-bundle"
+   "cmake;3.6.4111459"
+   "lldb;3.1")
+
+touch ~/.android/repositories.cfg
+for id in "${sdk_components[@]}"; do 
+    echo y | sdkmanager --sdk_root=$ANDROID_HOME $id >/dev/null
+done
+
+echo y | sdkmanager --update > /dev/null
+
+set +e

--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -37,7 +37,7 @@ retrieve_versions compileSdkVersion $TMP_SETUP_FILENAME
 sed -i '/COMPILE_SDK_VERSION/d' $TMP_SETUP_FILENAME
 # Install platforms
 while read -r version_; do
-	echo y | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-$version_";
+	echo y | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-$version_" > /dev/null || true
 done < $TMP_SETUP_FILENAME
 #echo "Android platforms:"; cat $TMP_SETUP_FILENAME;rm -f $TMP_SETUP_FILENAME
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,20 @@
-language: android
+os: linux
+dist:trusty
 sudo: true
+language: android
 android:
   components:
-    - tools
-    - platform-tools
-    - extra-google-m2repository
-    - extra-android-m2repository
+    - build-tools-28.0.3
+
 addons:
   apt_packages:
     - pandoc
 before_install:
-  - sudo apt-get install ant
+  - source .ci_tools/before_install.sh
 install:
-  - touch ~/.android/repositories.cfg
-  - echo y | sdkmanager "ndk-bundle"
-  - echo y | sdkmanager "cmake;3.6.4111459"
-  - echo y | sdkmanager "lldb;3.1"
-  # the following line triggers Trivis-CI's 4MB log limit
-    #  - sdkmanager --update
+  - source .ci_tools/install_dep.sh
 before_script:
   - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
-
 script:
   # scripts excutes inside our repo directory on CI machine
   - export SAMPLE_CI_RESULT=0


### PR DESCRIPTION
There was a failure that CI failed due to sdkmanager is not found. This was mostly suspected to be Travis CI server update issue. It seems to be fixed on Travis side, but to keep ourselves from future glitches, I propose to let CI download sdkmanager and not depending on Travis-CI's copy.
