### PR TITLE
OboeTester: fixed crash when exiting Auto Glitch Test

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AutoGlitchActivity.java
@@ -307,21 +307,23 @@ public class AutoGlitchActivity extends GlitchActivity implements Runnable {
             e.printStackTrace();
         } finally {
             super.stopAudioTest();
-            log("\n==== SUMMARY ========");
-            if (mFailCount > 0) {
-                log(mPassCount + " passed. " + mFailCount + " failed.");
-                log("These tests FAILED:");
-                log(mFailedSummary.toString());
-            } else {
-                log("All tests PASSED.");
-            }
-            log("== FINISHED at " + new Date());
-            runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    onTestFinished();
+            if (mThreadEnabled) {
+                log("\n==== SUMMARY ========");
+                if (mFailCount > 0) {
+                    log(mPassCount + " passed. " + mFailCount + " failed.");
+                    log("These tests FAILED:");
+                    log(mFailedSummary.toString());
+                } else {
+                    log("All tests PASSED.");
                 }
-            });
+                log("== FINISHED at " + new Date());
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        onTestFinished();
+                    }
+                });
+            }
         }
     }
 

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
@@ -49,7 +49,8 @@ abstract class TestAudioActivity extends Activity {
     public static final int AUDIO_STATE_STARTED = 1;
     public static final int AUDIO_STATE_PAUSED = 2;
     public static final int AUDIO_STATE_STOPPED = 3;
-    public static final int AUDIO_STATE_CLOSED = 4;
+    public static final int AUDIO_STATE_CLOSING = 4;
+    public static final int AUDIO_STATE_CLOSED = 5;
 
     public static final int COLOR_ACTIVE = 0xFFD0D0A0;
     public static final int COLOR_IDLE = 0xFFD0D0D0;
@@ -493,10 +494,26 @@ abstract class TestAudioActivity extends Activity {
         updateEnabledWidgets();
     }
 
-    public void closeAudio() {
+    // Make synchronized so we don't close from two streams at the same time.
+    public synchronized void closeAudio() {
+        if (mAudioState >= AUDIO_STATE_CLOSING) {
+            Log.d(TAG, "closeAudio() already closing");
+            return;
+        }
+        mAudioState = AUDIO_STATE_CLOSING;
+
         mStreamSniffer.stopStreamSniffer();
+        // Close output streams first because legacy callbacks may still be active
+        // and an output stream may be calling the input stream.
         for (StreamContext streamContext : mStreamContexts) {
-            streamContext.tester.close();
+            if (!streamContext.isInput()) {
+                streamContext.tester.close();
+            }
+        }
+        for (StreamContext streamContext : mStreamContexts) {
+            if (streamContext.isInput()) {
+                streamContext.tester.close();
+            }
         }
 
         if (mScoStarted) {


### PR DESCRIPTION
Hitting Back button while in the middle of the
Auto Glitch Test could cause a crash.

I was calling closeAudio when the test thread finished.
AND I was calling closeAudio() from the Activity onStop() call.
They were colliding as I deleted the Oboe Stream.
So I synchronized the closeAudio() method and protected it with a new CLOSING state.