### PR TITLE
Update sample code and documentation to use new data and error callback interfaces

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,7 @@ created with low latency using the AudioTrack.Builder method [`setPerformanceMod
 
 You can dynamically tune the latency of the stream just like in Oboe using [`setBufferSizeInFrames(int)`](https://developer.android.com/reference/android/media/AudioTrack.html#setBufferSizeInFrames(int))
 Also you can use blocking writes with the Java AudioTrack and still get a low latency stream.
-Oboe requires a callback to get a low latency stream and that does not work well with Java.
+Oboe requires a data callback to get a low latency stream and that does not work well with Java.
 
 Note that [`AudioTrack.PERFORMANCE_MODE_LOW_LATENCY`](https://developer.android.com/reference/android/media/AudioTrack#PERFORMANCE_MODE_LOW_LATENCY) was added in API 26, For API 24 or 25 use [`AudioAttributes.FLAG_LOW_LATENCY`](https://developer.android.com/reference/kotlin/android/media/AudioAttributes#flag_low_latency). That was deprecated but will still work with later APIs.
 
@@ -31,7 +31,7 @@ We have had several reports of this happening and are keen to understand the roo
 ## I requested a stream with `PerformanceMode::LowLatency`, but didn't get it. Why not?
 Usually if you call `builder.setPerformanceMode(PerformanceMode::LowLatency)` and don't specify other stream properties you will get a `LowLatency` stream. The most common reasons for not receiving one are: 
 
-- You are opening an output stream and did not specify a **callback**.
+- You are opening an output stream and did not specify a **data callback**.
 - You requested a **sample** rate which does not match the audio device's native sample rate. For playback streams, this means the audio data you write into the stream must be resampled before it's sent to the audio device. For recording streams, the  audio data must be resampled before you can read it. In both cases the resampling process (performed by the Android audio framework) adds latency and therefore providing a `LowLatency` stream is not possible. To avoid the resampler on API 26 and below you can specify a default value for the sample rate [as detailed here](https://github.com/google/oboe/blob/master/docs/GettingStarted.md#obtaining-optimal-latency).  Or you can use the [new resampler](https://google.github.io/oboe/reference/classoboe_1_1_audio_stream_builder.html#af7d24a9ec975d430732151e5ee0d1027) in Oboe, which allows the lower level code to run at the optimal rate and provide lower latency.
 - If you request **AudioFormat::Float on an Input** stream before Android 9.0 then you will **not** get a FAST track. You need to either request AudioFormat::Int16 or [enable format conversion by Oboe](https://google.github.io/oboe/reference/classoboe_1_1_audio_stream_builder.html#a7ec5f427cd6fe55cb1ce536ff0cbb4d2).
 - The audio **device** does not support `LowLatency` streams, for example Bluetooth. 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -149,13 +149,13 @@ The builder's set methods return a pointer to the builder. So they can be easily
 oboe::AudioStreamBuilder builder;
 builder.setPerformanceMode(oboe::PerformanceMode::LowLatency)
   ->setSharingMode(oboe::SharingMode::Exclusive)
-  ->setCallback(myCallback)
+  ->setDataCallback(myCallback)
   ->setFormat(oboe::AudioFormat::Float);
 ```
 
-Define an `AudioStreamCallback` class to receive callbacks whenever the stream requires new data.
+Define an `AudioStreamDataCallback` class to receive callbacks whenever the stream requires new data.
 
-    class MyCallback : public oboe::AudioStreamCallback {
+    class MyCallback : public oboe::AudioStreamDataCallback {
     public:
         oboe::DataCallbackResult
         onAudioReady(oboe::AudioStream *audioStream, void *audioData, int32_t numFrames) {
@@ -183,7 +183,7 @@ Declare your callback somewhere that it won't get deleted while you are using it
 
 Supply this callback class to the builder:
 
-    builder.setCallback(&myCallback);
+    builder.setDataCallback(&myCallback);
     
 Declare a ManagedStream. Make sure it is declared in an appropriate scope (e.g.the member of a managing class). Avoid declaring it as a global.
 ```
@@ -203,7 +203,7 @@ Note that this sample code uses the [logging macros from here](https://github.co
 
 ## Playing audio
 Check the properties of the created stream. If you did not specify a channelCount, sampleRate, or format then you need to 
-query the stream to see what you got. The **format** property will dictate the `audioData` type in the `AudioStreamCallback::onAudioReady` callback. If you did specify any of those three properties then you will get what you requested.
+query the stream to see what you got. The **format** property will dictate the `audioData` type in the `AudioStreamDataCallback::onAudioReady` callback. If you did specify any of those three properties then you will get what you requested.
 
     oboe::AudioFormat format = stream->getFormat();
     LOGI("AudioStream format is %s", oboe::convertToText(format));
@@ -266,7 +266,7 @@ closes the stream.
 #include <oboe/Oboe.h>
 #include <math.h>
 
-class OboeSinePlayer: public oboe::AudioStreamCallback {
+class OboeSinePlayer: public oboe::AudioStreamDataCallback {
 public:
 
 
@@ -278,7 +278,7 @@ public:
           ->setChannelCount(kChannelCount)
           ->setSampleRate(kSampleRate)
           ->setFormat(oboe::AudioFormat::Float)
-          ->setCallback(this)
+          ->setDataCallback(this)
           ->openManagedStream(outStream);
         // Typically, start the stream after querying some stream information, as well as some input from the user
         outStream->requestStart();
@@ -314,8 +314,8 @@ private:
 ```
 Note that this implementation computes  sine values at run-time for simplicity,
 rather than pre-computing them.
-Additionally, best practice is to implement a separate callback class, rather
-than managing the stream and defining its callback in the same class.
+Additionally, best practice is to implement a separate data callback class, rather
+than managing the stream and defining its data callback in the same class.
 This class also automatically starts the stream upon construction. Typically,
 the stream is queried for information prior to being started (e.g. burst size),
 and started upon user input.

--- a/docs/OpenSLESMigration.md
+++ b/docs/OpenSLESMigration.md
@@ -26,7 +26,7 @@ OpenSL uses an audio engine object, created using `slCreateEngine`, to create ot
 
 OpenSL uses audio player and audio recorder objects to communicate with audio devices. In Oboe an `AudioStream` is used.
 
-In OpenSL the audio callback mechanism is a user-defined function which is called each time a buffer is enqueued. In Oboe you construct an `AudioStreamCallback` object, and its `onAudioReady` method is called each time audio data is ready to be read or written.  
+In OpenSL the audio callback mechanism is a user-defined function which is called each time a buffer is enqueued. In Oboe you construct an `AudioStreamDataCallback` object, and its `onAudioReady` method is called each time audio data is ready to be read or written.  
 
 Here's a table which summarizes the object mappings:
 
@@ -59,7 +59,7 @@ Here's a table which summarizes the object mappings:
   <tr>
    <td>Callback function
    </td>
-   <td><code>AudioStreamCallback::onAudioReady</code>
+   <td><code>AudioStreamDataCallback::onAudioReady</code>
    </td>
   </tr>
 </table>
@@ -84,7 +84,7 @@ DataCallbackResult onAudioReady(
 ```
 
 
-You supply your implementation of `onAudioReady` when building the audio stream by constructing an `AudioStreamCallback` object. [Here's an example.](https://github.com/google/oboe/blob/master/docs/GettingStarted.md#creating-an-audio-stream)
+You supply your implementation of `onAudioReady` when building the audio stream by constructing an `AudioStreamDataCallback` object. [Here's an example.](https://github.com/google/oboe/blob/master/docs/GettingStarted.md#creating-an-audio-stream)
 
 
 ### Buffer sizes
@@ -124,7 +124,7 @@ However, you may want to specify some properties. These are set using the `Audio
 
 OpenSL has no mechanism, other than stopping callbacks, to indicate that an audio device has been disconnected - for example, when headphones are unplugged.
 
-In Oboe, you can be notified of stream disconnection by overriding one of the `onError` methods in `AudioStreamCallback`. This allows you to clean up any resources associated with the audio stream and create a new stream with optimal properties for the current audio device ([more info](https://github.com/google/oboe/blob/master/docs/FullGuide.md#disconnected-audio-stream)).
+In Oboe, you can be notified of stream disconnection by overriding one of the `onError` methods in `AudioStreamErrorCallback`. This allows you to clean up any resources associated with the audio stream and create a new stream with optimal properties for the current audio device ([more info](https://github.com/google/oboe/blob/master/docs/FullGuide.md#disconnected-audio-stream)).
 
 
 # Unsupported features
@@ -162,8 +162,8 @@ Oboe does **not** support the following features:
 
 *   Replace your audio player or recorder with an `AudioStream` created using an `AudioStreamBuilder`.
 *   Use your value for `numBuffers` to set the audio stream's buffer size as a multiple of the burst size. For example: `audioStream.setBufferSizeInFrames(audioStream.getFramesPerBurst * numBuffers)`.
-*   Create an `AudioStreamCallback` object and move your OpenSL callback code inside the `onAudioReady` method.
-*   Handle stream disconnect events by overriding one of the `AudioStreamCallback::onError` methods.
+*   Create an `AudioStreamDataCallback` object and move your OpenSL callback code inside the `onAudioReady` method.
+*   Handle stream disconnect events by creating an `AudioStreamErrorCallback` object and overriding one of its `onError` methods.
 *   Pass sensible default sample rate and buffer size values to Oboe from `AudioManager` [using this method](https://github.com/google/oboe/blob/master/docs/GettingStarted.md#obtaining-optimal-latency) so that your app is still performant on older devices.
 
 For more information please read the [Full Guide to Oboe](https://github.com/google/oboe/blob/master/docs/FullGuide.md).

--- a/docs/notes/disconnect.md
+++ b/docs/notes/disconnect.md
@@ -9,7 +9,7 @@ When Oboe is using **AAudio**, and a headset is plugged in or out, then
 the stream is no longer available and becomes "disconnected".
 The app should then be notified in one of two ways. 
 
-1) If the app is using a callback then the AudioStreamCallback object will be called.
+1) If the app is using an error callback then the AudioStreamErrorCallback methods will be called.
 It will launch a thread, which will call onErrorBeforeClose().
 Then it stops and closes the stream.
 Then onErrorAfterClose() will be called.

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -116,7 +116,7 @@ oboe::Result  LiveEffectEngine::openStreams() {
 oboe::AudioStreamBuilder *LiveEffectEngine::setupRecordingStreamParameters(
     oboe::AudioStreamBuilder *builder) {
     // This sample uses blocking read() by setting callback to null
-    builder->setCallback(nullptr)
+    builder->setDataCallback(nullptr)
         ->setDeviceId(mRecordingDeviceId)
         ->setDirection(oboe::Direction::Input)
         ->setSampleRate(mSampleRate)
@@ -132,7 +132,8 @@ oboe::AudioStreamBuilder *LiveEffectEngine::setupRecordingStreamParameters(
  */
 oboe::AudioStreamBuilder *LiveEffectEngine::setupPlaybackStreamParameters(
     oboe::AudioStreamBuilder *builder) {
-    builder->setCallback(this)
+    builder->setDataCallback(this)
+        ->setErrorCallback(this)
         ->setDeviceId(mPlaybackDeviceId)
         ->setDirection(oboe::Direction::Output)
         ->setChannelCount(mOutputChannelCount);

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -115,9 +115,8 @@ oboe::Result  LiveEffectEngine::openStreams() {
  */
 oboe::AudioStreamBuilder *LiveEffectEngine::setupRecordingStreamParameters(
     oboe::AudioStreamBuilder *builder) {
-    // This sample uses blocking read() by setting callback to null
-    builder->setDataCallback(nullptr)
-        ->setDeviceId(mRecordingDeviceId)
+    // This sample uses blocking read() because we don't specify a callback
+    builder->setDeviceId(mRecordingDeviceId)
         ->setDirection(oboe::Direction::Input)
         ->setSampleRate(mSampleRate)
         ->setChannelCount(mInputChannelCount);

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -36,10 +36,14 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     bool setEffectOn(bool isOn);
 
     /*
-     * oboe::AudioStreamCallback interface implementation
+     * oboe::AudioStreamDataCallback interface implementation
      */
     oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream,
                                           void *audioData, int32_t numFrames) override;
+
+    /*
+     * oboe::AudioStreamErrorCallback interface implementation
+     */
     void onErrorBeforeClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
     void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
 

--- a/samples/MegaDrone/src/main/cpp/MegaDroneEngine.h
+++ b/samples/MegaDrone/src/main/cpp/MegaDroneEngine.h
@@ -22,9 +22,10 @@
 #include <vector>
 
 #include "Synth.h"
-#include <DefaultAudioStreamCallback.h>
+#include <DefaultDataCallback.h>
 #include <TappableAudioSource.h>
 #include <IRestartable.h>
+#include <DefaultErrorCallback.h>
 
 using namespace oboe;
 
@@ -46,7 +47,8 @@ public:
 private:
     std::shared_ptr<AudioStream> mStream;
     std::shared_ptr<TappableAudioSource> mAudioSource;
-    std::unique_ptr<DefaultAudioStreamCallback> mCallback;
+    std::unique_ptr<DefaultDataCallback> mDataCallback;
+    std::unique_ptr<DefaultErrorCallback> mErrorCallback;
 
     oboe::Result createPlaybackStream();
     void createCallback(std::vector<int> cpuIds);

--- a/samples/RhythmGame/src/main/cpp/Game.cpp
+++ b/samples/RhythmGame/src/main/cpp/Game.cpp
@@ -175,7 +175,8 @@ bool Game::openStream() {
 
     // Create an audio stream
     AudioStreamBuilder builder;
-    builder.setCallback(this);
+    builder.setDataCallback(this);
+    builder.setErrorCallback(this);
     builder.setPerformanceMode(PerformanceMode::LowLatency);
     builder.setSharingMode(SharingMode::Exclusive);
 

--- a/samples/RhythmGame/src/main/cpp/Game.h
+++ b/samples/RhythmGame/src/main/cpp/Game.h
@@ -51,9 +51,11 @@ public:
     void tick();
     void tap(int64_t eventTimeAsUptime);
 
-    // Inherited from oboe::AudioStreamCallback
+    // Inherited from oboe::AudioStreamDataCallback
     DataCallbackResult
     onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numFrames) override;
+
+    // Inherited from oboe::AudioStreamErrorCallback
     void onErrorAfterClose(AudioStream *oboeStream, Result error) override;
 
 private:

--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
@@ -35,7 +35,8 @@
  *
  */
 HelloOboeEngine::HelloOboeEngine()
-        : mLatencyCallback(std::make_unique<LatencyTuningCallback>(*this)) {
+        : mLatencyCallback(std::make_unique<LatencyTuningCallback>()),
+        mErrorCallback(std::make_unique<DefaultErrorCallback>(*this)){
 }
 
 double HelloOboeEngine::getCurrentOutputLatencyMillis() {
@@ -119,7 +120,8 @@ oboe::Result HelloOboeEngine::createPlaybackStream() {
     return builder.setSharingMode(oboe::SharingMode::Exclusive)
         ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
         ->setFormat(oboe::AudioFormat::Float)
-        ->setCallback(mLatencyCallback.get())
+        ->setDataCallback(mLatencyCallback.get())
+        ->setErrorCallback(mErrorCallback.get())
         ->setAudioApi(mAudioApi)
         ->setChannelCount(mChannelCount)
         ->setDeviceId(mDeviceId)
@@ -128,6 +130,7 @@ oboe::Result HelloOboeEngine::createPlaybackStream() {
 
 void HelloOboeEngine::restart() {
     // The stream will have already been closed by the error callback.
+    mLatencyCallback->reset();
     start();
 }
 

--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
@@ -36,7 +36,7 @@
  */
 HelloOboeEngine::HelloOboeEngine()
         : mLatencyCallback(std::make_unique<LatencyTuningCallback>()),
-        mErrorCallback(std::make_unique<DefaultErrorCallback>(*this)){
+        mErrorCallback(std::make_unique<DefaultErrorCallback>(*this)) {
 }
 
 double HelloOboeEngine::getCurrentOutputLatencyMillis() {

--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.h
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.h
@@ -22,6 +22,7 @@
 #include "SoundGenerator.h"
 #include "LatencyTuningCallback.h"
 #include "IRestartable.h"
+#include "DefaultErrorCallback.h"
 
 constexpr int32_t kBufferSizeAutomatic = 0;
 
@@ -88,10 +89,10 @@ public:
 private:
     oboe::Result reopenStream();
     oboe::Result createPlaybackStream();
-    void         updateLatencyDetection();
 
     std::shared_ptr<oboe::AudioStream> mStream;
     std::unique_ptr<LatencyTuningCallback> mLatencyCallback;
+    std::unique_ptr<DefaultErrorCallback> mErrorCallback;
     std::shared_ptr<SoundGenerator> mAudioSource;
     bool mIsLatencyDetectionSupported = false;
 

--- a/samples/hello-oboe/src/main/cpp/LatencyTuningCallback.cpp
+++ b/samples/hello-oboe/src/main/cpp/LatencyTuningCallback.cpp
@@ -37,7 +37,7 @@ oboe::DataCallbackResult LatencyTuningCallback::onAudioReady(
     */
     if (Trace::isEnabled()) Trace::beginSection("numFrames %d, Underruns %d, buffer size %d",
         numFrames, underrunCountResult.value(), bufferSize);
-    auto result = DefaultAudioStreamCallback::onAudioReady(oboeStream, audioData, numFrames);
+    auto result = DefaultDataCallback::onAudioReady(oboeStream, audioData, numFrames);
     if (Trace::isEnabled()) Trace::endSection();
     return result;
 }

--- a/samples/hello-oboe/src/main/cpp/LatencyTuningCallback.h
+++ b/samples/hello-oboe/src/main/cpp/LatencyTuningCallback.h
@@ -22,19 +22,19 @@
 #include <oboe/LatencyTuner.h>
 
 #include <TappableAudioSource.h>
-#include <DefaultAudioStreamCallback.h>
+#include <DefaultDataCallback.h>
 #include <trace.h>
 
 /**
- * This callback object extends the functionality of `DefaultAudioStreamCallback` by automatically
+ * This callback object extends the functionality of `DefaultDataCallback` by automatically
  * tuning the latency of the audio stream. @see onAudioReady for more details on this.
  *
  * It also demonstrates how to use tracing functions for logging inside the audio callback without
  * blocking.
  */
-class LatencyTuningCallback: public DefaultAudioStreamCallback {
+class LatencyTuningCallback: public DefaultDataCallback {
 public:
-    LatencyTuningCallback(IRestartable &mParent) : DefaultAudioStreamCallback(mParent) {
+    LatencyTuningCallback() : DefaultDataCallback() {
 
         // Initialize the trace functions, this enables you to output trace statements without
         // blocking. See https://developer.android.com/studio/profile/systrace-commandline.html

--- a/samples/shared/DefaultDataCallback.h
+++ b/samples/shared/DefaultDataCallback.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SAMPLES_DEFAULT_AUDIO_STREAM_CALLBACK_H
-#define SAMPLES_DEFAULT_AUDIO_STREAM_CALLBACK_H
+#ifndef SAMPLES_DEFAULT_DATA_CALLBACK_H
+#define SAMPLES_DEFAULT_DATA_CALLBACK_H
 
 
 #include <vector>
@@ -26,16 +26,12 @@
 #include "IRestartable.h"
 
 /**
- * This is a callback object which will render data from an `IRenderableAudio` source. It is
- * constructed using an `IRestartable` which allows it to automatically restart the parent object
- * if the stream is disconnected (for example, when headphones are attached).
- *
- * @param IRestartable - the object which should be restarted when the stream is disconnected
+ * This is a callback object which will render data from an `IRenderableAudio` source.
  */
-class DefaultAudioStreamCallback : public oboe::AudioStreamCallback {
+class DefaultDataCallback : public oboe::AudioStreamDataCallback {
 public:
-    DefaultAudioStreamCallback(IRestartable &parent): mParent(parent) {}
-    virtual ~DefaultAudioStreamCallback() = default;
+    DefaultDataCallback() {}
+    virtual ~DefaultDataCallback() = default;
 
     virtual oboe::DataCallbackResult
     onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) override {
@@ -56,19 +52,15 @@ public:
         return oboe::DataCallbackResult::Continue;
     }
 
-    virtual void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override {
-        // Restart the stream when it errors out with disconnect
-        if (error == oboe::Result::ErrorDisconnected) {
-            LOGE("Restarting AudioStream after disconnect");
-            mParent.restart();
-        } else {
-            LOGE("Unknown error");
-        }
-        mIsThreadAffinitySet = false;
-    }
-
     void setSource(std::shared_ptr<IRenderableAudio> renderable) {
         mRenderable = renderable;
+    }
+
+    /**
+     * Reset the callback to its initial state.
+     */
+    void reset(){
+        mIsThreadAffinitySet = false;
     }
 
     std::shared_ptr<IRenderableAudio> getSource() {
@@ -98,7 +90,6 @@ public:
 
 private:
     std::shared_ptr<IRenderableAudio> mRenderable;
-    IRestartable &mParent;
     std::vector<int> mCpuIds; // IDs of CPU cores which the audio callback should be bound to
     std::atomic<bool> mIsThreadAffinityEnabled { false };
     std::atomic<bool> mIsThreadAffinitySet { false };
@@ -139,4 +130,4 @@ private:
 
 };
 
-#endif //SAMPLES_DEFAULT_AUDIO_STREAM_CALLBACK_H
+#endif //SAMPLES_DEFAULT_DATA_CALLBACK_H

--- a/samples/shared/DefaultErrorCallback.h
+++ b/samples/shared/DefaultErrorCallback.h
@@ -38,13 +38,13 @@ public:
     virtual ~DefaultErrorCallback() = default;
 
     virtual void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override {
-        // Restart the stream when it errors out with disconnect
-        if (error == oboe::Result::ErrorDisconnected) {
-            LOGE("Restarting AudioStream after disconnect");
+        // Restart the stream if the error is a disconnect or a timeout, otherwise do nothing
+        // and log the error reason.
+        if (error == oboe::Result::ErrorDisconnected || error == oboe::Result::ErrorTimeout) {
+            LOGI("Restarting AudioStream");
             mParent.restart();
-        } else {
-            LOGE("Unknown error");
         }
+        LOGE("Error was %s", oboe::convertToText(error));
     }
 
 private:

--- a/samples/shared/DefaultErrorCallback.h
+++ b/samples/shared/DefaultErrorCallback.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SAMPLES_DEFAULT_ERROR_CALLBACK_H
+#define SAMPLES_DEFAULT_ERROR_CALLBACK_H
+
+#include <vector>
+#include <oboe/AudioStreamCallback.h>
+#include <logging_macros.h>
+
+#include "IRestartable.h"
+
+/**
+ * This is a callback object which will be called when a stream error occurs.
+ *
+ * It is constructed using an `IRestartable` which allows it to automatically restart the parent
+ * object if the stream is disconnected (for example, when headphones are attached).
+ *
+ * @param IRestartable - the object which should be restarted when the stream is disconnected
+ */
+class DefaultErrorCallback : public oboe::AudioStreamErrorCallback {
+public:
+
+    DefaultErrorCallback(IRestartable &parent): mParent(parent) {}
+    virtual ~DefaultErrorCallback() = default;
+
+    virtual void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override {
+        // Restart the stream when it errors out with disconnect
+        if (error == oboe::Result::ErrorDisconnected) {
+            LOGE("Restarting AudioStream after disconnect");
+            mParent.restart();
+        } else {
+            LOGE("Unknown error");
+        }
+    }
+
+private:
+    IRestartable &mParent;
+
+};
+
+
+#endif //SAMPLES_DEFAULT_ERROR_CALLBACK_H

--- a/samples/shared/DefaultErrorCallback.h
+++ b/samples/shared/DefaultErrorCallback.h
@@ -38,9 +38,9 @@ public:
     virtual ~DefaultErrorCallback() = default;
 
     virtual void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override {
-        // Restart the stream if the error is a disconnect or a timeout, otherwise do nothing
-        // and log the error reason.
-        if (error == oboe::Result::ErrorDisconnected || error == oboe::Result::ErrorTimeout) {
+        // Restart the stream if the error is a disconnect, otherwise do nothing and log the error
+        // reason.
+        if (error == oboe::Result::ErrorDisconnected) {
             LOGI("Restarting AudioStream");
             mParent.restart();
         }


### PR DESCRIPTION
This PR refactors the sample code away from using a single callback (`AudioStreamCallback`) for both data and error events to using the new `AudioStreamDataCallback` and `AudioStreamErrorCallback` classes. 

The only issue I faced was that the original `DefaultAudioStreamCallback` (used by hello-oboe and megadrone) would attempt to set thread affinity inside the data callback and would reset it inside the error callback through a single field: `mIsThreadAffinitySet`. 

By separating the two callbacks the error callback no longer has access to this field. To solve this I added a `reset` method to `DefaultDataCallback` which can be called to reset the data callback to its initial configuration (in this case, only the thread affinity). 

The responsibility for calling `reset` moves away from the error callback, which just calls `restart` on its `IRestartable` parent. It's up to the parent to call `reset` on the data callback. Example here: https://github.com/google/oboe/compare/master...dturner:split_callbacks?expand=1#diff-300176f2b98467e0664a62ca6d40aa3f5c2401121741bcdea15a787557a6071bR133. 
