### PR TITLE
oboe: make sure OpenSL ES buffer capacity is OK

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 2
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 2
+#define OBOE_VERSION_PATCH 3
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)


### PR DESCRIPTION
Round it up to some number of bursts.
This may fix some glitching when doing blocking I/O.