### PR TITLE
oboe: renamed flowgraph classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set (oboe_sources
     src/fifo/FifoController.cpp
     src/fifo/FifoControllerBase.cpp
     src/fifo/FifoControllerIndirect.cpp
-    src/flowgraph/AudioProcessorBase.cpp
+        src/flowgraph/FlowGraphNode.cpp
     src/flowgraph/ClipToRange.cpp
     src/flowgraph/ManyToMultiConverter.cpp
     src/flowgraph/MonoToMultiConverter.cpp

--- a/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.h
+++ b/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.h
@@ -19,7 +19,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "oboe/Oboe.h"
 
 using namespace flowgraph;
@@ -34,7 +34,7 @@ public:
 //    AudioStreamGateway(int samplesPerFrame);
     virtual ~AudioStreamGateway() = default;
 
-    void setAudioSink(std::shared_ptr<flowgraph::AudioSink>  sink) {
+    void setAudioSink(std::shared_ptr<flowgraph::FlowGraphSink>  sink) {
         mAudioSink = sink;
         mFramePosition = sink->getLastFramePosition();
     }
@@ -53,7 +53,7 @@ private:
     int64_t  mFramePosition = 0;
     bool     mSchedulerChecked = false;
     int      mScheduler;
-    std::shared_ptr<flowgraph::AudioSink>  mAudioSink;
+    std::shared_ptr<flowgraph::FlowGraphSink>  mAudioSink;
 };
 
 

--- a/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.h
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-// TODO #include "flowgraph/AudioProcessorBase.h"
+// TODO #include "flowgraph/FlowGraph.h"
 #include "oboe/Oboe.h"
 #include "MultiChannelRecording.h"
 #include "PeakDetector.h"

--- a/apps/OboeTester/app/src/main/cpp/SawPingGenerator.h
+++ b/apps/OboeTester/app/src/main/cpp/SawPingGenerator.h
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "flowunits/OscillatorBase.h"
 
 class SawPingGenerator : public OscillatorBase {

--- a/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.cpp
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.cpp
@@ -19,7 +19,7 @@
 #include "ExponentialShape.h"
 
 ExponentialShape::ExponentialShape()
-        : AudioFilter(1) {
+        : FlowGraphFilter(1) {
 }
 
 int32_t ExponentialShape::onProcess(int32_t numFrames) {

--- a/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.h
@@ -18,14 +18,14 @@
 #ifndef OBOETESTER_EXPONENTIAL_SHAPE_H
 #define OBOETESTER_EXPONENTIAL_SHAPE_H
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 
 /**
  * Generate a exponential sweep between min and max.
  *
  * The waveform is not band-limited so it will have aliasing artifacts at higher frequencies.
  */
-class ExponentialShape : public flowgraph::AudioFilter {
+class ExponentialShape : public flowgraph::FlowGraphFilter {
 public:
     ExponentialShape();
 

--- a/apps/OboeTester/app/src/main/cpp/flowunits/ImpulseOscillator.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/ImpulseOscillator.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "OscillatorBase.h"
 
 /**

--- a/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.cpp
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.cpp
@@ -20,7 +20,7 @@
 using namespace flowgraph;
 
 LinearShape::LinearShape()
-        : AudioFilter(1) {
+        : FlowGraphFilter(1) {
 }
 
 int32_t LinearShape::onProcess(int numFrames) {

--- a/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.h
@@ -18,12 +18,12 @@
 #ifndef OBOETESTER_LINEAR_SHAPE_H
 #define OBOETESTER_LINEAR_SHAPE_H
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 
 /**
  * Convert an input between -1.0 and +1.0 to a linear region between min and max.
  */
-class LinearShape : public flowgraph::AudioFilter {
+class LinearShape : public flowgraph::FlowGraphFilter {
 public:
     LinearShape();
 

--- a/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.h
@@ -17,7 +17,7 @@
 #ifndef NATIVEOBOE_OSCILLATORBASE_H
 #define NATIVEOBOE_OSCILLATORBASE_H
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 
 /**
  * Base class for various oscillators.
@@ -29,7 +29,7 @@
  * This module has "frequency" and "amplitude" ports for control.
  */
 
-class OscillatorBase : public flowgraph::AudioProcessorBase {
+class OscillatorBase : public flowgraph::FlowGraphNode {
 public:
     OscillatorBase();
 
@@ -61,16 +61,16 @@ public:
     /**
      * Control the frequency of the oscillator in Hz.
      */
-    flowgraph::AudioFloatInputPort  frequency;
+    flowgraph::FlowGraphPortFloatInput  frequency;
 
     /**
      * Control the linear amplitude of the oscillator.
      * Silence is 0.0.
      * A typical full amplitude would be 1.0.
      */
-    flowgraph::AudioFloatInputPort  amplitude;
+    flowgraph::FlowGraphPortFloatInput  amplitude;
 
-    flowgraph::AudioFloatOutputPort output;
+    flowgraph::FlowGraphPortFloatOutput output;
 
 protected:
     /**

--- a/src/common/AudioSourceCaller.h
+++ b/src/common/AudioSourceCaller.h
@@ -20,7 +20,7 @@
 #include "OboeDebug.h"
 #include "oboe/Oboe.h"
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "FixedBlockReader.h"
 
 namespace oboe {
@@ -32,10 +32,10 @@ class AudioStream;
  * For output streams that use a callback, call the application for more data.
  * For input streams that do not use a callback, read from the stream.
  */
-class AudioSourceCaller : public flowgraph::AudioSource, public FixedBlockProcessor {
+class AudioSourceCaller : public flowgraph::FlowGraphSource, public FixedBlockProcessor {
 public:
     AudioSourceCaller(int32_t channelCount, int32_t framesPerCallback, int32_t bytesPerSample)
-            : AudioSource(channelCount)
+            : FlowGraphSource(channelCount)
             , mBlockReader(*this) {
         mBlockReader.open(channelCount * framesPerCallback * bytesPerSample);
     }

--- a/src/common/DataConversionFlowGraph.cpp
+++ b/src/common/DataConversionFlowGraph.cpp
@@ -72,7 +72,7 @@ static MultiChannelResampler::Quality convertOboeSRQualityToMCR(SampleRateConver
 //
 Result DataConversionFlowGraph::configure(AudioStream *sourceStream, AudioStream *sinkStream) {
 
-    AudioFloatOutputPort *lastOutput = nullptr;
+    FlowGraphPortFloatOutput *lastOutput = nullptr;
 
     bool isOutput = sourceStream->getDirection() == Direction::Output;
     mFilterStream = isOutput ? sourceStream : sinkStream;

--- a/src/common/DataConversionFlowGraph.h
+++ b/src/common/DataConversionFlowGraph.h
@@ -65,12 +65,12 @@ public:
     }
 
 private:
-    std::unique_ptr<flowgraph::AudioSourceBuffered>    mSource;
+    std::unique_ptr<flowgraph::FlowGraphSourceBuffered>    mSource;
     std::unique_ptr<AudioSourceCaller>                 mSourceCaller;
     std::unique_ptr<flowgraph::MonoToMultiConverter>   mChannelConverter;
     std::unique_ptr<resampler::MultiChannelResampler>  mResampler;
     std::unique_ptr<flowgraph::SampleRateConverter>    mRateConverter;
-    std::unique_ptr<flowgraph::AudioSink>              mSink;
+    std::unique_ptr<flowgraph::FlowGraphSink>              mSink;
 
     FixedBlockWriter                                   mBlockWriter;
     DataCallbackResult                                 mCallbackResult = DataCallbackResult::Continue;

--- a/src/common/SourceFloatCaller.cpp
+++ b/src/common/SourceFloatCaller.cpp
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 #include <unistd.h>
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "SourceFloatCaller.h"
 
 using namespace oboe;

--- a/src/common/SourceFloatCaller.h
+++ b/src/common/SourceFloatCaller.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "AudioSourceCaller.h"
 #include "FixedBlockReader.h"
 

--- a/src/common/SourceI16Caller.cpp
+++ b/src/common/SourceI16Caller.cpp
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 #include <unistd.h>
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "SourceI16Caller.h"
 
 #if FLOWGRAPH_ANDROID_INTERNAL

--- a/src/common/SourceI16Caller.h
+++ b/src/common/SourceI16Caller.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "flowgraph/AudioProcessorBase.h"
+#include "flowgraph/FlowGraphNode.h"
 #include "AudioSourceCaller.h"
 #include "FixedBlockReader.h"
 

--- a/src/flowgraph/ClipToRange.cpp
+++ b/src/flowgraph/ClipToRange.cpp
@@ -16,13 +16,13 @@
 
 #include <algorithm>
 #include <unistd.h>
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "ClipToRange.h"
 
 using namespace flowgraph;
 
 ClipToRange::ClipToRange(int32_t channelCount)
-        : AudioFilter(channelCount) {
+        : FlowGraphFilter(channelCount) {
 }
 
 int32_t ClipToRange::onProcess(int32_t numFrames) {

--- a/src/flowgraph/ClipToRange.h
+++ b/src/flowgraph/ClipToRange.h
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
@@ -30,7 +30,7 @@ namespace flowgraph {
 constexpr float kDefaultMaxHeadroom = 1.41253754f;
 constexpr float kDefaultMinHeadroom = -kDefaultMaxHeadroom;
 
-class ClipToRange : public AudioFilter {
+class ClipToRange : public FlowGraphFilter {
 public:
     explicit ClipToRange(int32_t channelCount);
 

--- a/src/flowgraph/ManyToMultiConverter.cpp
+++ b/src/flowgraph/ManyToMultiConverter.cpp
@@ -24,7 +24,7 @@ ManyToMultiConverter::ManyToMultiConverter(int32_t channelCount)
         : inputs(channelCount)
         , output(*this, channelCount) {
     for (int i = 0; i < channelCount; i++) {
-        inputs[i] = std::make_unique<AudioFloatInputPort>(*this, 1);
+        inputs[i] = std::make_unique<FlowGraphPortFloatInput>(*this, 1);
     }
 }
 

--- a/src/flowgraph/ManyToMultiConverter.h
+++ b/src/flowgraph/ManyToMultiConverter.h
@@ -21,12 +21,12 @@
 #include <sys/types.h>
 #include <vector>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 /**
  * Combine multiple mono inputs into one interleaved multi-channel output.
  */
-class ManyToMultiConverter : public flowgraph::AudioProcessorBase {
+class ManyToMultiConverter : public flowgraph::FlowGraphNode {
 public:
     explicit ManyToMultiConverter(int32_t channelCount);
 
@@ -36,8 +36,8 @@ public:
 
     void setEnabled(bool enabled) {}
 
-    std::vector<std::unique_ptr<flowgraph::AudioFloatInputPort>> inputs;
-    flowgraph::AudioFloatOutputPort output;
+    std::vector<std::unique_ptr<flowgraph::FlowGraphPortFloatInput>> inputs;
+    flowgraph::FlowGraphPortFloatOutput output;
 
     const char *getName() override {
         return "ManyToMultiConverter";

--- a/src/flowgraph/MonoToMultiConverter.cpp
+++ b/src/flowgraph/MonoToMultiConverter.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <unistd.h>
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "MonoToMultiConverter.h"
 
 using namespace flowgraph;

--- a/src/flowgraph/MonoToMultiConverter.h
+++ b/src/flowgraph/MonoToMultiConverter.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
@@ -28,7 +28,7 @@ namespace flowgraph {
  * Convert a monophonic stream to a multi-channel stream
  * with the same signal on each channel.
  */
-class MonoToMultiConverter : public AudioProcessorBase {
+class MonoToMultiConverter : public FlowGraphNode {
 public:
     explicit MonoToMultiConverter(int32_t channelCount);
 
@@ -40,8 +40,8 @@ public:
         return "MonoToMultiConverter";
     }
 
-    AudioFloatInputPort input;
-    AudioFloatOutputPort output;
+    FlowGraphPortFloatInput input;
+    FlowGraphPortFloatOutput output;
 };
 
 } /* namespace flowgraph */

--- a/src/flowgraph/RampLinear.cpp
+++ b/src/flowgraph/RampLinear.cpp
@@ -16,13 +16,13 @@
 
 #include <algorithm>
 #include <unistd.h>
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "RampLinear.h"
 
 using namespace flowgraph;
 
 RampLinear::RampLinear(int32_t channelCount)
-        : AudioFilter(channelCount) {
+        : FlowGraphFilter(channelCount) {
     mTarget.store(1.0f);
 }
 

--- a/src/flowgraph/RampLinear.h
+++ b/src/flowgraph/RampLinear.h
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
@@ -33,7 +33,7 @@ namespace flowgraph {
  * The target may be updated while a ramp is in progress, which will trigger
  * a new ramp from the current value.
  */
-class RampLinear : public AudioFilter {
+class RampLinear : public FlowGraphFilter {
 public:
     explicit RampLinear(int32_t channelCount);
 

--- a/src/flowgraph/SampleRateConverter.cpp
+++ b/src/flowgraph/SampleRateConverter.cpp
@@ -20,7 +20,7 @@ using namespace flowgraph;
 using namespace resampler;
 
 SampleRateConverter::SampleRateConverter(int32_t channelCount, MultiChannelResampler &resampler)
-        : AudioFilter(channelCount)
+        : FlowGraphFilter(channelCount)
         , mResampler(resampler) {
     setDataPulledAutomatically(false);
 }

--- a/src/flowgraph/SampleRateConverter.h
+++ b/src/flowgraph/SampleRateConverter.h
@@ -20,12 +20,12 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "resampler/MultiChannelResampler.h"
 
 namespace flowgraph {
 
-class SampleRateConverter : public AudioFilter {
+class SampleRateConverter : public FlowGraphFilter {
 public:
     explicit SampleRateConverter(int32_t channelCount, resampler::MultiChannelResampler &mResampler);
 

--- a/src/flowgraph/SinkFloat.cpp
+++ b/src/flowgraph/SinkFloat.cpp
@@ -16,13 +16,13 @@
 
 #include <algorithm>
 #include <unistd.h>
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "SinkFloat.h"
 
 using namespace flowgraph;
 
 SinkFloat::SinkFloat(int32_t channelCount)
-        : AudioSink(channelCount) {
+        : FlowGraphSink(channelCount) {
 }
 
 int32_t SinkFloat::read(int64_t framePosition, void *data, int32_t numFrames) {

--- a/src/flowgraph/SinkFloat.h
+++ b/src/flowgraph/SinkFloat.h
@@ -21,14 +21,14 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
 /**
  * AudioSink that lets you read data as 32-bit floats.
  */
-class SinkFloat : public AudioSink {
+class SinkFloat : public FlowGraphSink {
 public:
     explicit SinkFloat(int32_t channelCount);
 

--- a/src/flowgraph/SinkI16.cpp
+++ b/src/flowgraph/SinkI16.cpp
@@ -26,7 +26,7 @@
 using namespace flowgraph;
 
 SinkI16::SinkI16(int32_t channelCount)
-        : AudioSink(channelCount) {}
+        : FlowGraphSink(channelCount) {}
 
 int32_t SinkI16::read(int64_t framePosition, void *data, int32_t numFrames) {
     int16_t *shortData = (int16_t *) data;

--- a/src/flowgraph/SinkI16.h
+++ b/src/flowgraph/SinkI16.h
@@ -20,14 +20,14 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
 /**
  * AudioSink that lets you read data as 16-bit signed integers.
  */
-class SinkI16 : public AudioSink {
+class SinkI16 : public FlowGraphSink {
 public:
     explicit SinkI16(int32_t channelCount);
 

--- a/src/flowgraph/SinkI24.cpp
+++ b/src/flowgraph/SinkI24.cpp
@@ -18,7 +18,7 @@
 #include <unistd.h>
 
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "SinkI24.h"
 
 #if FLOWGRAPH_ANDROID_INTERNAL
@@ -28,7 +28,7 @@
 using namespace flowgraph;
 
 SinkI24::SinkI24(int32_t channelCount)
-        : AudioSink(channelCount) {}
+        : FlowGraphSink(channelCount) {}
 
 int32_t SinkI24::read(int64_t framePosition, void *data, int32_t numFrames) {
     uint8_t *byteData = (uint8_t *) data;

--- a/src/flowgraph/SinkI24.h
+++ b/src/flowgraph/SinkI24.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
@@ -28,7 +28,7 @@ namespace flowgraph {
  * AudioSink that lets you read data as packed 24-bit signed integers.
  * The sample size is 3 bytes.
  */
-class SinkI24 : public AudioSink {
+class SinkI24 : public FlowGraphSink {
 public:
     explicit SinkI24(int32_t channelCount);
 

--- a/src/flowgraph/SourceFloat.cpp
+++ b/src/flowgraph/SourceFloat.cpp
@@ -17,13 +17,13 @@
 #include "common/OboeDebug.h"
 #include <algorithm>
 #include <unistd.h>
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "SourceFloat.h"
 
 using namespace flowgraph;
 
 SourceFloat::SourceFloat(int32_t channelCount)
-        : AudioSourceBuffered(channelCount) {
+        : FlowGraphSourceBuffered(channelCount) {
 }
 
 int32_t SourceFloat::onProcess(int32_t numFrames) {

--- a/src/flowgraph/SourceFloat.h
+++ b/src/flowgraph/SourceFloat.h
@@ -20,14 +20,14 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
 /**
  * AudioSource that reads a block of pre-defined float data.
  */
-class SourceFloat : public AudioSourceBuffered {
+class SourceFloat : public FlowGraphSourceBuffered {
 public:
     explicit SourceFloat(int32_t channelCount);
 

--- a/src/flowgraph/SourceI16.cpp
+++ b/src/flowgraph/SourceI16.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <unistd.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "SourceI16.h"
 
 #if FLOWGRAPH_ANDROID_INTERNAL
@@ -27,7 +27,7 @@
 using namespace flowgraph;
 
 SourceI16::SourceI16(int32_t channelCount)
-        : AudioSourceBuffered(channelCount) {
+        : FlowGraphSourceBuffered(channelCount) {
 }
 
 int32_t SourceI16::onProcess(int32_t numFrames) {

--- a/src/flowgraph/SourceI16.h
+++ b/src/flowgraph/SourceI16.h
@@ -20,13 +20,13 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 /**
  * AudioSource that reads a block of pre-defined 16-bit integer data.
  */
-class SourceI16 : public AudioSourceBuffered {
+class SourceI16 : public FlowGraphSourceBuffered {
 public:
     explicit SourceI16(int32_t channelCount);
 

--- a/src/flowgraph/SourceI24.cpp
+++ b/src/flowgraph/SourceI24.cpp
@@ -21,7 +21,7 @@
 #include <audio_utils/primitives.h>
 #endif
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 #include "SourceI24.h"
 
 using namespace flowgraph;
@@ -29,7 +29,7 @@ using namespace flowgraph;
 constexpr int kBytesPerI24Packed = 3;
 
 SourceI24::SourceI24(int32_t channelCount)
-        : AudioSourceBuffered(channelCount) {
+        : FlowGraphSourceBuffered(channelCount) {
 }
 
 int32_t SourceI24::onProcess(int32_t numFrames) {

--- a/src/flowgraph/SourceI24.h
+++ b/src/flowgraph/SourceI24.h
@@ -20,14 +20,14 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "AudioProcessorBase.h"
+#include "FlowGraphNode.h"
 
 namespace flowgraph {
 
 /**
  * AudioSource that reads a block of pre-defined 24-bit packed integer data.
  */
-class SourceI24 : public AudioSourceBuffered {
+class SourceI24 : public FlowGraphSourceBuffered {
 public:
     explicit SourceI24(int32_t channelCount);
 


### PR DESCRIPTION
AudioProcessorBase to FlowGraphNode
AudioInputPort to FlowGraphPortInput
etcetera

There should be no change in functionality with this commit.

Fixes #653 