### PR TITLE
tests: test for invalid formats with OpenSL ES

### DIFF
--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -138,6 +138,29 @@ TEST_F(StreamOpen, InputForOpenSLESPerformanceModeShouldBeNone){
     closeStream();
 }
 
+TEST_F(StreamOpen, ForOpenSlesIllegalFormatRejectedOutput) {
+    mBuilder.setAudioApi(AudioApi::OpenSLES);
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
+    mBuilder.setFormat(static_cast<AudioFormat>(666));
+    Result r = mBuilder.openStream(&mStream);
+    EXPECT_NE(r, Result::OK) << "Should not open stream " << convertToText(r);
+    if (mStream != nullptr) {
+        mStream->close(); // just in case it accidentally opened
+    }
+}
+
+TEST_F(StreamOpen, ForOpenSlesIllegalFormatRejectedInput) {
+    mBuilder.setAudioApi(AudioApi::OpenSLES);
+    mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
+    mBuilder.setDirection(Direction::Input);
+    mBuilder.setFormat(static_cast<AudioFormat>(666));
+    Result r = mBuilder.openStream(&mStream);
+    EXPECT_NE(r, Result::OK) << "Should not open stream " << convertToText(r);
+    if (mStream != nullptr) {
+        mStream->close(); // just in case it accidentally opened
+    }
+}
+
 // Make sure the callback is called with the requested FramesPerCallback
 TEST_F(StreamOpen, OpenSLESFramesPerCallback) {
     const int kRequestedFramesPerCallback = 417;


### PR DESCRIPTION
This replaces PR #553 which had a tangled merge.
Oboe is returning ErrorInternal for invalid formats.

See #989 for adding more parameter checks.