### PR TITLE
oboe: warn user of permission errors

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -239,6 +239,11 @@ Result AudioStreamAAudio::open() {
         mAAudioStream.store(stream);
     }
     if (result != Result::OK) {
+        // Warn developer because ErrorInternal is not very informative.
+        if (result == Result::ErrorInternal && mDirection == Direction::Input) {
+            LOGW("AudioStreamAAudio.open() may have failed due to lack of "
+                 "audio recording permission.");
+        }
         goto error2;
     }
 


### PR DESCRIPTION
AAudio returns confusing error codes when an open
fails due to permission errors. Suggest a possible reason.

Related to #888