### PR TITLE
unit tests: fix direct AAudio test

### DIFF
--- a/tests/testAAudio.cpp
+++ b/tests/testAAudio.cpp
@@ -22,8 +22,16 @@ using namespace oboe;
 
 class AAudioDirect : public ::testing::Test {
 public:
-    void createBuilder() {
+
+    /**
+     * @return true if AAudio NOT supported
+     */
+    bool openAAudio() {
         mAAudioLoader = AAudioLoader::getInstance();
+        return (mAAudioLoader->open() != 0);
+    }
+
+    void createBuilder() {
         ASSERT_NE(mAAudioLoader, nullptr);
         ASSERT_EQ(0, mAAudioLoader->open());
         ASSERT_NE(mAAudioLoader->createStreamBuilder, nullptr);
@@ -46,18 +54,20 @@ public:
     AAudioLoader *mAAudioLoader = nullptr;
 };
 
-TEST_F(AAudioDirect, InstantiateAAudioLoader){
-AAudioLoader *aaudioLoader = AAudioLoader::getInstance();
-ASSERT_NE(aaudioLoader, nullptr);
+TEST_F(AAudioDirect, InstantiateAAudioLoader) {
+    AAudioLoader *aaudioLoader = AAudioLoader::getInstance();
+    ASSERT_NE(aaudioLoader, nullptr);
 }
 
-TEST_F(AAudioDirect, OpenCloseHighLatencyStream){
+TEST_F(AAudioDirect, OpenCloseHighLatencyStream) {
+    if (openAAudio()) return;
     createBuilder();
     mAAudioLoader->builder_setPerformanceMode(mBuilder, AAUDIO_PERFORMANCE_MODE_NONE);
     openCloseStream();
 }
 
-TEST_F(AAudioDirect, OpenCloseLowLatencyStream){
+TEST_F(AAudioDirect, OpenCloseLowLatencyStream) {
+    if (openAAudio()) return;
     createBuilder();
     mAAudioLoader->builder_setPerformanceMode(mBuilder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
     openCloseStream();


### PR DESCRIPTION
Was failing if AAudio not supported.
AAudio is only supported on 8.1 and later.