### PR TITLE
Prevent test segfaults when a stream can't be opened

### DIFF
--- a/tests/testStreamClosedMethods.cpp
+++ b/tests/testStreamClosedMethods.cpp
@@ -32,25 +32,24 @@ class StreamClosedReturnValues : public ::testing::Test {
 
 protected:
 
-    bool openStream(){
+    bool openStream() {
         Result r = mBuilder.openStream(&mStream);
         EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
         return (r == Result::OK);
     }
 
-    void closeStream(){
-        if (mStream != nullptr){
-            Result r = mStream->close();
-            if (r != Result::OK){
-                FAIL() << "Failed to close stream. " << convertToText(r);
-            }
-        }
+    bool closeStream() {
+        Result r = mStream->close();
+        EXPECT_EQ(r, Result::OK) << "Failed to close stream. " << convertToText(r);
+        return (r == Result::OK);
     }
 
-    void openAndCloseStream(){
-        openStream();
-        closeStream();
-        ASSERT_EQ(mStream->getState(), StreamState::Closed) << "Stream state " << convertToText(mStream->getState());
+    bool openAndCloseStream() {
+        if (!openStream() || !closeStream())
+            return false;
+        StreamState s = mStream->getState();
+        EXPECT_EQ(s, StreamState::Closed) << "Stream state " << convertToText(mStream->getState());
+        return (s == StreamState::Closed);
     }
 
     AudioStreamBuilder mBuilder;
@@ -61,7 +60,7 @@ protected:
 TEST_F(StreamClosedReturnValues, GetChannelCountReturnsLastKnownValue){
 
     mBuilder.setChannelCount(2);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getChannelCount(), 2);
 }
 
@@ -70,68 +69,68 @@ TEST_F(StreamClosedReturnValues, GetDirectionReturnsLastKnownValue){
     // Note that when testing on the emulator setting the direction to Input will result in ErrorInternal when
     // opening the stream
     mBuilder.setDirection(Direction::Input);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getDirection(), Direction::Input);
 }
 
 TEST_F(StreamClosedReturnValues, GetSampleRateReturnsLastKnownValue){
 
     mBuilder.setSampleRate(8000);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getSampleRate(), 8000);
 }
 
 TEST_F(StreamClosedReturnValues, GetFramesPerCallbackReturnsLastKnownValue) {
 
     mBuilder.setFramesPerCallback(192);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getFramesPerCallback(), 192);
 }
 
 TEST_F(StreamClosedReturnValues, GetFormatReturnsLastKnownValue) {
 
     mBuilder.setFormat(AudioFormat::I16);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getFormat(), AudioFormat::I16);
 }
 
 TEST_F(StreamClosedReturnValues, GetBufferSizeInFramesReturnsLastKnownValue) {
 
-    openStream();
+    ASSERT_TRUE(openStream());
     int32_t bufferSize = mStream->getBufferSizeInFrames();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getBufferSizeInFrames(), bufferSize);
 }
 
 TEST_F(StreamClosedReturnValues, GetBufferCapacityInFramesReturnsLastKnownValue) {
 
-    openStream();
+    ASSERT_TRUE(openStream());
     int32_t bufferCapacity = mStream->getBufferCapacityInFrames();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getBufferCapacityInFrames(), bufferCapacity);
 }
 
 TEST_F(StreamClosedReturnValues, GetSharingModeReturnsLastKnownValue) {
 
-    openStream();
+    ASSERT_TRUE(openStream());
     SharingMode s = mStream->getSharingMode();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getSharingMode(), s);
 }
 
 TEST_F(StreamClosedReturnValues, GetPerformanceModeReturnsLastKnownValue) {
 
-    openStream();
+    ASSERT_TRUE(openStream());
     PerformanceMode p = mStream->getPerformanceMode();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getPerformanceMode(), p);
 }
 
 TEST_F(StreamClosedReturnValues, GetDeviceIdReturnsLastKnownValue) {
 
-    openStream();
+    ASSERT_TRUE(openStream());
     int32_t d = mStream->getDeviceId();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getDeviceId(), d);
 }
 
@@ -139,81 +138,81 @@ TEST_F(StreamClosedReturnValues, GetCallbackReturnsLastKnownValue) {
 
     AudioStreamCallback *callback = new MyCallback();
     mBuilder.setCallback(callback);
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
 
     AudioStreamCallback *callback2 = mStream->getCallback();
     ASSERT_EQ(callback, callback2);
 }
 
 TEST_F(StreamClosedReturnValues, GetUsageReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     Usage u = mStream->getUsage();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getUsage(), u);
 }
 
 TEST_F(StreamClosedReturnValues, GetContentTypeReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     ContentType c = mStream->getContentType();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getContentType(), c);
 }
 
 TEST_F(StreamClosedReturnValues, GetInputPresetReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     auto i = mStream->getInputPreset();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getInputPreset(), i);
 }
 
 TEST_F(StreamClosedReturnValues, GetSessionIdReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     auto s = mStream->getSessionId();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getSessionId(), s);
 }
 
 TEST_F(StreamClosedReturnValues, StreamStateIsClosed){
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     ASSERT_EQ(mStream->getState(), StreamState::Closed);
 }
 
 TEST_F(StreamClosedReturnValues, GetXRunCountReturnsLastKnownValue){
 
-    openStream();
+    ASSERT_TRUE(openStream());
     if (mStream->isXRunCountSupported()){
         auto i = mStream->getXRunCount();
         ASSERT_EQ(mStream->getXRunCount(), i);
     }
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamClosedReturnValues, GetFramesPerBurstReturnsLastKnownValue){
 
-    openStream();
+    ASSERT_TRUE(openStream());
     auto f = mStream->getFramesPerBurst();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getFramesPerBurst(), f);
 }
 
 TEST_F(StreamClosedReturnValues, GetBytesPerFrameReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     auto f = mStream->getBytesPerFrame();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getBytesPerFrame(), f);
 }
 
 TEST_F(StreamClosedReturnValues, GetBytesPerSampleReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     auto f = mStream->getBytesPerSample();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getBytesPerSample(), f);
 }
 
 TEST_F(StreamClosedReturnValues, GetFramesWrittenReturnsLastKnownValue){
     mBuilder.setFormat(AudioFormat::I16);
     mBuilder.setChannelCount(1);
-    openStream();
+    ASSERT_TRUE(openStream());
     mStream->start();
 
     int16_t buffer[4] = { 1, 2, 3, 4 };
@@ -225,7 +224,7 @@ TEST_F(StreamClosedReturnValues, GetFramesWrittenReturnsLastKnownValue){
     auto f = mStream->getFramesWritten();
     ASSERT_EQ(f, 4);
 
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getFramesWritten(), f);
 }
 
@@ -236,26 +235,25 @@ TEST_F(StreamClosedReturnValues, GetFramesReadReturnsLastKnownValue) {
     mBuilder.setFormat(AudioFormat::I16);
     mBuilder.setChannelCount(1);
 
-    if (openStream()){
-        mStream->start();
+    ASSERT_TRUE(openStream());
+    mStream->start();
 
 /*
-        int16_t buffer[192];
-        auto r = mStream->read(&buffer, 192, 0);
-        ASSERT_EQ(r.value(), 192);
+    int16_t buffer[192];
+    auto r = mStream->read(&buffer, 192, 0);
+    ASSERT_EQ(r.value(), 192);
 */
 
-        auto f = mStream->getFramesRead();
-//        ASSERT_EQ(f, 192);
+    auto f = mStream->getFramesRead();
+//    ASSERT_EQ(f, 192);
 
-        closeStream();
-        ASSERT_EQ(mStream->getFramesRead(), f);
-    };
+    ASSERT_TRUE(closeStream());
+    ASSERT_EQ(mStream->getFramesRead(), f);
 }
 
 TEST_F(StreamClosedReturnValues, GetTimestampReturnsErrorClosedIfSupported){
 
-    openStream();
+    ASSERT_TRUE(openStream());
 
     int64_t framePosition;
     int64_t presentationTime;
@@ -263,7 +261,7 @@ TEST_F(StreamClosedReturnValues, GetTimestampReturnsErrorClosedIfSupported){
     auto r = mStream->getTimestamp(CLOCK_MONOTONIC, &framePosition, &presentationTime);
     bool isTimestampSupported = (r == Result::OK);
 
-    closeStream();
+    ASSERT_TRUE(closeStream());
 
     if (isTimestampSupported){
         ASSERT_EQ(mStream->getTimestamp(CLOCK_MONOTONIC, &framePosition, &presentationTime), Result::ErrorClosed);
@@ -271,22 +269,22 @@ TEST_F(StreamClosedReturnValues, GetTimestampReturnsErrorClosedIfSupported){
 }
 
 TEST_F(StreamClosedReturnValues, GetAudioApiReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     AudioApi a = mStream->getAudioApi();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->getAudioApi(), a);
 }
 
 TEST_F(StreamClosedReturnValues, GetUsesAAudioReturnsLastKnownValue){
-    openStream();
+    ASSERT_TRUE(openStream());
     bool a = mStream->usesAAudio();
-    closeStream();
+    ASSERT_TRUE(closeStream());
     ASSERT_EQ(mStream->usesAAudio(), a);
 }
 
 TEST_F(StreamClosedReturnValues, StreamStateControlsReturnClosed){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     Result r = mStream->close();
     EXPECT_EQ(r, Result::ErrorClosed) << convertToText(r);
     r = mStream->start();
@@ -302,7 +300,7 @@ TEST_F(StreamClosedReturnValues, StreamStateControlsReturnClosed){
 
 TEST_F(StreamClosedReturnValues, WaitForStateChangeReturnsClosed){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     StreamState next;
     Result r = mStream->waitForStateChange(StreamState::Open, &next, 0);
     ASSERT_EQ(r, Result::ErrorClosed) << convertToText(r);
@@ -310,14 +308,14 @@ TEST_F(StreamClosedReturnValues, WaitForStateChangeReturnsClosed){
 
 TEST_F(StreamClosedReturnValues, SetBufferSizeInFramesReturnsClosed){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
     auto r = mStream->setBufferSizeInFrames(192);
     ASSERT_EQ(r.error(), Result::ErrorClosed);
 }
 
 TEST_F(StreamClosedReturnValues, CalculateLatencyInMillisReturnsClosedIfSupported){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
 
     if (mStream->getAudioApi() == AudioApi::AAudio){
         auto r = mStream->calculateLatencyMillis();
@@ -327,7 +325,7 @@ TEST_F(StreamClosedReturnValues, CalculateLatencyInMillisReturnsClosedIfSupporte
 
 TEST_F(StreamClosedReturnValues, ReadReturnsClosed){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
 
     int buffer[8]{0};
     auto r = mStream->read(buffer, 1, 0);
@@ -336,7 +334,7 @@ TEST_F(StreamClosedReturnValues, ReadReturnsClosed){
 
 TEST_F(StreamClosedReturnValues, WriteReturnsClosed){
 
-    openAndCloseStream();
+    ASSERT_TRUE(openAndCloseStream());
 
     int buffer[8]{0};
     auto r = mStream->write(buffer, 1, 0);

--- a/tests/testStreamClosedMethods.cpp
+++ b/tests/testStreamClosedMethods.cpp
@@ -32,10 +32,6 @@ class StreamClosedReturnValues : public ::testing::Test {
 
 protected:
 
-    void SetUp(){
-
-    }
-
     bool openStream(){
         Result r = mBuilder.openStream(&mStream);
         EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -45,14 +45,11 @@ protected:
         return (r == Result::OK);
     }
 
-    void closeStream() {
-        if (mStream != nullptr) {
-            Result r = mStream->close();
-            if (r != Result::OK) {
-                FAIL() << "Failed to close stream. " << convertToText(r);
-            }
-        }
+    bool closeStream() {
+        Result r = mStream->close();
+        EXPECT_EQ(r, Result::OK) << "Failed to close stream. " << convertToText(r);
         usleep(500 * 1000); // give previous stream time to settle
+        return (r == Result::OK);
     }
 
     void checkSampleRateConversionAdvancing(Direction direction) {
@@ -65,7 +62,7 @@ protected:
         mBuilder.setSampleRate(44100);
         mBuilder.setSampleRateConversionQuality(SampleRateConversionQuality::Medium);
 
-        openStream();
+        ASSERT_TRUE(openStream());
 
         ASSERT_EQ(mStream->requestStart(), Result::OK);
         int timeout = 20;
@@ -77,7 +74,7 @@ protected:
         ASSERT_GT(callback.framesPerCallback, 0);
         ASSERT_EQ(mStream->requestStop(), Result::OK);
 
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 
     AudioStreamBuilder mBuilder;
@@ -91,9 +88,9 @@ TEST_F(StreamOpen, ForOpenSLESDefaultSampleRateIsUsed){
     DefaultStreamValues::SampleRate = 44100;
     DefaultStreamValues::FramesPerBurst = 192;
     mBuilder.setAudioApi(AudioApi::OpenSLES);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->getSampleRate(), 44100);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, ForOpenSLESDefaultFramesPerBurstIsUsed){
@@ -102,18 +99,18 @@ TEST_F(StreamOpen, ForOpenSLESDefaultFramesPerBurstIsUsed){
     DefaultStreamValues::FramesPerBurst = 128; // used for low latency
     mBuilder.setAudioApi(AudioApi::OpenSLES);
     mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->getFramesPerBurst(), 128);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, ForOpenSLESDefaultChannelCountIsUsed){
 
     DefaultStreamValues::ChannelCount = 1;
     mBuilder.setAudioApi(AudioApi::OpenSLES);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->getChannelCount(), 1);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, OutputForOpenSLESPerformanceModeShouldBeNone){
@@ -122,9 +119,9 @@ TEST_F(StreamOpen, OutputForOpenSLESPerformanceModeShouldBeNone){
     mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
     mBuilder.setDirection(Direction::Output);
     mBuilder.setAudioApi(AudioApi::OpenSLES);
-    openStream();
+	ASSERT_TRUE(openStream());
     ASSERT_EQ((int)mStream->getPerformanceMode(), (int)PerformanceMode::None);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, InputForOpenSLESPerformanceModeShouldBeNone){
@@ -133,9 +130,9 @@ TEST_F(StreamOpen, InputForOpenSLESPerformanceModeShouldBeNone){
     mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
     mBuilder.setDirection(Direction::Input);
     mBuilder.setAudioApi(AudioApi::OpenSLES);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ((int)mStream->getPerformanceMode(), (int)PerformanceMode::None);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, ForOpenSlesIllegalFormatRejectedOutput) {
@@ -172,7 +169,7 @@ TEST_F(StreamOpen, OpenSLESFramesPerCallback) {
     mBuilder.setAudioApi(AudioApi::OpenSLES);
     mBuilder.setFramesPerCallback(kRequestedFramesPerCallback);
     mBuilder.setCallback(&callback);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->requestStart(), Result::OK);
     int timeout = 20;
     while (callback.framesPerCallback == 0 && timeout > 0) {
@@ -182,7 +179,7 @@ TEST_F(StreamOpen, OpenSLESFramesPerCallback) {
     ASSERT_EQ(kRequestedFramesPerCallback, callback.framesPerCallback);
     ASSERT_EQ(kRequestedFramesPerCallback, mStream->getFramesPerCallback());
     ASSERT_EQ(mStream->requestStop(), Result::OK);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 /* TODO - This is hanging!
@@ -195,7 +192,7 @@ TEST_F(StreamOpen, AAudioFramesPerCallbackLowLatency) {
     mBuilder.setFramesPerCallback(kRequestedFramesPerCallback);
     mBuilder.setCallback(&callback);
     mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(kRequestedFramesPerCallback, mStream->getFramesPerCallback());
     ASSERT_EQ(mStream->requestStart(), Result::OK);
     int timeout = 20;
@@ -205,7 +202,7 @@ TEST_F(StreamOpen, AAudioFramesPerCallbackLowLatency) {
     }
     ASSERT_EQ(kRequestedFramesPerCallback, callback.framesPerCallback);
     ASSERT_EQ(mStream->requestStop(), Result::OK);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 */
 
@@ -219,7 +216,7 @@ TEST_F(StreamOpen, AAudioFramesPerCallbackNone) {
     mBuilder.setFramesPerCallback(kRequestedFramesPerCallback);
     mBuilder.setCallback(&callback);
     mBuilder.setPerformanceMode(PerformanceMode::None);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(kRequestedFramesPerCallback, mStream->getFramesPerCallback());
     ASSERT_EQ(mStream->setBufferSizeInFrames(mStream->getBufferCapacityInFrames()), Result::OK);
     ASSERT_EQ(mStream->requestStart(), Result::OK);
@@ -230,7 +227,7 @@ TEST_F(StreamOpen, AAudioFramesPerCallbackNone) {
     }
     ASSERT_EQ(kRequestedFramesPerCallback, callback.framesPerCallback);
     ASSERT_EQ(mStream->requestStop(), Result::OK);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 */
 
@@ -239,9 +236,9 @@ TEST_F(StreamOpen, RecordingFormatUnspecifiedReturnsI16BeforeMarshmallow){
     if (getSdkVersion() < __ANDROID_API_M__){
         mBuilder.setDirection(Direction::Input);
         mBuilder.setFormat(AudioFormat::Unspecified);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::I16);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -250,9 +247,9 @@ TEST_F(StreamOpen, RecordingFormatUnspecifiedReturnsFloatOnMarshmallowAndLater){
     if (getSdkVersion() >= __ANDROID_API_M__){
         mBuilder.setDirection(Direction::Input);
         mBuilder.setFormat(AudioFormat::Unspecified);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::Float);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -263,7 +260,7 @@ TEST_F(StreamOpen, RecordingFormatFloatReturnsErrorBeforeMarshmallow){
         mBuilder.setFormat(AudioFormat::Float);
         Result r = mBuilder.openStream(&mStream);
         ASSERT_EQ(r, Result::ErrorInvalidFormat) << convertToText(r);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -272,9 +269,9 @@ TEST_F(StreamOpen, RecordingFormatFloatReturnsFloatOnMarshmallowAndLater){
     if (getSdkVersion() >= __ANDROID_API_M__){
         mBuilder.setDirection(Direction::Input);
         mBuilder.setFormat(AudioFormat::Float);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::Float);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -282,9 +279,9 @@ TEST_F(StreamOpen, RecordingFormatI16ReturnsI16){
 
     mBuilder.setDirection(Direction::Input);
     mBuilder.setFormat(AudioFormat::I16);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->getFormat(), AudioFormat::I16);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, PlaybackFormatUnspecifiedReturnsI16BeforeLollipop){
@@ -292,9 +289,9 @@ TEST_F(StreamOpen, PlaybackFormatUnspecifiedReturnsI16BeforeLollipop){
     if (getSdkVersion() < __ANDROID_API_L__){
         mBuilder.setDirection(Direction::Output);
         mBuilder.setFormat(AudioFormat::Unspecified);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::I16);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -303,9 +300,9 @@ TEST_F(StreamOpen, PlaybackFormatUnspecifiedReturnsFloatOnLollipopAndLater){
     if (getSdkVersion() >= __ANDROID_API_L__){
         mBuilder.setDirection(Direction::Output);
         mBuilder.setFormat(AudioFormat::Unspecified);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::Float);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -316,7 +313,7 @@ TEST_F(StreamOpen, PlaybackFormatFloatReturnsErrorBeforeLollipop){
         mBuilder.setFormat(AudioFormat::Float);
         Result r = mBuilder.openStream(&mStream);
         ASSERT_EQ(r, Result::ErrorInvalidFormat);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
@@ -325,27 +322,27 @@ TEST_F(StreamOpen, PlaybackFormatFloatReturnsFloatOnLollipopAndLater){
     if (getSdkVersion() >= __ANDROID_API_L__){
         mBuilder.setDirection(Direction::Output);
         mBuilder.setFormat(AudioFormat::Float);
-        openStream();
+        ASSERT_TRUE(openStream());
         ASSERT_EQ(mStream->getFormat(), AudioFormat::Float);
-        closeStream();
+        ASSERT_TRUE(closeStream());
     }
 }
 
 TEST_F(StreamOpen, PlaybackFormatI16ReturnsI16) {
     mBuilder.setDirection(Direction::Output);
     mBuilder.setFormat(AudioFormat::I16);
-    openStream();
+    ASSERT_TRUE(openStream());
     ASSERT_EQ(mStream->getFormat(), AudioFormat::I16);
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, OpenCloseLowLatencyStream){
     mBuilder.setDirection(Direction::Output);
     mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
     float *buf = new float[100];
-    openStream();
+    ASSERT_TRUE(openStream());
     delete[] buf;
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(StreamOpen, LowLatencyStreamHasSmallBufferSize){
@@ -353,10 +350,10 @@ TEST_F(StreamOpen, LowLatencyStreamHasSmallBufferSize){
     if (mBuilder.isAAudioRecommended()) {
         mBuilder.setDirection(Direction::Output);
         mBuilder.setPerformanceMode(PerformanceMode::LowLatency);
-        openStream();
+        ASSERT_TRUE(openStream());
         int32_t bufferSize = mStream->getBufferSizeInFrames();
         int32_t burst = mStream->getFramesPerBurst();
-        closeStream();
+        ASSERT_TRUE(closeStream());
         ASSERT_LE(bufferSize, burst * 3);
     }
 }

--- a/tests/testStreamStates.cpp
+++ b/tests/testStreamStates.cpp
@@ -59,13 +59,6 @@ protected:
         }
     }
 
-    void openAndCloseStream(){
-
-        openStream();
-        closeStream();
-        ASSERT_EQ(mStream->getState(), StreamState::Closed) << "Stream state " << convertToText(mStream->getState());
-    }
-
     void checkStreamStateIsStartedAfterStartingTwice(Direction direction) {
         openStream(direction);
 

--- a/tests/testStreamWaitState.cpp
+++ b/tests/testStreamWaitState.cpp
@@ -33,6 +33,7 @@ protected:
 
     bool openStream(Direction direction, PerformanceMode perfMode) {
         mBuilder.setDirection(direction);
+        mBuilder.setPerformanceMode(perfMode);
         Result r = mBuilder.openStream(&mStream);
         EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
         if (r != Result::OK)

--- a/tests/testStreamWaitState.cpp
+++ b/tests/testStreamWaitState.cpp
@@ -35,8 +35,12 @@ protected:
         mBuilder.setDirection(direction);
         Result r = mBuilder.openStream(&mStream);
         EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
-        EXPECT_EQ(mStream->getDirection(), direction) << convertToText(mStream->getDirection());
-        return (r == Result::OK);
+        if (r != Result::OK)
+            return false;
+
+        Direction d = mStream->getDirection();
+        EXPECT_EQ(d, direction) << convertToText(mStream->getDirection());
+        return (d == direction);
     }
 
     bool openStream(AudioStreamBuilder &builder) {
@@ -45,14 +49,11 @@ protected:
         return (r == Result::OK);
     }
 
-    void closeStream() {
-        if (mStream != nullptr){
-            Result r = mStream->close();
-            mStream = nullptr;
-            if (r != Result::OK && r != Result::ErrorClosed){
-                FAIL() << "Failed to close stream. " << convertToText(r);
-            }
-        }
+    bool closeStream() {
+        Result r = mStream->close();
+        EXPECT_TRUE(r == Result::OK || r == Result::ErrorClosed) <<
+            "Failed to close stream. " << convertToText(r);
+        return (r == Result::OK || r == Result::ErrorClosed);
     }
 
     void checkWaitZeroTimeout() {
@@ -119,46 +120,46 @@ protected:
 };
 
 TEST_F(TestStreamWaitState, OutputLowWaitZero) {
-    openStream(Direction::Output, PerformanceMode::LowLatency);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::LowLatency));
     checkWaitZeroTimeout();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputNoneWaitZero) {
-    openStream(Direction::Output, PerformanceMode::None);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::None));
     checkWaitZeroTimeout();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputLowWaitZeroSLES) {
     AudioStreamBuilder builder;
     builder.setPerformanceMode(PerformanceMode::LowLatency);
     builder.setAudioApi(AudioApi::OpenSLES);
-    openStream(builder);
+    ASSERT_TRUE(openStream(builder));
     checkWaitZeroTimeout();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputNoneWaitZeroSLES) {
     AudioStreamBuilder builder;
     builder.setPerformanceMode(PerformanceMode::None);
     builder.setAudioApi(AudioApi::OpenSLES);
-    openStream(builder);
+    ASSERT_TRUE(openStream(builder));
     checkWaitZeroTimeout();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 
 TEST_F(TestStreamWaitState, OutputLowStopWhileWaiting) {
-    openStream(Direction::Output, PerformanceMode::LowLatency);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::LowLatency));
     checkStopWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputNoneStopWhileWaiting) {
-    openStream(Direction::Output, PerformanceMode::LowLatency);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::LowLatency));
     checkStopWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 
@@ -166,43 +167,43 @@ TEST_F(TestStreamWaitState, OutputLowStopWhileWaitingSLES) {
     AudioStreamBuilder builder;
     builder.setPerformanceMode(PerformanceMode::LowLatency);
     builder.setAudioApi(AudioApi::OpenSLES);
-    openStream(builder);
+    ASSERT_TRUE(openStream(builder));
     checkStopWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 
 TEST_F(TestStreamWaitState, OutputLowCloseWhileWaiting) {
-    openStream(Direction::Output, PerformanceMode::LowLatency);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::LowLatency));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputNoneCloseWhileWaiting) {
-    openStream(Direction::Output, PerformanceMode::None);
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::None));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, InputLowCloseWhileWaiting) {
-    openStream(Direction::Input, PerformanceMode::LowLatency);
+    ASSERT_TRUE(openStream(Direction::Input, PerformanceMode::LowLatency));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, InputNoneCloseWhileWaiting) {
-    openStream(Direction::Input, PerformanceMode::None);
+    ASSERT_TRUE(openStream(Direction::Input, PerformanceMode::None));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(TestStreamWaitState, OutputNoneCloseWhileWaitingSLES) {
     AudioStreamBuilder builder;
     builder.setPerformanceMode(PerformanceMode::None);
     builder.setAudioApi(AudioApi::OpenSLES);
-    openStream(builder);
+    ASSERT_TRUE(openStream(builder));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 
@@ -210,7 +211,7 @@ TEST_F(TestStreamWaitState, OutputLowCloseWhileWaitingSLES) {
     AudioStreamBuilder builder;
     builder.setPerformanceMode(PerformanceMode::LowLatency);
     builder.setAudioApi(AudioApi::OpenSLES);
-    openStream(builder);
+    ASSERT_TRUE(openStream(builder));
     checkCloseWhileWaiting();
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }

--- a/tests/testXRunBehaviour.cpp
+++ b/tests/testXRunBehaviour.cpp
@@ -32,11 +32,6 @@ class XRunBehaviour : public ::testing::Test {
 
 protected:
 
-    void SetUp(){
-
-    }
-
-
     void openStream(){
         Result r = mBuilder.openStream(&mStream);
         if (r != Result::OK){
@@ -51,13 +46,6 @@ protected:
                 FAIL() << "Failed to close stream. " << convertToText(r);
             }
         }
-    }
-
-    void openAndCloseStream(){
-
-        openStream();
-        closeStream();
-        ASSERT_EQ(mStream->getState(), StreamState::Closed);
     }
 
     AudioStreamBuilder mBuilder;

--- a/tests/testXRunBehaviour.cpp
+++ b/tests/testXRunBehaviour.cpp
@@ -32,20 +32,16 @@ class XRunBehaviour : public ::testing::Test {
 
 protected:
 
-    void openStream(){
+    bool openStream() {
         Result r = mBuilder.openStream(&mStream);
-        if (r != Result::OK){
-            FAIL() << "Failed to open stream. " << convertToText(r);
-        }
+        EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
+        return (r == Result::OK);
     }
 
-    void closeStream(){
-        if (mStream != nullptr){
-            Result r = mStream->close();
-            if (r != Result::OK){
-                FAIL() << "Failed to close stream. " << convertToText(r);
-            }
-        }
+    bool closeStream() {
+        Result r = mStream->close();
+        EXPECT_EQ(r, Result::OK) << "Failed to close stream. " << convertToText(r);
+        return (r == Result::OK);
     }
 
     AudioStreamBuilder mBuilder;
@@ -57,29 +53,29 @@ protected:
 //  however, these aren't the same as the actual stream underruns
 TEST_F(XRunBehaviour, SupportedWhenStreamIsUsingAAudio){
 
-    openStream();
+    ASSERT_TRUE(openStream());
     if (mStream->getAudioApi() == AudioApi::AAudio){
         ASSERT_TRUE(mStream->isXRunCountSupported());
     }
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(XRunBehaviour, NotSupportedOnOpenSLESWhenStreamIsUsingCallback){
 
     MyCallback callback;
     mBuilder.setCallback(&callback);
-    openStream();
+    ASSERT_TRUE(openStream());
     if (mStream->getAudioApi() == AudioApi::OpenSLES){
         ASSERT_FALSE(mStream->isXRunCountSupported());
     }
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }
 
 TEST_F(XRunBehaviour, SupportedOnOpenSLESWhenStreamIsUsingBlockingIO){
 
-    openStream();
+    ASSERT_TRUE(openStream());
     if (mStream->getAudioApi() == AudioApi::OpenSLES){
         ASSERT_TRUE(mStream->isXRunCountSupported());
     }
-    closeStream();
+    ASSERT_TRUE(closeStream());
 }


### PR DESCRIPTION
Clean up the test code, including a refactoring that lets us properly handle errors in the common `openStream()`/`closeStream()`/`openAndCloseStream()` functions. This prevents the tests from segfaulting when, e.g., run as non-root on Android where attempting to open streams fails.