### PR TITLE
HelloOboe: fix crash on exit

### DIFF
--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
@@ -36,7 +36,6 @@
  */
 HelloOboeEngine::HelloOboeEngine()
         : mLatencyCallback(std::make_unique<LatencyTuningCallback>(*this)) {
-    start();
 }
 
 double HelloOboeEngine::getCurrentOutputLatencyMillis() {
@@ -154,14 +153,17 @@ oboe::Result HelloOboeEngine::start() {
     return result;
 }
 
-oboe::Result HelloOboeEngine::reopenStream() {
-    {
-        // Stop and close in case not already closed.
-        std::lock_guard<std::mutex> lock(mLock);
-        if (mStream) {
-            mStream->stop();
-            mStream->close();
-        }
+void HelloOboeEngine::stop() {
+    // Stop, close and delete in case not already closed.
+    std::lock_guard<std::mutex> lock(mLock);
+    if (mStream) {
+        mStream->stop();
+        mStream->close();
+        mStream.reset();
     }
+}
+
+oboe::Result HelloOboeEngine::reopenStream() {
+    stop();
     return start();
 }

--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.h
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.h
@@ -34,6 +34,17 @@ public:
 
     void tap(bool isDown);
 
+    /**
+     * Open and start a stream.
+     * @return error or OK
+     */
+    oboe::Result start();
+
+    /**
+     * Stop and close the stream.
+     */
+    void stop();
+
     // From IRestartable
     void restart() override;
 
@@ -78,7 +89,6 @@ private:
     oboe::Result reopenStream();
     oboe::Result createPlaybackStream();
     void         updateLatencyDetection();
-    oboe::Result start();
 
     std::shared_ptr<oboe::AudioStream> mStream;
     std::unique_ptr<LatencyTuningCallback> mLatencyCallback;

--- a/samples/hello-oboe/src/main/cpp/jni_bridge.cpp
+++ b/samples/hello-oboe/src/main/cpp/jni_bridge.cpp
@@ -32,6 +32,17 @@ Java_com_google_oboe_samples_hellooboe_PlaybackEngine_native_1createEngine(
         jclass /*unused*/) {
     // We use std::nothrow so `new` returns a nullptr if the engine creation fails
     HelloOboeEngine *engine = new(std::nothrow) HelloOboeEngine();
+    if (engine == nullptr) {
+        LOGE("Could not instantiate HelloOboeEngine");
+        return 0;
+    }
+    auto result = engine->start();
+    if (result != oboe::Result::OK) {
+        LOGE("Opening and starting stream failed. Returned %d", result);
+        engine->stop();
+        delete engine;
+        return 0;
+    }
     return reinterpret_cast<jlong>(engine);
 }
 
@@ -41,7 +52,9 @@ Java_com_google_oboe_samples_hellooboe_PlaybackEngine_native_1deleteEngine(
         jclass,
         jlong engineHandle) {
 
-    delete reinterpret_cast<HelloOboeEngine *>(engineHandle);
+    HelloOboeEngine *engine = reinterpret_cast<HelloOboeEngine *>(engineHandle);
+    engine->stop();
+    delete engine;
 }
 
 JNIEXPORT void JNICALL
@@ -151,10 +164,11 @@ Java_com_google_oboe_samples_hellooboe_PlaybackEngine_native_1isLatencyDetection
 }
 
 JNIEXPORT void JNICALL
-Java_com_google_oboe_samples_hellooboe_PlaybackEngine_native_1setDefaultStreamValues(JNIEnv *env,
-                                                                                  jclass type,
-                                                                                  jint sampleRate,
-                                                                                  jint framesPerBurst) {
+Java_com_google_oboe_samples_hellooboe_PlaybackEngine_native_1setDefaultStreamValues(
+        JNIEnv *env,
+        jclass type,
+        jint sampleRate,
+        jint framesPerBurst) {
     oboe::DefaultStreamValues::SampleRate = (int32_t) sampleRate;
     oboe::DefaultStreamValues::FramesPerBurst = (int32_t) framesPerBurst;
 }


### PR DESCRIPTION
It was crashing when the app was closed because
the stream was still running when the engine was deleted.
Now the stream is stopped and closed before deleting.

Also moved start() out of constructor.