### PR TITLE
oboe: cleanup fifo includes

### DIFF
--- a/src/fifo/FifoBuffer.cpp
+++ b/src/fifo/FifoBuffer.cpp
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
-#include <time.h>
-#include <memory.h>
-#include <cassert>
 #include <algorithm>
+#include <memory.h>
+#include <stdint.h>
 
-#include "common/OboeDebug.h"
 #include "fifo/FifoControllerBase.h"
 #include "fifo/FifoController.h"
 #include "fifo/FifoControllerIndirect.h"
 #include "fifo/FifoBuffer.h"
-#include "common/AudioClock.h"
 
 namespace oboe {
 

--- a/src/fifo/FifoBuffer.h
+++ b/src/fifo/FifoBuffer.h
@@ -17,12 +17,12 @@
 #ifndef OBOE_FIFOPROCESSOR_H
 #define OBOE_FIFOPROCESSOR_H
 
-#include <unistd.h>
-#include <sys/types.h>
+#include <memory>
+#include <stdint.h>
 
-#include "common/OboeDebug.h"
-#include "FifoControllerBase.h"
 #include "oboe/Definitions.h"
+
+#include "FifoControllerBase.h"
 
 namespace oboe {
 

--- a/src/fifo/FifoController.cpp
+++ b/src/fifo/FifoController.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cassert>
-#include <sys/types.h>
+#include <stdint.h>
+
 #include "FifoControllerBase.h"
 #include "FifoController.h"
 

--- a/src/fifo/FifoController.h
+++ b/src/fifo/FifoController.h
@@ -17,9 +17,10 @@
 #ifndef NATIVEOBOE_FIFOCONTROLLER_H
 #define NATIVEOBOE_FIFOCONTROLLER_H
 
-#include <sys/types.h>
-#include "FifoControllerBase.h"
 #include <atomic>
+#include <stdint.h>
+
+#include "FifoControllerBase.h"
 
 namespace oboe {
 

--- a/src/fifo/FifoControllerBase.cpp
+++ b/src/fifo/FifoControllerBase.cpp
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-#include "FifoControllerBase.h"
-
-#include <cassert>
-#include <sys/types.h>
 #include <algorithm>
-#include "FifoControllerBase.h"
+#include <cassert>
+#include <stdint.h>
 
-#include "common/OboeDebug.h"
+#include "FifoControllerBase.h"
 
 namespace oboe {
 

--- a/src/fifo/FifoControllerBase.h
+++ b/src/fifo/FifoControllerBase.h
@@ -18,7 +18,6 @@
 #define NATIVEOBOE_FIFOCONTROLLERBASE_H
 
 #include <stdint.h>
-#include <sys/types.h>
 
 namespace oboe {
 

--- a/src/fifo/FifoControllerIndirect.cpp
+++ b/src/fifo/FifoControllerIndirect.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
 
 #include "FifoControllerIndirect.h"
 

--- a/src/fifo/FifoControllerIndirect.h
+++ b/src/fifo/FifoControllerIndirect.h
@@ -17,8 +17,10 @@
 #ifndef NATIVEOBOE_FIFOCONTROLLERINDIRECT_H
 #define NATIVEOBOE_FIFOCONTROLLERINDIRECT_H
 
-#include "FifoControllerBase.h"
 #include <atomic>
+#include <stdint.h>
+
+#include "FifoControllerBase.h"
 
 namespace oboe {
 


### PR DESCRIPTION
Remove AudioClock.h and other unnecessary includes.

Fixes #927