### PR TITLE
LiveEffect: handle failure to open the stream

### DIFF
--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include "LiveEffectEngine.h"
-#include <assert.h>
+#include <cassert>
 #include <logging_macros.h>
+
+#include "LiveEffectEngine.h"
 
 LiveEffectEngine::LiveEffectEngine() {
     assert(mOutputChannelCount == mInputChannelCount);
@@ -59,7 +60,6 @@ bool LiveEffectEngine::setEffectOn(bool isOn) {
                 mIsEffectOn = isOn;
             }
         } else {
-            mIsEffectOn = isOn;
             mFullDuplexPass.stop();
             /*
             * Note: The order of events is important here.
@@ -71,6 +71,7 @@ bool LiveEffectEngine::setEffectOn(bool isOn) {
             */
             closeStream(mPlayStream);
             closeStream(mRecordingStream);
+            mIsEffectOn = isOn;
        }
     }
     return success;

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -29,8 +29,11 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     ~LiveEffectEngine();
     void setRecordingDeviceId(int32_t deviceId);
     void setPlaybackDeviceId(int32_t deviceId);
-    void setEffectOn(bool isOn);
-    void openStreams();
+    /**
+     * @param isOn
+     * @return true if it succeeds
+     */
+    bool setEffectOn(bool isOn);
 
     /*
      * oboe::AudioStreamCallback interface implementation
@@ -56,6 +59,7 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     oboe::AudioStream *mPlayStream = nullptr;
     oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
 
+    oboe::Result openStreams();
     void closeStream(oboe::AudioStream *stream);
 
 

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -39,9 +39,9 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
      * oboe::AudioStreamCallback interface implementation
      */
     oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream,
-                                          void *audioData, int32_t numFrames);
-    void onErrorBeforeClose(oboe::AudioStream *oboeStream, oboe::Result error);
-    void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error);
+                                          void *audioData, int32_t numFrames) override;
+    void onErrorBeforeClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
+    void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
 
     bool setAudioApi(oboe::AudioApi);
     bool isAAudioSupported(void);
@@ -55,13 +55,14 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     int32_t mSampleRate = oboe::kUnspecified;
     int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
     int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
-    oboe::AudioStream *mRecordingStream = nullptr;
-    oboe::AudioStream *mPlayStream = nullptr;
+
+    oboe::ManagedStream mRecordingStream;
+    oboe::ManagedStream mPlayStream;
+
     oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
 
     oboe::Result openStreams();
-    void closeStream(oboe::AudioStream *stream);
-
+    void closeStream(oboe::ManagedStream &stream);
 
     oboe::AudioStreamBuilder *setupCommonStreamParameters(
         oboe::AudioStreamBuilder *builder);
@@ -69,7 +70,7 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
         oboe::AudioStreamBuilder *builder);
     oboe::AudioStreamBuilder *setupPlaybackStreamParameters(
         oboe::AudioStreamBuilder *builder);
-    void warnIfNotLowLatency(oboe::AudioStream *stream);
+    void warnIfNotLowLatency(oboe::ManagedStream &stream);
 };
 
 #endif  // OBOE_LIVEEFFECTENGINE_H

--- a/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
+++ b/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
@@ -42,17 +42,17 @@ Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_delete(JNIEnv *env,
     engine = nullptr;
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_setEffectOn(
     JNIEnv *env, jclass, jboolean isEffectOn) {
     if (engine == nullptr) {
         LOGE(
             "Engine is null, you must call createEngine before calling this "
             "method");
-        return;
+        return JNI_FALSE;
     }
 
-    engine->setEffectOn(isEffectOn);
+    return (jboolean) engine->setEffectOn(isEffectOn);
 }
 
 JNIEXPORT void JNICALL

--- a/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
+++ b/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
@@ -25,14 +25,14 @@ static LiveEffectEngine *engine = nullptr;
 
 extern "C" {
 
-JNIEXPORT bool JNICALL
+JNIEXPORT jboolean JNICALL
 Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_create(JNIEnv *env,
                                                                jclass) {
     if (engine == nullptr) {
         engine = new LiveEffectEngine();
     }
 
-    return (engine != nullptr);
+    return (engine != nullptr) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL
@@ -52,7 +52,7 @@ Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_setEffectOn(
         return JNI_FALSE;
     }
 
-    return (jboolean) engine->setEffectOn(isEffectOn);
+    return engine->setEffectOn(isEffectOn) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL
@@ -105,8 +105,7 @@ Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_setAPI(JNIEnv *env,
             return JNI_FALSE;
     }
 
-    return static_cast<jboolean>(engine->setAudioApi(audioApi) ? JNI_TRUE
-                                                               : JNI_FALSE);
+    return engine->setAudioApi(audioApi) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL
@@ -118,15 +117,14 @@ Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_isAAudioSupported(
             "before calling this method");
         return JNI_FALSE;
     }
-    return static_cast<jboolean>(engine->isAAudioSupported() ? JNI_TRUE
-                                                             : JNI_FALSE);
+    return engine->isAAudioSupported() ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL
 Java_com_google_sample_oboe_liveEffect_LiveEffectEngine_native_1setDefaultStreamValues(JNIEnv *env,
-                                                                            jclass type,
-                                                                            jint sampleRate,
-                                                                            jint framesPerBurst) {
+                                               jclass type,
+                                               jint sampleRate,
+                                               jint framesPerBurst) {
     oboe::DefaultStreamValues::SampleRate = (int32_t) sampleRate;
     oboe::DefaultStreamValues::FramesPerBurst = (int32_t) framesPerBurst;
 }

--- a/samples/LiveEffect/src/main/java/com/google/sample/oboe/liveEffect/LiveEffectEngine.java
+++ b/samples/LiveEffect/src/main/java/com/google/sample/oboe/liveEffect/LiveEffectEngine.java
@@ -32,7 +32,7 @@ public enum LiveEffectEngine {
     static native boolean create();
     static native boolean isAAudioSupported();
     static native boolean setAPI(int apiType);
-    static native void setEffectOn(boolean isEffectOn);
+    static native boolean setEffectOn(boolean isEffectOn);
     static native void setRecordingDeviceId(int deviceId);
     static native void setPlaybackDeviceId(int deviceId);
     static native void delete();

--- a/samples/LiveEffect/src/main/java/com/google/sample/oboe/liveEffect/MainActivity.java
+++ b/samples/LiveEffect/src/main/java/com/google/sample/oboe/liveEffect/MainActivity.java
@@ -131,7 +131,7 @@ public class MainActivity extends Activity
         }
         findViewById(R.id.slesButton).setEnabled(enable);
         if(!aaudioSupported) {
-          findViewById(R.id.aaudioButton).setEnabled(false);
+            findViewById(R.id.aaudioButton).setEnabled(false);
         } else {
             findViewById(R.id.aaudioButton).setEnabled(enable);
         }
@@ -139,6 +139,7 @@ public class MainActivity extends Activity
         ((RadioGroup)findViewById(R.id.apiSelectionGroup))
           .check(apiSelection == OBOE_API_AAUDIO ? R.id.aaudioButton : R.id.slesButton);
     }
+
     @Override
     protected void onStart() {
         super.onStart();
@@ -163,9 +164,7 @@ public class MainActivity extends Activity
     public void toggleEffect() {
         if (isPlaying) {
             stopEffect();
-            EnableAudioApiUI(true);
         } else {
-            EnableAudioApiUI(false);
             LiveEffectEngine.setAPI(apiSelection);
             startEffect();
         }
@@ -179,11 +178,17 @@ public class MainActivity extends Activity
             return;
         }
 
-        setSpinnersEnabled(false);
-        LiveEffectEngine.setEffectOn(true);
-        statusText.setText(R.string.status_playing);
-        toggleEffectButton.setText(R.string.stop_effect);
-        isPlaying = true;
+        boolean success = LiveEffectEngine.setEffectOn(true);
+        if (success) {
+            setSpinnersEnabled(false);
+            statusText.setText(R.string.status_playing);
+            toggleEffectButton.setText(R.string.stop_effect);
+            isPlaying = true;
+            EnableAudioApiUI(false);
+        } else {
+            statusText.setText(R.string.status_open_failed);
+            isPlaying = false;
+        }
     }
 
     private void stopEffect() {
@@ -193,6 +198,7 @@ public class MainActivity extends Activity
         toggleEffectButton.setText(R.string.start_effect);
         isPlaying = false;
         setSpinnersEnabled(true);
+        EnableAudioApiUI(true);
     }
 
     private void setSpinnersEnabled(boolean isEnabled){
@@ -219,6 +225,7 @@ public class MainActivity extends Activity
                 new String[]{Manifest.permission.RECORD_AUDIO},
                 AUDIO_EFFECT_REQUEST);
     }
+
     private void resetStatusView() {
         statusText.setText(R.string.status_warning);
     }

--- a/samples/LiveEffect/src/main/res/values/strings.xml
+++ b/samples/LiveEffect/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="stop_effect">Stop</string>
     <string name="need_record_audio_permission">"This sample needs RECORD_AUDIO permission"</string>
     <string name="status_playing">Engine Playing ....</string>
+    <string name="status_open_failed">Engine Failed to Open Streams!</string>
     <string name="status_record_audio_denied">Error: Permission for RECORD_AUDIO was denied</string>
     <string name="status_touch_to_begin">RECORD_AUDIO permission granted, touch START to begin</string>
     <string name="status_warning">Warning: If you run this sample using the built-in microphone


### PR DESCRIPTION
Used to crash on a nullptr.
Now it passes the result up to Java.
Also uses ManagedStream to prevent leaked resources.

Bug: #796