### PR TITLE
Fixing lldb 3.1 installation failure in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   - touch ~/.android/repositories.cfg
   - echo y | sdkmanager "ndk-bundle"
   - echo y | sdkmanager "cmake;3.6.4111459"
-  - echo y | sdkmanager "lldb;3.1"
   # the following line triggers Trivis-CI's 4MB log limit
     #  - sdkmanager --update
 before_script:


### PR DESCRIPTION
seems ok w/o lldb, let's remove. 