### PR TITLE
OboeTester: fix state of workarounds checkbox

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -103,6 +103,12 @@ Java_com_google_sample_oboe_manualtest_NativeEngine_setWorkaroundsEnabled(JNIEnv
     oboe::OboeGlobals::setWorkaroundsEnabled(enabled);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_google_sample_oboe_manualtest_NativeEngine_areWorkaroundsEnabled(JNIEnv *env,
+        jclass type) {
+    return oboe::OboeGlobals::areWorkaroundsEnabled();
+}
+
 JNIEXPORT jint JNICALL
 Java_com_google_sample_oboe_manualtest_OboeAudioStream_openNative(
         JNIEnv *env, jobject synth,

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/MainActivity.java
@@ -60,6 +60,7 @@ public class MainActivity extends Activity {
     private TextView mBluetoothScoStatusView;
     private Bundle mBundleFromIntent;
     private BroadcastReceiver mScoStateReceiver;
+    private CheckBox mWorkaroundsCheckBox;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -100,6 +101,10 @@ public class MainActivity extends Activity {
         } catch (PackageManager.NameNotFoundException e) {
             mVersionTextView.setText(e.getMessage());
         }
+
+        mWorkaroundsCheckBox = (CheckBox) findViewById(R.id.boxEnableWorkarounds);
+        // Turn off workarounds so we can test the underlying API bugs.
+        NativeEngine.setWorkaroundsEnabled(false);
 
         mBuildTextView = (TextView) findViewById(R.id.text_build_info);
         mBuildTextView.setText(Build.DISPLAY);
@@ -173,7 +178,7 @@ public class MainActivity extends Activity {
     @Override
     public void onResume(){
         super.onResume();
-        NativeEngine.setWorkaroundsEnabled(false);
+        mWorkaroundsCheckBox.setChecked(NativeEngine.areWorkaroundsEnabled());
         processBundleFromIntent();
         registerScoStateReceiver();
     }

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/NativeEngine.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/NativeEngine.java
@@ -7,4 +7,6 @@ public class NativeEngine {
     static native boolean isMMapExclusiveSupported();
 
     static native void setWorkaroundsEnabled(boolean enabled);
+
+    static native boolean areWorkaroundsEnabled();
 }


### PR DESCRIPTION
It was getting out of sync with the model.
Now we update the view based on the model in onResume.

Fixes #818