### PR TITLE
oboe: change close() to close_l() for OpenSL

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -226,7 +226,7 @@ Result AudioInputStreamOpenSLES::close() {
         mLock.lock();
         // invalidate any interfaces
         mRecordInterface = nullptr;
-        result = AudioStreamOpenSLES::close();
+        result = AudioStreamOpenSLES::close_l();
     }
     mLock.unlock(); // avoid recursive lock
     return result;

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -253,7 +253,7 @@ Result AudioOutputStreamOpenSLES::close() {
         mLock.lock();
         // invalidate any interfaces
         mPlayInterface = nullptr;
-        result = AudioStreamOpenSLES::close();
+        result = AudioStreamOpenSLES::close_l();
     }
     mLock.unlock(); // avoid recursive lock
     return result;

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -260,7 +260,8 @@ SLresult AudioStreamOpenSLES::updateStreamParameters(SLAndroidConfigurationItf c
     return result;
 }
 
-Result AudioStreamOpenSLES::close() {
+// This is called under mLock.
+Result AudioStreamOpenSLES::close_l() {
     if (mState == StreamState::Closed) {
         return Result::ErrorClosed;
     }

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -50,7 +50,6 @@ public:
     virtual ~AudioStreamOpenSLES() = default;
 
     virtual Result open() override;
-    virtual Result close() override;
 
     /**
      * Query the current state, eg. OBOE_STREAM_STATE_PAUSING
@@ -79,6 +78,9 @@ public:
                               int64_t timeoutNanoseconds) override;
 
 protected:
+
+    // This must be called under mLock.
+    Result close_l();
 
     SLuint32 channelCountToChannelMaskDefault(int channelCount) const;
 


### PR DESCRIPTION
Change AudioStreamOpenSLES::close() to close_l() to indicate that it must be called under mLock.
The subclasses acquire the lock.

No runtime change. Just a name change.

Fixes #591