### PR TITLE
Simple fix to hello-oboe related to shared_ptr

### DIFF
--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
@@ -134,7 +134,6 @@ void HelloOboeEngine::restart() {
 
 oboe::Result HelloOboeEngine::start() {
     std::lock_guard<std::mutex> lock(mLock);
-    if (!mStream) return oboe::Result::ErrorNull;
 
     auto result = createPlaybackStream();
     if (result == oboe::Result::OK){


### PR DESCRIPTION
At the app starting up time, inside the HelloOboeEngine constructor, mStream would always nullptr as no allocation to the raw pointer yet; when calling into HelloOboeEngine::start(), so it would still be nullptr, so check for nullptr would always fail, hence mStream would never get chance to be allocated; when later calling into HelloOboeEngine::tap(), a nullptr is dereferenced, resulting to a crash.

Since builder->openStream() reset the share_ptr, it could tolerate a nullptr. The fix is enable nullptr case in mStream in this sample, there will not be memory leak side-effect.