### PR TITLE
OboeTester: add glitch display

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -33,8 +33,8 @@ class GlitchAnalyzer : public LoopbackProcessor {
 public:
 
     GlitchAnalyzer()
-    : LoopbackProcessor()
-    , mInfiniteRecording(64 * 1024) {}
+            : LoopbackProcessor()
+            , mInfiniteRecording(64 * 1024) {}
 
     int32_t getState() {
         return mState;
@@ -430,8 +430,7 @@ private:
 
     sine_state_t  mState = STATE_IDLE;
 
-    std::mutex    mGlitchLock;
-    InfiniteRecording mInfiniteRecording;
+    InfiniteRecording<float> mInfiniteRecording;
     int64_t       mLastGlitchPosition;
 };
 

--- a/apps/OboeTester/app/src/main/cpp/analyzer/InfiniteRecording.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/InfiniteRecording.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOETESTER_INFINITE_RECORDING_H
+#define OBOETESTER_INFINITE_RECORDING_H
+
+#include <memory>
+#include <unistd.h>
+
+/**
+ * Record forever. Keep last data.
+ */
+class InfiniteRecording {
+public:
+    InfiniteRecording(size_t maxSamples)
+        : mMaxSamples(maxSamples) {
+        mData = std::make_unique<float[]>(mMaxSamples);
+    }
+
+    int32_t readFrom(float *buffer, size_t position, size_t count) {
+        size_t maxPosition = mWritten.load();
+        position = std::min(position, maxPosition);
+        size_t numToRead = std::min(count, mMaxSamples);
+        numToRead = std::min(numToRead, maxPosition - position);
+        if (numToRead == 0) return 0;
+        // We may need to read in two parts if it wraps.
+        size_t offset = position % mMaxSamples;
+        size_t firstReadSize = std::min(numToRead, mMaxSamples - offset); // till end
+        std::copy(&mData[offset], &mData[offset + firstReadSize], buffer);
+        if (firstReadSize < numToRead) {
+            // Second read needed.
+            std::copy(&mData[0], &mData[numToRead - firstReadSize], &buffer[firstReadSize]);
+        }
+        return numToRead;
+    }
+
+    void write(float sample) {
+        size_t position = mWritten.load();
+        size_t offset = position % mMaxSamples;
+        mData[offset] = sample;
+        mWritten++;
+    }
+
+    int64_t getTotalWritten() {
+        return mWritten.load();
+    }
+
+private:
+    std::unique_ptr<float[]> mData;
+    std::atomic<size_t> mWritten{0};
+    const size_t mMaxSamples;
+};
+#endif //OBOETESTER_INFINITE_RECORDING_H

--- a/apps/OboeTester/app/src/main/cpp/analyzer/InfiniteRecording.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/InfiniteRecording.h
@@ -23,22 +23,23 @@
 /**
  * Record forever. Keep last data.
  */
+template <typename T>
 class InfiniteRecording {
 public:
     InfiniteRecording(size_t maxSamples)
-        : mMaxSamples(maxSamples) {
-        mData = std::make_unique<float[]>(mMaxSamples);
+            : mMaxSamples(maxSamples) {
+        mData = std::make_unique<T[]>(mMaxSamples);
     }
 
-    int32_t readFrom(float *buffer, size_t position, size_t count) {
-        size_t maxPosition = mWritten.load();
+    int32_t readFrom(T *buffer, size_t position, size_t count) {
+        const size_t maxPosition = mWritten.load();
         position = std::min(position, maxPosition);
         size_t numToRead = std::min(count, mMaxSamples);
         numToRead = std::min(numToRead, maxPosition - position);
         if (numToRead == 0) return 0;
         // We may need to read in two parts if it wraps.
-        size_t offset = position % mMaxSamples;
-        size_t firstReadSize = std::min(numToRead, mMaxSamples - offset); // till end
+        const size_t offset = position % mMaxSamples;
+        const size_t firstReadSize = std::min(numToRead, mMaxSamples - offset); // till end
         std::copy(&mData[offset], &mData[offset + firstReadSize], buffer);
         if (firstReadSize < numToRead) {
             // Second read needed.
@@ -47,9 +48,9 @@ public:
         return numToRead;
     }
 
-    void write(float sample) {
-        size_t position = mWritten.load();
-        size_t offset = position % mMaxSamples;
+    void write(T sample) {
+        const size_t position = mWritten.load();
+        const size_t offset = position % mMaxSamples;
         mData[offset] = sample;
         mWritten++;
     }
@@ -59,8 +60,8 @@ public:
     }
 
 private:
-    std::unique_ptr<float[]> mData;
-    std::atomic<size_t> mWritten{0};
-    const size_t mMaxSamples;
+    std::unique_ptr<T[]> mData;
+    std::atomic<size_t>      mWritten{0};
+    const size_t             mMaxSamples;
 };
 #endif //OBOETESTER_INFINITE_RECORDING_H

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -590,7 +590,7 @@ Java_com_google_sample_oboe_manualtest_GlitchActivity_setTolerance(JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_com_google_sample_oboe_manualtest_ManualGlitchActivity_getGlitch(JNIEnv *env, jobject instance,
                                                                       jfloatArray waveform_) {
-    float *waveform = env->GetFloatArrayElements(waveform_, NULL);
+    float *waveform = env->GetFloatArrayElements(waveform_, nullptr);
     jsize length = env->GetArrayLength(waveform_);
     jsize numSamples = 0;
     auto *analyzer = engine.mActivityGlitches.getGlitchAnalyzer();

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -587,4 +587,19 @@ Java_com_google_sample_oboe_manualtest_GlitchActivity_setTolerance(JNIEnv *env,
     }
 }
 
+JNIEXPORT jint JNICALL
+Java_com_google_sample_oboe_manualtest_ManualGlitchActivity_getGlitch(JNIEnv *env, jobject instance,
+                                                                      jfloatArray waveform_) {
+    float *waveform = env->GetFloatArrayElements(waveform_, NULL);
+    jsize length = env->GetArrayLength(waveform_);
+    jsize numSamples = 0;
+    auto *analyzer = engine.mActivityGlitches.getGlitchAnalyzer();
+    if (analyzer) {
+        numSamples = analyzer->getLastGlitch(waveform, length);
+    }
+
+    env->ReleaseFloatArrayElements(waveform_, waveform, 0);
+    return numSamples;
+}
+
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/GlitchActivity.java
@@ -139,6 +139,7 @@ public class GlitchActivity extends AnalyzerActivity {
                 if (glitchFrames > mLastGlitchFrames || glitchCount > mLastGlitchCount) {
                     mTimeOfLastGlitch = now;
                     mSecondsWithoutGlitches = 0.0;
+                    onGlitchDetected();
                 } else if (lockedFrames > mLastLockedFrames) {
                     mSecondsWithoutGlitches = (now - mTimeOfLastGlitch) / 1000.0;
                 }
@@ -215,6 +216,10 @@ public class GlitchActivity extends AnalyzerActivity {
         }
     }
 
+    // Called on UI thread
+    protected void onGlitchDetected() {
+    }
+
     private GlitchSniffer mGlitchSniffer = new GlitchSniffer();
 
     private void setAnalyzerText(String s) {
@@ -276,6 +281,7 @@ public class GlitchActivity extends AnalyzerActivity {
         openAudio();
         startAudio();
         mGlitchSniffer.startSniffer();
+        onTestBegan();
     }
 
     public void onCancel(View view) {
@@ -288,6 +294,10 @@ public class GlitchActivity extends AnalyzerActivity {
         stopAudioTest();
         onTestFinished();
         keepScreenOn(false);
+    }
+
+    // Must be called on UI thread.
+    public void onTestBegan() {
     }
 
     // Must be called on UI thread.

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
@@ -263,23 +263,15 @@ public class ManualGlitchActivity extends GlitchActivity {
     // Called on UI thread
     @Override
     protected void onGlitchDetected() {
-        float[] waveform = getGlitchWaveform();
-        mWaveformView.setSampleData(waveform);
+        int numSamples = getGlitch(mWaveform);
+        mWaveformView.setSampleData(mWaveform, 0, numSamples);
         mWaveformView.postInvalidate();
     }
 
     private float[] getGlitchWaveform() {
-        int numSamples = getGlitch(mWaveform);
         return mWaveform;
     }
 
     private native int getGlitch(float[] mWaveform);
 
-    private float[] getRandomWaveform() {
-        float[] waveform = new float[16];
-        for (int i = 0; i < waveform.length; i++) {
-            waveform[i] = (float) ((Math.random() * 2.0) - 1.0);
-        }
-        return waveform;
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
@@ -57,6 +57,8 @@ public class ManualGlitchActivity extends GlitchActivity {
     private TextView mTextTolerance;
     private SeekBar mFaderTolerance;
     protected ExponentialTaper mTaperTolerance;
+    private WaveformView mWaveformView;
+    private float[] mWaveform = new float[256];
     private boolean mTestRunningByIntent;
     private Bundle mBundleFromIntent;
 
@@ -94,6 +96,8 @@ public class ManualGlitchActivity extends GlitchActivity {
         mTaperTolerance = new ExponentialTaper(0.0, 0.5, 100.0);
         mFaderTolerance.setOnSeekBarChangeListener(mToleranceListener);
         setToleranceFader(DEFAULT_TOLERANCE);
+
+        mWaveformView = (WaveformView) findViewById(R.id.waveview_audio);
     }
 
     private void setToleranceFader(float tolerance) {
@@ -248,5 +252,34 @@ public class ManualGlitchActivity extends GlitchActivity {
     public void onTestFinished() {
         super.onTestFinished();
     }
+    // Only call from UI thread.
+    @Override
+    public void onTestBegan() {
+        mWaveformView.clearSampleData();
+        mWaveformView.postInvalidate();
+        super.onTestBegan();
+    }
 
+    // Called on UI thread
+    @Override
+    protected void onGlitchDetected() {
+        float[] waveform = getGlitchWaveform();
+        mWaveformView.setSampleData(waveform);
+        mWaveformView.postInvalidate();
+    }
+
+    private float[] getGlitchWaveform() {
+        int numSamples = getGlitch(mWaveform);
+        return mWaveform;
+    }
+
+    private native int getGlitch(float[] mWaveform);
+
+    private float[] getRandomWaveform() {
+        float[] waveform = new float[16];
+        for (int i = 0; i < waveform.length; i++) {
+            waveform[i] = (float) ((Math.random() * 2.0) - 1.0);
+        }
+        return waveform;
+    }
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WaveformView.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WaveformView.java
@@ -87,20 +87,21 @@ public class WaveformView extends View {
         float xScale = ((float) mCurrentWidth) / (mSampleCount - 1);
         float x0 = 0.0f;
         if (xScale < 1.0) {
-            // Draw a vertical bar for a multiple samples.
+            // Draw a vertical bar for multiple samples.
             float ymin = mOffsetY;
             float ymax = mOffsetY;
-            for (int i = 1; i < mSampleCount; i++) {
+            for (int i = 0; i < mSampleCount; i++) {
                 float x1 = i * xScale;
-                float y1 = (localData[i] * mScaleY) + mOffsetY;
-                ymin = Math.min(ymin, y1);
-                ymax = Math.max(ymax, y1);
                 if ((int) x0 != (int) x1) {
-                    canvas.drawLine(x0, ymin, x1, ymax, mWavePaint);
+                    // draw old data
+                    canvas.drawLine(x0, ymin, x0, ymax, mWavePaint);
                     x0 = x1;
                     ymin = mOffsetY;
                     ymax = mOffsetY;
                 }
+                float y1 = (localData[i] * mScaleY) + mOffsetY;
+                ymin = Math.min(ymin, y1);
+                ymax = Math.max(ymax, y1);
             }
         } else {
             // Draw line between samples.

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WaveformView.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WaveformView.java
@@ -84,21 +84,33 @@ public class WaveformView extends View {
         if (localData == null || mSampleCount == 0) {
             return;
         }
-        float xScale = ((float) mCurrentWidth) / mSampleCount;
+        float xScale = ((float) mCurrentWidth) / (mSampleCount - 1);
         float x0 = 0.0f;
-        float ymin = mOffsetY;
-        float ymax = mOffsetY;
-        for (int i = 1; i < mSampleCount; i++) {
-            float x1 = i * xScale;
-            float y1 = (localData[i] * mScaleY) + mOffsetY;
-            if ((int)x0 != (int)x1) {
-                canvas.drawLine(x0, ymin, x1, ymax, mWavePaint);
-                x0 = x1;
-                ymin = mOffsetY;
-                ymax = mOffsetY;
-            } else {
+        if (xScale < 1.0) {
+            // Draw a vertical bar for a multiple samples.
+            float ymin = mOffsetY;
+            float ymax = mOffsetY;
+            for (int i = 1; i < mSampleCount; i++) {
+                float x1 = i * xScale;
+                float y1 = (localData[i] * mScaleY) + mOffsetY;
                 ymin = Math.min(ymin, y1);
                 ymax = Math.max(ymax, y1);
+                if ((int) x0 != (int) x1) {
+                    canvas.drawLine(x0, ymin, x1, ymax, mWavePaint);
+                    x0 = x1;
+                    ymin = mOffsetY;
+                    ymax = mOffsetY;
+                }
+            }
+        } else {
+            // Draw line between samples.
+            float y0 = (localData[0] * mScaleY) + mOffsetY;
+            for (int i = 1; i < mSampleCount; i++) {
+                float x1 = i * xScale;
+                float y1 = (localData[i] * mScaleY) + mOffsetY;
+                canvas.drawLine(x0, y0, x1, y1, mWavePaint);
+                x0 = x1;
+                y0 = y1;
             }
         }
         if (mCursors != null) {

--- a/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
@@ -97,4 +97,8 @@
         android:textSize="18sp"
         android:textStyle="bold" />
 
+    <com.google.sample.oboe.manualtest.WaveformView
+        android:id="@+id/waveview_audio"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
 </LinearLayout>


### PR DESCRIPTION
Grab the last glitch from the GlitchAnalyser and display the waveform.
It is possible to recognize the source of the glitch from the shape.