### PR TITLE
Added device section for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,24 @@ App name used for testing:
 
 **Actual behavior**
 
+**Device**
+
+If device specific, please share values for these properties:
+
+```
+adb shell getprop ro.product.brand
+adb shell getprop ro.product.manufacturer
+adb shell getprop ro.product.model
+adb shell getprop ro.product.device
+adb shell getprop ro.product.cpu.abi
+adb shell getprop ro.build.description
+adb shell getprop ro.hardware
+adb shell getprop ro.hardware.chipname
+adb shell getprop ro.arch
+adb shell getprop | grep aaudio
+
+```
+
 **Any additional context**
 
 If applicable, please attach a recording of the sound.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,20 +24,10 @@ App name used for testing:
 
 **Device**
 
-If device specific, please share values for these properties:
+If device specific, please share the result for the following: 
 
 ```
-adb shell getprop ro.product.brand
-adb shell getprop ro.product.manufacturer
-adb shell getprop ro.product.model
-adb shell getprop ro.product.device
-adb shell getprop ro.product.cpu.abi
-adb shell getprop ro.build.description
-adb shell getprop ro.hardware
-adb shell getprop ro.hardware.chipname
-adb shell getprop ro.arch
-adb shell getprop | grep aaudio
-
+for p in ro.product.brand ro.product.manufacturer ro.product.model ro.product.device ro.product.cpu.abi ro.build.description ro.hardware ro.hardware.chipname ro.arch "| grep aaudio"; do echo "$p = $(adb shell getprop $p)"; done
 ```
 
 **Any additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,14 @@ App name used for testing:
 
 **Device**
 
-If device specific, please share the result for the following: 
+If device specific, connect the device and please share the result for the following script. This gets properties of the device. 
 
 ```
-for p in ro.product.brand ro.product.manufacturer ro.product.model ro.product.device ro.product.cpu.abi ro.build.description ro.hardware ro.hardware.chipname ro.arch "| grep aaudio"; do echo "$p = $(adb shell getprop $p)"; done
+for p in \
+    ro.product.brand ro.product.manufacturer ro.product.model \
+    ro.product.device ro.product.cpu.abi ro.build.description \
+    ro.hardware ro.hardware.chipname ro.arch "| grep aaudio";
+    do echo "$p = $(adb shell getprop $p)"; done
 ```
 
 **Any additional context**


### PR DESCRIPTION
Phil usually requests `ro.hardware.chipname` and `ro.arch` which don't exist on my devices. So additionally I added related properties I found.