### PR TITLE
opensles: scale buffer size by sample rate

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -198,7 +198,7 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
-    oboeResult = configureBufferSizes();
+    oboeResult = configureBufferSizes(mSampleRate);
     if (Result::OK != oboeResult) {
         goto error;
     }

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -223,7 +223,7 @@ Result AudioOutputStreamOpenSLES::open() {
         goto error;
     }
 
-    oboeResult = configureBufferSizes();
+    oboeResult = configureBufferSizes(mSampleRate);
     if (Result::OK != oboeResult) {
         goto error;
     }

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -100,7 +100,7 @@ protected:
     PerformanceMode convertPerformanceMode(SLuint32 openslMode) const;
     SLuint32 convertPerformanceMode(PerformanceMode oboeMode) const;
 
-    Result configureBufferSizes();
+    Result configureBufferSizes(int32_t sampleRate);
 
     void logUnsupportedAttributes();
 


### PR DESCRIPTION
Use smaller buffer sizes for lower rates.
Base on 20 msec period common on Android.
Pass mSampleRate so caller can guarantee it is set.

Fixes #751