### PR TITLE
oboe: use bigger burst in OpenSL ES

### DIFF
--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -163,7 +163,7 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
         if (optimalBufferSize >= 0) {
             auto setBufferResult = streamP->setBufferSizeInFrames(optimalBufferSize);
             if (!setBufferResult) {
-                LOGW("Failed to set buffer size to %d. Error was %s",
+                LOGW("Failed to setBufferSizeInFrames(%d). Error was %s",
                      optimalBufferSize,
                      convertToText(setBufferResult.error()));
             }

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -196,12 +196,17 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
+    oboeResult = configureBufferSizes();
+    if (Result::OK != oboeResult) {
+        goto error;
+    }
+
     allocateFifo();
 
     setState(StreamState::Open);
     return Result::OK;
 
-    error:
+error:
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE
 }
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -221,10 +221,16 @@ Result AudioOutputStreamOpenSLES::open() {
         goto error;
     }
 
+    oboeResult = configureBufferSizes();
+    if (Result::OK != oboeResult) {
+        goto error;
+    }
+
     allocateFifo();
 
     setState(StreamState::Open);
     return Result::OK;
+
 error:
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE
 }

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -24,7 +24,7 @@
 namespace oboe {
 
 constexpr int kDefaultBurstsPerBuffer = 16;  // arbitrary, allows dynamic latency tuning
-
+constexpr int kMinFramesPerBuffer     = 48 * 32; // arbitrary
 /*
  * AudioStream with a FifoBuffer
  */
@@ -37,13 +37,14 @@ void AudioStreamBuffered::allocateFifo() {
     // callback that reads data from the FIFO.
     if (usingFIFO()) {
         // FIFO is configured with the same format and channels as the stream.
-        int32_t capacity = getBufferCapacityInFrames();
-        if (capacity == oboe::kUnspecified) {
-            capacity = getFramesPerBurst() * kDefaultBurstsPerBuffer;
-            mBufferCapacityInFrames = capacity;
+        int32_t capacityFrames = getBufferCapacityInFrames();
+        if (capacityFrames == oboe::kUnspecified) {
+            capacityFrames = getFramesPerBurst() * kDefaultBurstsPerBuffer;
         }
+        capacityFrames = std::max(kMinFramesPerBuffer, capacityFrames);
         // TODO consider using std::make_unique if we require c++14
-        mFifoBuffer.reset(new FifoBuffer(getBytesPerFrame(), capacity));
+        mFifoBuffer.reset(new FifoBuffer(getBytesPerFrame(), capacityFrames));
+        mBufferCapacityInFrames = capacityFrames;
     }
 }
 
@@ -72,6 +73,8 @@ DataCallbackResult AudioStreamBuffered::onDefaultCallback(void *audioData, int n
     }
 
     if (framesTransferred < numFrames) {
+        LOGD("AudioStreamBuffered::%s(): xrun! framesTransferred = %d, numFrames = %d",
+                __func__, framesTransferred, numFrames);
         // TODO If we do not allow FIFO to wrap then our timestamps will drift when there is an XRun!
         incrementXRunCount();
     }

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -100,6 +100,9 @@ protected:
     PerformanceMode convertPerformanceMode(SLuint32 openslMode) const;
     SLuint32 convertPerformanceMode(PerformanceMode oboeMode) const;
 
+
+    Result configureBufferSizes();
+
     /**
      * Internal use only.
      * Use this instead of directly setting the internal state variable.


### PR DESCRIPTION
If we do not get a low latency stream, then use a bigger burst.
We were getting a 96 frame burst on some devices without a FAST track,
which is too small.