### PR TITLE
Default to building both x86 and ARM ABIs

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -13,8 +13,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14"
-                // abiFilters "x86", "armeabi-v7a", "arm64-v8a"
-                // abiFilters "arm64-v8a"
+                abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
             }
         }
     }


### PR DESCRIPTION
Default to building: arm32, arm64, x86_32, and x86_64 ABIs. Handy
for testing intel-based devices like Chromebooks.