### PR TITLE
MegaDrone: fix memory leak in JNI

### DIFF
--- a/samples/MegaDrone/src/main/cpp/native-lib.cpp
+++ b/samples/MegaDrone/src/main/cpp/native-lib.cpp
@@ -21,20 +21,18 @@
 #include "MegaDroneEngine.h"
 
 
-std::vector<int> convertJavaArrayToVector(JNIEnv *env, jintArray intArray){
-
+std::vector<int> convertJavaArrayToVector(JNIEnv *env, jintArray intArray) {
     std::vector<int> v;
     jsize length = env->GetArrayLength(intArray);
-
     if (length > 0) {
-        jboolean isCopy;
-        jint *elements = env->GetIntArrayElements(intArray, &isCopy);
-        for (int i = 0; i < length; i++) {
-            v.push_back(elements[i]);
-        }
+        jint *elements = env->GetIntArrayElements(intArray, nullptr);
+        v.insert(v.end(), &elements[0], &elements[length]);
+        // Unpin the memory for the array, or free the copy.
+        env->ReleaseIntArrayElements(intArray, elements, 0);
     }
     return v;
 }
+
 extern "C" {
 /**
  * Start the audio engine


### PR DESCRIPTION
Call ReleaseIntArrayElements()
and simplify vector initialization.
Fixes #713