### PR TITLE
OboeTester: use FLOAT for Analyzer

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 25
         targetSdkVersion 28
         // Also update the version in the AndroidManifest.xml file.
-        versionCode 24
-        versionName "1.5.16"
+        versionCode 25
+        versionName "1.5.17"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="24"
-    android:versionName="1.5.16">
+    android:versionCode="25"
+    android:versionName="1.5.17">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AnalyzerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AnalyzerActivity.java
@@ -127,6 +127,21 @@ public class AnalyzerActivity extends TestInputActivity {
     protected void resetConfiguration() {
         super.resetConfiguration();
         mAudioOutTester.reset();
+
+        StreamContext streamContext = getFirstInputStreamContext();
+        if (streamContext != null) {
+            if (streamContext.configurationView != null) {
+                streamContext.configurationView.setFormat(StreamConfiguration.AUDIO_FORMAT_PCM_FLOAT);
+                streamContext.configurationView.setFormatConversionAllowed(true);
+            }
+        }
+        streamContext = getFirstOutputStreamContext();
+        if (streamContext != null) {
+            if (streamContext.configurationView != null) {
+                streamContext.configurationView.setFormat(StreamConfiguration.AUDIO_FORMAT_PCM_FLOAT);
+                streamContext.configurationView.setFormatConversionAllowed(true);
+            }
+        }
     }
 
     public void startAudio() {

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/StreamConfiguration.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/StreamConfiguration.java
@@ -314,7 +314,9 @@ public class StreamConfiguration {
         return mChannelConversionAllowed;
     }
 
-    public void setFormatConversionAllowed(boolean b) { mFormatConversionAllowed = b; }
+    public void setFormatConversionAllowed(boolean b) {
+        mFormatConversionAllowed = b;
+    }
 
     public boolean getFormatConversionAllowed() {
         return mFormatConversionAllowed;

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/StreamConfigurationView.java
@@ -433,7 +433,6 @@ public class StreamConfigurationView extends LinearLayout {
             mRateConversionQualitySpinner.setSelection(configuration.getRateConversionQuality());
             mChannelConversionBox.setChecked(configuration.getChannelConversionAllowed());
             mFormatConversionBox.setChecked(configuration.getFormatConversionAllowed());
-            mRateConversionQualitySpinner.setSelection(configuration.getRateConversionQuality());
         }
     }
 
@@ -449,5 +448,15 @@ public class StreamConfigurationView extends LinearLayout {
         mRequestedConfiguration.setSharingMode(b
                 ? StreamConfiguration.SHARING_MODE_EXCLUSIVE
                 : StreamConfiguration.SHARING_MODE_SHARED);
+    }
+
+    public void setFormat(int format) {
+        mFormatSpinner.setSelection(format); // position matches format
+        mRequestedConfiguration.setFormat(format);
+    }
+
+    public void setFormatConversionAllowed(boolean allowed) {
+        mFormatConversionBox.setChecked(allowed);
+        mRequestedConfiguration.setFormatConversionAllowed(allowed);
     }
 }


### PR DESCRIPTION
Set defaults to FLOAT format and FLoatFormatConversionAllowed(true).
This fixes the problem where OpenSL ES will not get a LOW Latency
stream for input.
Then the glitch and latency tests may fail.