### PR TITLE
Oboetester: do not reset full duplex analyzer

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,9 @@ android {
         applicationId = "com.google.sample.oboe.manualtest"
         minSdkVersion 25
         targetSdkVersion 28
-        versionCode 23
-        versionName "1.5.15"
+        // Also update the version in the AndroidManifest.xml file.
+        versionCode 24
+        versionName "1.5.16"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="23"
-    android:versionName="1.5.15">
+    android:versionCode="24"
+    android:versionName="1.5.16">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
@@ -48,16 +48,17 @@ oboe::DataCallbackResult FullDuplexAnalyzer::onBothStreamsReady(
             inputFloat += inputStride;
             mRecording->write(buffer, 1);
         }
+        // Handle mismatch in in numFrames.
+        buffer[0] = 0.0f; // gap in output
         for (int i = numBoth; i < numInputFrames; i++) {
-            buffer[0] = 0.0f; // gap
             buffer[1] = *inputFloat;
             inputFloat += inputStride;
             mRecording->write(buffer, 1);
         }
+        buffer[1] = 0.0f; // gap in input
         for (int i = numBoth; i < numOutputFrames; i++) {
             buffer[0] = *outputFloat;
             outputFloat += outputStride;
-            buffer[1] = 0.0f; // gap
             mRecording->write(buffer, 1);
         }
     }

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
@@ -31,44 +31,33 @@ oboe::DataCallbackResult FullDuplexAnalyzer::onBothStreamsReady(
 
     int32_t inputStride = getInputStream()->getChannelCount();
     int32_t outputStride = getOutputStream()->getChannelCount();
+    float *inputFloat = (float *) inputData;
+    float *outputFloat = (float *) outputData;
 
-    // TODO Pull up into superclass
-    // reset analyzer if we miss some input data
-    if (numInputFrames < numOutputFrames) {
-        LOGD("numInputFrames (%4d) < numOutputFrames (%4d) so reset analyzer",
-             numInputFrames, numOutputFrames);
-        getLoopbackProcessor()->onInsufficientRead();
-    } else {
-        float *inputFloat = (float *) inputData;
-        float *outputFloat = (float *) outputData;
+    (void) getLoopbackProcessor()->process(inputFloat, inputStride, numInputFrames,
+                                   outputFloat, outputStride, numOutputFrames);
 
-        (void) getLoopbackProcessor()->process(inputFloat, inputStride,
-                                       outputFloat, outputStride,
-                                       numOutputFrames);
-
-        // zero out remainder of output array
-        int32_t framesLeft = numOutputFrames - numInputFrames;
-        outputFloat += numOutputFrames * outputStride;
-
-        if (framesLeft > 0) {
-            memset(outputFloat, 0, framesLeft * getOutputStream()->getBytesPerFrame());
-        }
-    }
-
-    // write the first channel of output and input to the recorder
+    // write the first channel of output and input to the stereo recorder
     if (mRecording != nullptr) {
         float buffer[2];
-        float *inputFloat = (float *) inputData;
-        float *outputFloat = (float *) outputData;
-        for (int i = 0; i < numOutputFrames; i++) {
+        int numBoth = std::min(numInputFrames, numOutputFrames);
+        for (int i = 0; i < numBoth; i++) {
             buffer[0] = *outputFloat;
             outputFloat += outputStride;
-            if (i < numInputFrames) {
-                buffer[1] = *inputFloat;
-                inputFloat += inputStride;
-            } else {
-                buffer[1] = 0.0f;
-            }
+            buffer[1] = *inputFloat;
+            inputFloat += inputStride;
+            mRecording->write(buffer, 1);
+        }
+        for (int i = numBoth; i < numInputFrames; i++) {
+            buffer[0] = 0.0f; // gap
+            buffer[1] = *inputFloat;
+            inputFloat += inputStride;
+            mRecording->write(buffer, 1);
+        }
+        for (int i = numBoth; i < numOutputFrames; i++) {
+            buffer[0] = *outputFloat;
+            outputFloat += outputStride;
+            buffer[1] = 0.0f; // gap
             mRecording->write(buffer, 1);
         }
     }

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexStream.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexStream.cpp
@@ -85,9 +85,6 @@ oboe::DataCallbackResult FullDuplexStream::onAudioReady(
                     callbackResult = oboe::DataCallbackResult::Stop;
                 } else {
                     framesRead = resultRead.value();
-                    if (framesRead != numFrames) {
-                        LOGE("glitch, framesRead = %d, numFrames = %d", framesRead, numFrames);
-                    }
                 }
             }
         }

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexStream.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexStream.cpp
@@ -85,6 +85,9 @@ oboe::DataCallbackResult FullDuplexStream::onAudioReady(
                     callbackResult = oboe::DataCallbackResult::Stop;
                 } else {
                     framesRead = resultRead.value();
+                    if (framesRead != numFrames) {
+                        LOGE("glitch, framesRead = %d, numFrames = %d", framesRead, numFrames);
+                    }
                 }
             }
         }

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -512,7 +512,7 @@ public:
         }
     }
 
-    virtual FullDuplexAnalyzer *getFullDuplexAnalyzer() override {
+    FullDuplexAnalyzer *getFullDuplexAnalyzer() override {
         return (FullDuplexAnalyzer *) mFullDuplexEcho.get();
     }
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  */
 public class RoundTripLatencyActivity extends AnalyzerActivity {
 
-    private static final int STATE_GOT_DATA = 3; // Defined in LatencyAnalyzer.h
+    private static final int STATE_GOT_DATA = 2; // Defined in LatencyAnalyzer.h
 
     private TextView mAnalyzerView;
     private Button mMeasureButton;


### PR DESCRIPTION
Keep analysing even if we do not read the desired number of frames.
This will allow glitch detection and latency measurement when combining
streams with very different burst sizes.

Fixes #485
Fixes #618