### PR TITLE
prevent AAudio from calling Oboe flowgraph

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.cpp
+++ b/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.cpp
@@ -20,7 +20,7 @@
 #include "oboe/Oboe.h"
 #include "AudioStreamGateway.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 oboe::DataCallbackResult AudioStreamGateway::onAudioReady(
         oboe::AudioStream *audioStream,

--- a/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.h
+++ b/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.h
@@ -22,7 +22,7 @@
 #include "flowgraph/FlowGraphNode.h"
 #include "oboe/Oboe.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 /**
  * Bridge between an audio flowgraph and an audio device.
@@ -34,7 +34,7 @@ public:
 //    AudioStreamGateway(int samplesPerFrame);
     virtual ~AudioStreamGateway() = default;
 
-    void setAudioSink(std::shared_ptr<flowgraph::FlowGraphSink>  sink) {
+    void setAudioSink(std::shared_ptr<oboe::flowgraph::FlowGraphSink>  sink) {
         mAudioSink = sink;
     }
 
@@ -51,7 +51,7 @@ public:
 private:
     bool     mSchedulerChecked = false;
     int      mScheduler;
-    std::shared_ptr<flowgraph::FlowGraphSink>  mAudioSink;
+    std::shared_ptr<oboe::flowgraph::FlowGraphSink>  mAudioSink;
 };
 
 

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -456,8 +456,8 @@ protected:
 
     std::unique_ptr<ManyToMultiConverter>   manyToMulti;
     std::unique_ptr<MonoToMultiConverter>   monoToMulti;
-    std::shared_ptr<flowgraph::SinkFloat>   mSinkFloat;
-    std::shared_ptr<flowgraph::SinkI16>     mSinkI16;
+    std::shared_ptr<oboe::flowgraph::SinkFloat>   mSinkFloat;
+    std::shared_ptr<oboe::flowgraph::SinkI16>     mSinkI16;
 };
 
 /**
@@ -640,7 +640,7 @@ public:
 private:
     std::unique_ptr<SineOscillator>         sineOscillator;
     std::unique_ptr<MonoToMultiConverter>   monoToMulti;
-    std::shared_ptr<flowgraph::SinkFloat>   mSinkFloat;
+    std::shared_ptr<oboe::flowgraph::SinkFloat>   mSinkFloat;
 };
 
 /**

--- a/apps/OboeTester/app/src/main/cpp/SawPingGenerator.cpp
+++ b/apps/OboeTester/app/src/main/cpp/SawPingGenerator.cpp
@@ -19,7 +19,7 @@
 #include "oboe/Definitions.h"
 #include "SawPingGenerator.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 SawPingGenerator::SawPingGenerator()
         : OscillatorBase()

--- a/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/ExponentialShape.h
@@ -25,7 +25,7 @@
  *
  * The waveform is not band-limited so it will have aliasing artifacts at higher frequencies.
  */
-class ExponentialShape : public flowgraph::FlowGraphFilter {
+class ExponentialShape : public oboe::flowgraph::FlowGraphFilter {
 public:
     ExponentialShape();
 

--- a/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.cpp
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.cpp
@@ -17,7 +17,7 @@
 
 #include "LinearShape.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 LinearShape::LinearShape()
         : FlowGraphFilter(1) {

--- a/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/LinearShape.h
@@ -23,7 +23,7 @@
 /**
  * Convert an input between -1.0 and +1.0 to a linear region between min and max.
  */
-class LinearShape : public flowgraph::FlowGraphFilter {
+class LinearShape : public oboe::flowgraph::FlowGraphFilter {
 public:
     LinearShape();
 

--- a/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.cpp
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.cpp
@@ -16,7 +16,7 @@
 
 #include "OscillatorBase.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 OscillatorBase::OscillatorBase()
         : frequency(*this, 1)

--- a/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.h
+++ b/apps/OboeTester/app/src/main/cpp/flowunits/OscillatorBase.h
@@ -29,7 +29,7 @@
  * This module has "frequency" and "amplitude" ports for control.
  */
 
-class OscillatorBase : public flowgraph::FlowGraphNode {
+class OscillatorBase : public oboe::flowgraph::FlowGraphNode {
 public:
     OscillatorBase();
 
@@ -61,16 +61,16 @@ public:
     /**
      * Control the frequency of the oscillator in Hz.
      */
-    flowgraph::FlowGraphPortFloatInput  frequency;
+    oboe::flowgraph::FlowGraphPortFloatInput  frequency;
 
     /**
      * Control the linear amplitude of the oscillator.
      * Silence is 0.0.
      * A typical full amplitude would be 1.0.
      */
-    flowgraph::FlowGraphPortFloatInput  amplitude;
+    oboe::flowgraph::FlowGraphPortFloatInput  amplitude;
 
-    flowgraph::FlowGraphPortFloatOutput output;
+    oboe::flowgraph::FlowGraphPortFloatOutput output;
 
 protected:
     /**

--- a/src/flowgraph/ChannelCountConverter.cpp
+++ b/src/flowgraph/ChannelCountConverter.cpp
@@ -18,6 +18,11 @@
 #include "FlowGraphNode.h"
 #include "ChannelCountConverter.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 ChannelCountConverter::ChannelCountConverter(

--- a/src/flowgraph/ChannelCountConverter.h
+++ b/src/flowgraph/ChannelCountConverter.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -48,5 +53,6 @@ namespace flowgraph {
     };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_CHANNEL_COUNT_CONVERTER_H

--- a/src/flowgraph/ClipToRange.cpp
+++ b/src/flowgraph/ClipToRange.cpp
@@ -19,6 +19,11 @@
 #include "FlowGraphNode.h"
 #include "ClipToRange.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 ClipToRange::ClipToRange(int32_t channelCount)

--- a/src/flowgraph/ClipToRange.h
+++ b/src/flowgraph/ClipToRange.h
@@ -23,6 +23,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 // This is 3 dB, (10^(3/20)), to match the maximum headroom in AudioTrack for float data.
@@ -64,5 +69,6 @@ private:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_CLIP_TO_RANGE_H

--- a/src/flowgraph/FlowGraphNode.cpp
+++ b/src/flowgraph/FlowGraphNode.cpp
@@ -19,6 +19,11 @@
 #include <sys/types.h>
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 /***************************************************************************/

--- a/src/flowgraph/FlowGraphNode.h
+++ b/src/flowgraph/FlowGraphNode.h
@@ -40,8 +40,15 @@
 
 // Set this to 1 if using it inside the Android framework.
 // This code is kept here so that it can be moved easily between Oboe and AAudio.
+#ifndef FLOWGRAPH_ANDROID_INTERNAL
 #define FLOWGRAPH_ANDROID_INTERNAL 0
+#endif
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 // Default block size that can be overridden when the FlowGraphPortFloat is created.
@@ -429,5 +436,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif /* FLOWGRAPH_FLOW_GRAPH_NODE_H */

--- a/src/flowgraph/ManyToMultiConverter.cpp
+++ b/src/flowgraph/ManyToMultiConverter.cpp
@@ -18,6 +18,11 @@
 
 #include "ManyToMultiConverter.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 ManyToMultiConverter::ManyToMultiConverter(int32_t channelCount)

--- a/src/flowgraph/ManyToMultiConverter.h
+++ b/src/flowgraph/ManyToMultiConverter.h
@@ -23,6 +23,13 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
+namespace flowgraph {
+
 /**
  * Combine multiple mono inputs into one interleaved multi-channel output.
  */
@@ -45,5 +52,8 @@ public:
 
 private:
 };
+
+} /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_MANY_TO_MULTI_CONVERTER_H

--- a/src/flowgraph/MonoToMultiConverter.cpp
+++ b/src/flowgraph/MonoToMultiConverter.cpp
@@ -18,6 +18,11 @@
 #include "FlowGraphNode.h"
 #include "MonoToMultiConverter.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 MonoToMultiConverter::MonoToMultiConverter(int32_t outputChannelCount)

--- a/src/flowgraph/MonoToMultiConverter.h
+++ b/src/flowgraph/MonoToMultiConverter.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -45,5 +50,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_MONO_TO_MULTI_CONVERTER_H

--- a/src/flowgraph/MultiToMonoConverter.cpp
+++ b/src/flowgraph/MultiToMonoConverter.cpp
@@ -18,6 +18,11 @@
 #include "FlowGraphNode.h"
 #include "MultiToMonoConverter.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 MultiToMonoConverter::MultiToMonoConverter(int32_t inputChannelCount)

--- a/src/flowgraph/MultiToMonoConverter.h
+++ b/src/flowgraph/MultiToMonoConverter.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -45,5 +50,6 @@ namespace flowgraph {
     };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_MULTI_TO_MONO_CONVERTER_H

--- a/src/flowgraph/RampLinear.cpp
+++ b/src/flowgraph/RampLinear.cpp
@@ -19,6 +19,11 @@
 #include "FlowGraphNode.h"
 #include "RampLinear.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 RampLinear::RampLinear(int32_t channelCount)

--- a/src/flowgraph/RampLinear.h
+++ b/src/flowgraph/RampLinear.h
@@ -23,6 +23,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -92,5 +97,6 @@ private:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_RAMP_LINEAR_H

--- a/src/flowgraph/SampleRateConverter.cpp
+++ b/src/flowgraph/SampleRateConverter.cpp
@@ -16,6 +16,11 @@
 
 #include "SampleRateConverter.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 using namespace resampler;
 

--- a/src/flowgraph/SampleRateConverter.h
+++ b/src/flowgraph/SampleRateConverter.h
@@ -23,6 +23,11 @@
 #include "FlowGraphNode.h"
 #include "resampler/MultiChannelResampler.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 class SampleRateConverter : public FlowGraphFilter {
@@ -52,5 +57,8 @@ private:
     int64_t mInputFramePosition = 0; // monotonic counter of input frames used for pullData
 
 };
+
 } /* namespace flowgraph */
+} /* namespace oboe */
+
 #endif //OBOE_SAMPLE_RATE_CONVERTER_H

--- a/src/flowgraph/SinkFloat.cpp
+++ b/src/flowgraph/SinkFloat.cpp
@@ -19,6 +19,11 @@
 #include "FlowGraphNode.h"
 #include "SinkFloat.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 SinkFloat::SinkFloat(int32_t channelCount)

--- a/src/flowgraph/SinkFloat.h
+++ b/src/flowgraph/SinkFloat.h
@@ -23,6 +23,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -40,5 +45,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SINK_FLOAT_H

--- a/src/flowgraph/SinkI16.cpp
+++ b/src/flowgraph/SinkI16.cpp
@@ -23,6 +23,11 @@
 #include <audio_utils/primitives.h>
 #endif
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 SinkI16::SinkI16(int32_t channelCount)

--- a/src/flowgraph/SinkI16.h
+++ b/src/flowgraph/SinkI16.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -39,5 +44,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SINK_I16_H

--- a/src/flowgraph/SinkI24.cpp
+++ b/src/flowgraph/SinkI24.cpp
@@ -25,6 +25,11 @@
 #include <audio_utils/primitives.h>
 #endif
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 SinkI24::SinkI24(int32_t channelCount)

--- a/src/flowgraph/SinkI24.h
+++ b/src/flowgraph/SinkI24.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -40,5 +45,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SINK_I24_H

--- a/src/flowgraph/SourceFloat.cpp
+++ b/src/flowgraph/SourceFloat.cpp
@@ -20,6 +20,11 @@
 #include "FlowGraphNode.h"
 #include "SourceFloat.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 SourceFloat::SourceFloat(int32_t channelCount)

--- a/src/flowgraph/SourceFloat.h
+++ b/src/flowgraph/SourceFloat.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -39,5 +44,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SOURCE_FLOAT_H

--- a/src/flowgraph/SourceI16.cpp
+++ b/src/flowgraph/SourceI16.cpp
@@ -24,6 +24,11 @@
 #include <audio_utils/primitives.h>
 #endif
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 SourceI16::SourceI16(int32_t channelCount)

--- a/src/flowgraph/SourceI16.h
+++ b/src/flowgraph/SourceI16.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 /**
  * AudioSource that reads a block of pre-defined 16-bit integer data.
@@ -38,5 +43,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SOURCE_I16_H

--- a/src/flowgraph/SourceI24.cpp
+++ b/src/flowgraph/SourceI24.cpp
@@ -24,6 +24,11 @@
 #include "FlowGraphNode.h"
 #include "SourceI24.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+using namespace aaudio;
+#else
+using namespace oboe;
+#endif
 using namespace flowgraph;
 
 constexpr int kBytesPerI24Packed = 3;

--- a/src/flowgraph/SourceI24.h
+++ b/src/flowgraph/SourceI24.h
@@ -22,6 +22,11 @@
 
 #include "FlowGraphNode.h"
 
+#if FLOWGRAPH_ANDROID_INTERNAL
+namespace aaudio {
+#else
+namespace oboe {
+#endif
 namespace flowgraph {
 
 /**
@@ -39,5 +44,6 @@ public:
 };
 
 } /* namespace flowgraph */
+} /* namespace oboe */
 
 #endif //FLOWGRAPH_SOURCE_I24_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(
         testOboe
         testAAudio.cpp
         testUtilities.cpp
-#        testFlowgraph.cpp
+        testFlowgraph.cpp
         testStreamClosedMethods.cpp
         testStreamWaitState.cpp
         testXRunBehaviour.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.4.1)
 # This may work on Linux.
 # set(ANDROID_NDK $ENV{HOME}/Android/sdk/ndk-bundle)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -std=c++14 -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -std=c++14")
 
 # Include GoogleTest library
 set(GOOGLETEST_ROOT ${ANDROID_NDK}/sources/third_party/googletest)
@@ -28,7 +28,7 @@ add_executable(
         testOboe
         testAAudio.cpp
         testUtilities.cpp
-        testFlowgraph.cpp
+#        testFlowgraph.cpp
         testStreamClosedMethods.cpp
         testStreamWaitState.cpp
         testXRunBehaviour.cpp

--- a/tests/testFlowgraph.cpp
+++ b/tests/testFlowgraph.cpp
@@ -36,7 +36,7 @@
 #include "flowgraph/SourceI16.h"
 #include "flowgraph/SourceI24.h"
 
-using namespace flowgraph;
+using namespace oboe::flowgraph;
 
 constexpr int kBytesPerI24Packed = 3;
 


### PR DESCRIPTION
Use an oboe::flowgraph namespace to prevent AAudio from calling
objects in the Oboe flowgraph library.
That was causing memory corruption.

Fixes #930