### PR TITLE
oboe: bump OpenSL framesPerBurst by version

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 2
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 3
+#define OBOE_VERSION_PATCH 4
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -101,9 +101,13 @@ Result AudioStreamOpenSLES::configureBufferSizes() {
         mFramesPerBurst = DefaultStreamValues::FramesPerBurst;
     }
     // For high latency streams, use a larger buffer size.
-    if (mPerformanceMode != PerformanceMode::LowLatency
+    // Performance Mode support was added in N_MR1 (7.1)
+    if (getSdkVersion() >= __ANDROID_API_N_MR1__
+        && mPerformanceMode != PerformanceMode::LowLatency
         && mFramesPerBurst < kFramesPerHighLatencyBurst) {
-        mFramesPerBurst = kFramesPerHighLatencyBurst;
+        // Find a multiple of framesPerBurst >= kFramesPerHighLatencyBurst.
+        int32_t numBursts = (kFramesPerHighLatencyBurst + mFramesPerBurst - 1) / mFramesPerBurst;
+        mFramesPerBurst *= numBursts;
         LOGD("AudioStreamOpenSLES:%s() NOT low latency, set mFramesPerBurst = %d",
              __func__, mFramesPerBurst);
     }


### PR DESCRIPTION
Only increase the framesPerBurst for OpenSL ES for low latency
streams for SDK >= N_MR1.
Round to multiple of original framesPerBurst above 960.

Bump version to 1.2.4

Fixes #694