### PR TITLE
oboe: use proxy for callback size adapter

### DIFF
--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -80,9 +80,10 @@ AudioStream *AudioStreamBuilder::build() {
 }
 
 bool AudioStreamBuilder::isCompatible(AudioStreamBase &other) {
-    return getSampleRate() == other.getSampleRate()
-           && getFormat() == other.getFormat()
-           && getChannelCount() == other.getChannelCount();
+    return (getSampleRate() == oboe::Unspecified || getSampleRate() == other.getSampleRate())
+           && (getFormat() == (AudioFormat)oboe::Unspecified || getFormat() == other.getFormat())
+           && (getFramesPerCallback() == oboe::Unspecified || getFramesPerCallback() == other.getFramesPerCallback())
+           && (getChannelCount() == oboe::Unspecified || getChannelCount() == other.getChannelCount());
 }
 
 Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
@@ -111,7 +112,7 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
         }
 
         if (isCompatible(*tempStream)) {
-            // Everything matches so we can just use the child stream directly.
+            // The child stream would work as the requested stream so we can just use it directly.
             *streamPP = tempStream;
             return result;
         } else {
@@ -125,6 +126,9 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
             }
             if (getSampleRate() == oboe::Unspecified) {
                 parentBuilder.setSampleRate(tempStream->getSampleRate());
+            }
+            if (getFramesPerCallback() == oboe::Unspecified) {
+                parentBuilder.setFramesPerCallback(tempStream->getFramesPerCallback());
             }
 
             // Use childStream in a FilterAudioStream.

--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -120,6 +120,28 @@ bool QuirksManager::isConversionNeeded(
     const bool isInput = builder.getDirection() == Direction::Input;
     const bool isFloat = builder.getFormat() == AudioFormat::Float;
 
+    // There are multiple bugs involving using callback with a specified callback size.
+    // Issue #778: O to Q had a problem with Legacy INPUT streams for FLOAT streams
+    // and a specified callback size. It would assert because of a bad buffer size.
+    //
+    // Issue #973: O to R had a problem with Legacy output streams using callback and a specified callback size.
+    // An AudioTrack stream could still be running when the AAudio FixedBlockReader was closed.
+    // Internally b/161914201#comment25
+    //
+    // Issue #983: O to R would glitch if the framesPerCallback was too small.
+    //
+    // Most of these problems were related to Legacy stream. MMAP was OK. But we don't
+    // know if we will get an MMAP stream. So, to be safe, just do the conversion in Oboe.
+    if (OboeGlobals::areWorkaroundsEnabled()
+            && builder.willUseAAudio()
+            && builder.getCallback() != nullptr
+            && builder.getFramesPerCallback() != 0
+            && getSdkVersion() <= __ANDROID_API_R__) {
+        LOGI("QuirksManager::%s() avoid setFramesPerCallback(n>0)", __func__);
+        childBuilder.setFramesPerCallback(oboe::Unspecified);
+        conversionNeeded = true;
+    }
+
     // If a SAMPLE RATE is specified for low latency then let the native code choose an optimal rate.
     // TODO There may be a problem if the devices supports low latency
     //      at a higher rate than the default.


### PR DESCRIPTION
Avoid using callback size adapters in AAudio because of various bugs.
If setFramesPerCallback() called then use a filter stream and do the
block size adaptation in Oboe as part of the data conversion flowgraph.

Fixes #778
Fixes #973
Fixes #983