### PR TITLE
opensles: prevent crash in releaseBuffer()

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 4
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 0
+#define OBOE_VERSION_PATCH 1
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -112,7 +112,7 @@ protected:
         mState.store(state);
     }
 
-    int64_t getFramesProcessedByServer() const;
+    int64_t getFramesProcessedByServer();
 
     // OpenSLES stuff
     SLObjectItf                   mObjectInterface = nullptr;


### PR DESCRIPTION
Move call to getPosition() outside the callback.
This was triggering a restoreTrack_l() inside
AudioFlinger folowing a headset insertion.
That in turn caused an assert in releaseBuffer() in
AudioTrack or AudioRecord.

Now it is called when needed by getFramesRead() or getFramesWritten().

Fixes ##535