### PR TITLE
OboeTester: support OpenSLES in automated tests

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         // Also update the versions in the AndroidManifest.xml file.
-        versionCode 36
-        versionName "1.5.28"
+        versionCode 37
+        versionName "1.5.29"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.oboe.manualtest"
-    android:versionCode="36"
-    android:versionName="1.5.28">
+    android:versionCode="37"
+    android:versionName="1.5.29">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AnalyzerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/AnalyzerActivity.java
@@ -26,6 +26,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -46,6 +47,12 @@ public class AnalyzerActivity extends TestInputActivity {
 
     protected static final String KEY_FILE_NAME = "file";
     protected static final String KEY_BUFFER_BURSTS = "buffer_bursts";
+
+    public static final String VALUE_UNSPECIFIED = "unspecified";
+    public static final String KEY_IN_API = "in_api";
+    public static final String KEY_OUT_API = "out_api";
+    public static final String VALUE_API_AAUDIO = "aaudio";
+    public static final String VALUE_API_OPENSLES = "opensles";
 
     AudioOutputTester mAudioOutTester;
     protected BufferSizeView mBufferSizeView;
@@ -160,6 +167,30 @@ public class AnalyzerActivity extends TestInputActivity {
     }
 
     public void stopAudioTest() {
+    }
+
+    private int getApiFromText(String text) {
+        if (VALUE_API_AAUDIO.equals(text)) {
+            return StreamConfiguration.NATIVE_API_AAUDIO;
+        } else if (VALUE_API_OPENSLES.equals(text)) {
+            return StreamConfiguration.NATIVE_API_OPENSLES;
+        } else {
+            return StreamConfiguration.NATIVE_API_UNSPECIFIED;
+        }
+    }
+
+    void configureStreamsFromBundleForApi(Bundle bundle) {
+        // Configure settings
+        StreamConfiguration requestedInConfig = mAudioInputTester.requestedConfiguration;
+        StreamConfiguration requestedOutConfig = mAudioOutTester.requestedConfiguration;
+
+        // OpenSL ES or AAudio API
+        String text = bundle.getString(KEY_IN_API, VALUE_UNSPECIFIED);
+        int audioApi = getApiFromText(text);
+        requestedInConfig.setNativeApi(audioApi);
+        text = bundle.getString(KEY_OUT_API, VALUE_UNSPECIFIED);
+        audioApi = getApiFromText(text);
+        requestedOutConfig.setNativeApi(audioApi);
     }
 
     void writeTestResultIfPermitted(String resultString) {

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/ManualGlitchActivity.java
@@ -20,11 +20,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
 import java.io.IOException;
-import java.util.stream.Stream;
 
 public class ManualGlitchActivity extends GlitchActivity {
 
@@ -176,6 +176,8 @@ public class ManualGlitchActivity extends GlitchActivity {
 
         requestedInConfig.reset();
         requestedOutConfig.reset();
+
+        configureStreamsFromBundleForApi(bundle);
 
         // Extract parameters from the bundle.
         String text = bundle.getString(KEY_IN_PERF, VALUE_PERF_LOW_LATENCY);

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
@@ -325,11 +325,15 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
             handler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    onMeasure(null);
+                    startAutomaticTest();
                 }
             }, 500); // TODO where is the race, close->open?
-
         }
+    }
+
+    void startAutomaticTest() {
+        configureStreamsFromBundleForApi(mBundleFromIntent);
+        onMeasure(null);
         mBundleFromIntent = null;
     }
 


### PR DESCRIPTION
Use with automated latency and glitch test.
For example: -es in_api opensles

Fixes #944