### PR TITLE
oboe: delay before closing an AAudio stream

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -301,8 +301,8 @@ Result AudioStreamAAudio::close() {
         // even after a close. If the stream has been closed then the callback
         // can access memory that has been freed. That causes a crash.
         // Two milliseconds may be enough but 10 msec is even safer.
-        // This seems to be less likely in Q but we have seen some reports.
-        if (getSdkVersion() <= __ANDROID_API_Q__) {
+        // This seems to be more likely in P or earlier. But it can also occur in later versions.
+        if (OboeGlobals::areWorkaroundsEnabled()) {
             usleep(kDelayBeforeCloseMillis * 1000);
         }
         return static_cast<Result>(mLibLoader->stream_close(stream));

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -110,6 +110,9 @@ protected:
 
 private:
 
+    // Time to sleep in order to prevent a race condition with a callback after a close().
+    static constexpr int kDelayBeforeCloseMillis = 10;
+
     std::atomic<bool>    mCallbackThreadEnabled;
 
     // pointer to the underlying AAudio stream, valid if open, null if closed


### PR DESCRIPTION
This is a workaround for a possible callback after close that can occur
if close is called immediately after a stop.
This can occur on P, particularly when using Bluetooth devices.

Fixes #967 