### PR TITLE
corrected intent constant

### DIFF
--- a/docs/notes/disconnect.md
+++ b/docs/notes/disconnect.md
@@ -26,7 +26,7 @@ know that the device has changed. There is a "Test Disconnects" option in
 [OboeTester](https://github.com/google/oboe/tree/master/apps/OboeTester/docs)
 that can be used to diagnose this problem.
 
-As a workaround you can listen for a Java Intent.HEADSET_PLUG, which is fired when a head set is plugged in or out.
+As a workaround you can listen for a Java Intent.ACTION_HEADSET_PLUG, which is fired when a head set is plugged in or out.
 
     // Receive a broadcast Intent when a headset is plugged in or unplugged.
     public class PluginBroadcastReceiver extends BroadcastReceiver {


### PR DESCRIPTION
The [documentation](https://developer.android.com/reference/android/content/Intent#ACTION_HEADSET_PLUG) of `Intent.ACTION_HEADSET_PLUG` recommends to use `AudioManager.ACTION_HEADSET_PLUG` instead if min sdk _is_ LOLLIPOP. It is unclear if it means min sdk is _at least_ LOLLIPOP. It may be worth mentioning it here.