### PR TITLE
samples: build.gradle: Update to Gradle v5.4.1 and Gradle plugin v3.5.0

### DIFF
--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/samples/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/samples/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 21 09:55:30 PDT 2019
+#Mon Sep 16 13:43:25 MMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
We should update current latest Gradle version and Android Gradle plugin version for Oboe android samples.
Updated current latest version:
 Gradle version - 5.4.1
 Android Gradle plugin version - 3.5.0
