### PR TITLE
live-effect: use playback stream sample rate to open record stream

### DIFF
--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -86,7 +86,10 @@ oboe::Result  LiveEffectEngine::openStreams() {
     setupPlaybackStreamParameters(&outBuilder);
     oboe::Result result = outBuilder.openManagedStream(mPlayStream);
     if (result != oboe::Result::OK) {
+        mSampleRate = oboe::kUnspecified;
         return result;
+    } else {
+        mSampleRate = mPlayStream->getSampleRate();
     }
     warnIfNotLowLatency(mPlayStream);
 


### PR DESCRIPTION
Related issue: https://github.com/google/oboe/issues/956