### PR TITLE
Avoid global variables

### DIFF
--- a/src/flowgraph/resampler/IntegerRatio.cpp
+++ b/src/flowgraph/resampler/IntegerRatio.cpp
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-#include <vector>
-
 #include "IntegerRatio.h"
 
 using namespace resampler;
 
 // Enough primes to cover the common sample rates.
-const std::vector<int>  IntegerRatio::kPrimes{
+static const int kPrimes[] = {
         2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41,
         43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
         101, 103, 107, 109, 113, 127, 131, 137, 139, 149,

--- a/src/flowgraph/resampler/IntegerRatio.h
+++ b/src/flowgraph/resampler/IntegerRatio.h
@@ -18,7 +18,6 @@
 #define OBOE_INTEGER_RATIO_H
 
 #include <sys/types.h>
-#include <vector>
 
 namespace resampler {
 
@@ -46,7 +45,6 @@ public:
 private:
     int32_t mNumerator;
     int32_t mDenominator;
-    static const std::vector<int> kPrimes;
 };
 
 }


### PR DESCRIPTION
Using global variables in c++ gives the problems with integrating with other languages.
In particular the linking errors like that: https://github.com/rust-lang/rust/issues/36710.
So I think we can and should avoid global variables at all.