### PR TITLE
DrumThumper, fix restart on device change.

### DIFF
--- a/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
+++ b/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
@@ -66,6 +66,7 @@ void SimpleMultiPlayer::onErrorAfterClose(AudioStream *oboeStream, Result error)
     resetAll();
     openStream();
     startStream();
+    
     mOutputReset = true;
 }
 

--- a/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
+++ b/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
@@ -65,6 +65,7 @@ void SimpleMultiPlayer::onErrorAfterClose(AudioStream *oboeStream, Result error)
 
     resetAll();
     openStream();
+    startStream();
     mOutputReset = true;
 }
 

--- a/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
+++ b/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
@@ -64,10 +64,9 @@ void SimpleMultiPlayer::onErrorAfterClose(AudioStream *oboeStream, Result error)
     __android_log_print(ANDROID_LOG_INFO, TAG, "==== onErrorAfterClose() error:%d", error);
 
     resetAll();
-    openStream();
-    startStream();
-
-    mOutputReset = true;
+    if (openStream() && startStream()) {
+        mOutputReset = true;
+    }
 }
 
 void SimpleMultiPlayer::onErrorBeforeClose(AudioStream *, Result error) {

--- a/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
+++ b/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.cpp
@@ -66,7 +66,7 @@ void SimpleMultiPlayer::onErrorAfterClose(AudioStream *oboeStream, Result error)
     resetAll();
     openStream();
     startStream();
-    
+
     mOutputReset = true;
 }
 


### PR DESCRIPTION
Missed the "startStream()" call in onErrorAfterClose() after refactor.