### PR TITLE
oboe: change default buffer sizes for INPUT

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 2
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 1
+#define OBOE_VERSION_PATCH 2
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -156,7 +156,7 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
             // run close to empty. And a low size can result in XRuns so always use the maximum.
             optimalBufferSize = streamP->getBufferCapacityInFrames();
         } else if (streamP->getPerformanceMode() == PerformanceMode::LowLatency
-                && streamP->getDirection() == Direction::Output)  { // // output check is redundant
+                && streamP->getDirection() == Direction::Output)  { // Output check is redundant.
             optimalBufferSize = streamP->getFramesPerBurst() *
                                     kBufferSizeInBurstsForLowLatencyStreams;
         }


### PR DESCRIPTION
Fixes #655
Bump Oboe version to 1.2.1