### PR TITLE
fixes #1027 handling of skipped chunks during wav parse

### DIFF
--- a/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
+++ b/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
@@ -94,7 +94,7 @@ void WavStreamReader::parse() {
         } else {
             chunk = new WavChunkHeader(tag);
             chunk->read(mStream);
-            mStream->advance(mDataChunk->mChunkSize); // skip the body
+            mStream->advance(chunk->mChunkSize); // skip the body
         }
 
         (*mChunkMap)[tag] = chunk;


### PR DESCRIPTION
Skipped chunks should now be skipped properly without crashing.