### PR TITLE
OboeTester: add Workload fader that will burn up the CPU

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 25
         targetSdkVersion 28
         // Also update the version in the AndroidManifest.xml file.
-        versionCode 29
-        versionName "1.5.21"
+        versionCode 30
+        versionName "1.5.22"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="29"
-    android:versionName="1.5.21">
+    android:versionCode="30"
+    android:versionName="1.5.22">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -240,7 +240,10 @@ public:
         return stopAllStreams();
     }
 
-    virtual void setAmplitude(double amplitude) {}
+    void setWorkload(double workload) {
+        LOGD("ActivityContext::%s(%f)", __func__, workload);
+        oboeCallbackProxy.setWorkload(workload);
+    }
 
     virtual oboe::Result startPlayback() {
         return oboe::Result::OK;
@@ -416,15 +419,6 @@ public:
 
     void runBlockingIO() override;
 
-    void setAmplitude(double amplitude) override {
-        LOGD("%s(%f)", __func__, amplitude);
-        for (int i = 0; i < mChannelCount; i++) {
-            sineOscillators[i].amplitude.setValue(amplitude);
-            sawtoothOscillators[i].amplitude.setValue(amplitude);
-        }
-        impulseGenerator.amplitude.setValue(amplitude);
-    }
-
     void setChannelEnabled(int channelIndex, bool enabled) override;
 
     // WARNING - must match order in strings.xml and OboeAudioOutputStream.java
@@ -445,7 +439,6 @@ protected:
 
     std::vector<SineOscillator>      sineOscillators;
     std::vector<SawtoothOscillator>  sawtoothOscillators;
-    ImpulseOscillator                impulseGenerator;
     static constexpr float           kSweepPeriod = 10.0; // for triangle up and down
 
     // A triangle LFO is shaped into either a linear or an exponential range.
@@ -469,12 +462,6 @@ public:
     virtual ~ActivityTapToTone() = default;
 
     void configureForStart() override;
-
-    void setAmplitude(double amplitude) override {
-        LOGD("%s(%f)", __func__, amplitude);
-        ActivityTestOutput::setAmplitude(amplitude);
-        sawPingGenerator.amplitude.setValue(amplitude);
-    }
 
     virtual void setEnabled(bool enabled) override {
         sawPingGenerator.setEnabled(enabled);

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
@@ -17,10 +17,30 @@
 #include "common/OboeDebug.h"
 #include "OboeStreamCallbackProxy.h"
 
-bool OboeStreamCallbackProxy::mCallbackReturnStop = false;
-
-OboeStreamCallbackProxy::~OboeStreamCallbackProxy() {
+// Linear congruential random number generator.
+static uint32_t s_random16() {
+    static uint32_t seed = 1234;
+    seed = ((seed * 31421) + 6927) & 0x0FFFF;
+    return seed;
 }
+
+/**
+ * The random number generator is good for burning CPU because the compiler cannot
+ * easily optimize away the computation.
+ * @param workload number of times to execute the loop
+ * @return a white noise value between -1.0 and +1.0
+ */
+static float s_burnCPU(int32_t workload) {
+    uint32_t random = 0;
+    for (int32_t i = 0; i < workload; i++) {
+        for (int32_t j = 0; j < 10; j++) {
+            random = random ^ s_random16();
+        }
+    }
+    return (random - 32768) * (1.0 / 32768);
+}
+
+bool OboeStreamCallbackProxy::mCallbackReturnStop = false;
 
 oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
         oboe::AudioStream *audioStream,
@@ -30,6 +50,10 @@ oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
     if (mCallbackReturnStop) {
         return oboe::DataCallbackResult::Stop;
     }
+
+    //
+    s_burnCPU((int32_t)(mWorkload * kWorkloadScaler * numFrames));
+
     if (mCallback != nullptr) {
         return mCallback->onAudioReady(audioStream, audioData, numFrames);
     }

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
@@ -24,8 +24,6 @@
 
 class OboeStreamCallbackProxy : public oboe::AudioStreamCallback {
 public:
-    OboeStreamCallbackProxy() {}
-    ~OboeStreamCallbackProxy();
 
     void setCallback(oboe::AudioStreamCallback *callback) {
         mCallback = callback;
@@ -56,7 +54,22 @@ public:
 
     void onErrorAfterClose(oboe::AudioStream *audioStream, oboe::Result error) override;
 
+    /**
+     * Specify the amount of artificial workload that will waste CPU cycles
+     * and increase the CPU load.
+     * @param workload typically ranges from 0.0 to 100.0
+     */
+    void setWorkload(double workload) {
+        mWorkload = std::max(0.0, workload);
+    }
+
+    double getWorkload() const {
+        return mWorkload;
+    }
+
 private:
+    static constexpr int32_t   kWorkloadScaler = 500;
+    double                     mWorkload = 0.0;
 
     oboe::AudioStreamCallback *mCallback = nullptr;
     static bool                mCallbackReturnStop;

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -372,6 +372,12 @@ Java_com_google_sample_oboe_manualtest_OboeAudioStream_getLatency(JNIEnv *env, j
     return -1.0;
 }
 
+JNIEXPORT void JNICALL
+Java_com_google_sample_oboe_manualtest_OboeAudioStream_setWorkload(
+        JNIEnv *env, jobject, jdouble workload) {
+    engine.getCurrentActivity()->setWorkload(workload);
+}
+
 JNIEXPORT jint JNICALL
 Java_com_google_sample_oboe_manualtest_OboeAudioStream_getState(JNIEnv *env, jobject instance, jint streamIndex) {
     oboe::AudioStream *oboeStream = engine.getCurrentActivity()->getStream(streamIndex);
@@ -439,13 +445,6 @@ JNIEXPORT void JNICALL
 Java_com_google_sample_oboe_manualtest_OboeAudioOutputStream_setToneType(
         JNIEnv *env, jobject, jint toneType) {
 // FIXME    engine.getCurrentActivity()->setToneType(toneType);
-}
-
-JNIEXPORT void JNICALL
-Java_com_google_sample_oboe_manualtest_OboeAudioOutputStream_setAmplitude(
-        JNIEnv *env, jobject, jdouble amplitude) {
-    engine.getCurrentActivity()->setAmplitude(amplitude);
-
 }
 
 JNIEXPORT void JNICALL

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioOutputTester.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioOutputTester.java
@@ -50,10 +50,6 @@ public class AudioOutputTester extends AudioStreamTester {
         mOboeAudioOutputStream.setToneEnabled(flag);
     }
 
-    public void setAmplitude(double amplitude) {
-        mCurrentAudioStream.setAmplitude(amplitude);
-    }
-
     public void setChannelEnabled(int channelIndex, boolean enabled)  {
         mOboeAudioOutputStream.setChannelEnabled(channelIndex, enabled);
     }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioStreamBase.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioStreamBase.java
@@ -158,7 +158,7 @@ public abstract class AudioStreamBase {
         return false;
     }
 
-    public void setAmplitude(double amplitude) {}
+    public void setWorkload(double workload) {}
 
     public abstract int getXRunCount();
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioStreamTester.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AudioStreamTester.java
@@ -45,4 +45,7 @@ class AudioStreamTester {
         mCurrentAudioStream.startPlayback();
     }
 
+    public void setWorkload(double workload) {
+        mCurrentAudioStream.setWorkload(workload);
+    }
 }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioOutputStream.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioOutputStream.java
@@ -36,9 +36,6 @@ public class OboeAudioOutputStream extends OboeAudioStream {
 
     public native void setToneType(int index);
 
-    @Override
-    public native void setAmplitude(double amplitude);
-
     public native void setChannelEnabled(int channelIndex, boolean enabled);
 
     public native void setSignalType(int type);

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioStream.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioStream.java
@@ -231,6 +231,9 @@ abstract class OboeAudioStream extends AudioStreamBase {
     public native double getLatency(int streamIndex);
 
     @Override
+    public native void setWorkload(double workload);
+
+    @Override
     public int getState() {
         return getState(streamIndex);
     }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestInputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestInputActivity.java
@@ -51,6 +51,7 @@ public class TestInputActivity  extends TestAudioActivity
     private VolumeBarView[] mVolumeBars = new VolumeBarView[NUM_VOLUME_BARS];
     private InputMarginView mInputMarginView;
     private int mInputMarginBursts = 0;
+    private WorkloadView mWorkloadView;
 
     public native void setMinimumFramesBeforeRead(int frames);
     public native int saveWaveFile(String absolutePath);
@@ -80,6 +81,10 @@ public class TestInputActivity  extends TestAudioActivity
 
         mAudioInputTester = addAudioInputTester();
 
+        mWorkloadView = (WorkloadView) findViewById(R.id.workload_view);
+        if (mWorkloadView != null) {
+            mWorkloadView.setAudioStreamTester(mAudioInputTester);
+        }
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivity.java
@@ -26,7 +26,7 @@ import android.widget.Spinner;
 import java.io.IOException;
 
 /**
- * Base class for output test activities
+ * Test basic output.
  */
 public final class TestOutputActivity extends TestOutputActivityBase {
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivityBase.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestOutputActivityBase.java
@@ -28,30 +28,10 @@ import java.io.IOException;
 abstract class TestOutputActivityBase extends TestAudioActivity {
     AudioOutputTester mAudioOutTester;
 
-    protected TextView mTextAmplitude;
-    protected SeekBar mFaderAmplitude;
-    protected ExponentialTaper mTaperAmplitude;
     private BufferSizeView mBufferSizeView;
+    private WorkloadView mWorkloadView;
 
     @Override boolean isOutput() { return true; }
-
-    private SeekBar.OnSeekBarChangeListener mAmplitudeListener = new SeekBar.OnSeekBarChangeListener() {
-        @Override
-        public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-            double amplitude = mTaperAmplitude.linearToExponential(
-                    ((double)progress) / FADER_PROGRESS_MAX);
-            mAudioOutTester.setAmplitude(amplitude);
-            mTextAmplitude.setText("Amplitude = " + amplitude);
-        }
-
-        @Override
-        public void onStartTrackingTouch(SeekBar seekBar) {
-        }
-
-        @Override
-        public void onStopTrackingTouch(SeekBar seekBar) {
-        }
-    };
 
     @Override
     protected void resetConfiguration() {
@@ -61,18 +41,15 @@ abstract class TestOutputActivityBase extends TestAudioActivity {
 
     protected void findAudioCommon() {
         super.findAudioCommon();
-
         mBufferSizeView = (BufferSizeView) findViewById(R.id.buffer_size_view);
-        mTextAmplitude = (TextView) findViewById(R.id.textAmplitude);
-        mFaderAmplitude = (SeekBar) findViewById(R.id.faderAmplitude);
-        mFaderAmplitude.setOnSeekBarChangeListener(mAmplitudeListener);
-        mTaperAmplitude = new ExponentialTaper(0.0, 4.0, 100.0);
+        mWorkloadView = (WorkloadView) findViewById(R.id.workload_view);
     }
 
     @Override
     public AudioOutputTester addAudioOutputTester() {
         AudioOutputTester audioOutTester = super.addAudioOutputTester();
         mBufferSizeView.setAudioOutTester(audioOutTester);
+        mWorkloadView.setAudioStreamTester(audioOutTester);
         return audioOutTester;
     }
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WorkloadView.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/WorkloadView.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sample.oboe.manualtest;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+public class WorkloadView extends LinearLayout {
+
+    private AudioStreamTester mAudioStreamTester;
+
+    protected static final int FADER_PROGRESS_MAX = 1000; // must match layout
+    protected TextView mTextView;
+    protected SeekBar mSeekBar;
+    protected ExponentialTaper mExponentialTaper;
+
+    private SeekBar.OnSeekBarChangeListener mChangeListener = new SeekBar.OnSeekBarChangeListener() {
+        @Override
+        public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+            setValueByPosition(progress);
+        }
+
+        @Override
+        public void onStartTrackingTouch(SeekBar seekBar) {
+        }
+
+        @Override
+        public void onStopTrackingTouch(SeekBar seekBar) {
+        }
+    };
+
+    public WorkloadView(Context context) {
+        super(context);
+        initializeViews(context);
+    }
+
+    public WorkloadView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initializeViews(context);
+    }
+
+    public WorkloadView(Context context,
+                        AttributeSet attrs,
+                        int defStyle) {
+        super(context, attrs, defStyle);
+        initializeViews(context);
+    }
+
+    public AudioStreamTester getAudioStreamTester() {
+        return mAudioStreamTester;
+    }
+
+    public void setAudioStreamTester(AudioStreamTester audioStreamTester) {
+        mAudioStreamTester = audioStreamTester;
+    }
+
+    void setFaderNormalizedProgress(double fraction) {
+        mSeekBar.setProgress((int)(fraction * FADER_PROGRESS_MAX));
+    }
+
+    /**
+     * Inflates the views in the layout.
+     *
+     * @param context
+     *           the current context for the view.
+     */
+    private void initializeViews(Context context) {
+        LayoutInflater inflater = (LayoutInflater) context
+                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        inflater.inflate(R.layout.workload_view, this);
+
+        mTextView = (TextView) findViewById(R.id.textWorkload);
+        mSeekBar = (SeekBar) findViewById(R.id.faderWorkload);
+        mSeekBar.setOnSeekBarChangeListener(mChangeListener);
+        mExponentialTaper = new ExponentialTaper(0.0, 100.0, 10.0);
+        //mSeekBar.setProgress(0);
+    }
+
+    private void setValueByPosition(int progress) {
+        double workload = mExponentialTaper.linearToExponential(
+                ((double)progress) / FADER_PROGRESS_MAX);
+        mAudioStreamTester.setWorkload(workload);
+        mTextView.setText("Workload = " + String.format("%6.2f", workload));
+    }
+
+    public void updateBufferSize() {
+        int progress = mSeekBar.getProgress();
+        setValueByPosition(progress);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        mSeekBar.setEnabled(enabled);
+    }
+}

--- a/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
@@ -37,6 +37,13 @@
         android:gravity="center"
         android:orientation="horizontal" />
 
+    <com.google.sample.oboe.manualtest.WorkloadView
+        android:id="@+id/workload_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/apps/OboeTester/app/src/main/res/layout/merge_audio_common.xml
+++ b/apps/OboeTester/app/src/main/res/layout/merge_audio_common.xml
@@ -16,24 +16,12 @@
         android:gravity="center"
         android:orientation="horizontal" />
 
-    <LinearLayout
+    <com.google.sample.oboe.manualtest.WorkloadView
+        android:id="@+id/workload_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/textAmplitude"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Amplitude" />
-
-        <SeekBar
-            android:id="@+id/faderAmplitude"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:max="1000"
-            android:progress="1000" />
-    </LinearLayout>
+        android:gravity="center"
+        android:orientation="horizontal" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/layout/workload_view.xml
+++ b/apps/OboeTester/app/src/main/res/layout/workload_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textWorkload"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Workload" />
+
+    <SeekBar
+        android:id="@+id/faderWorkload"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="1000"
+        android:progress="0" />
+
+</LinearLayout>


### PR DESCRIPTION
This can be used to stress the system and cause glitches.
It can also be used to make race conditions more likely.