### PR TITLE
fixed shebang in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2018 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,8 +43,6 @@
 # permission, hence the need for the UnitTestRunner app. 
 # 
 ################################################
-
-#!/bin/bash
 
 # Directories, paths and filenames
 BUILD_DIR=build


### PR DESCRIPTION
.. otherwise shebang won't be taken into account and the script will run in the default shell.
When I ran the original script, it ran on my zsh and produced errors (Ubuntu/Linux).
Moving shebang to the top fixes the issue as the script run in bash as expected.