### PR TITLE
Add *FramesPerDataCallback and deprecate *FramesPerCallback methods

### DIFF
--- a/include/oboe/AudioStreamBase.h
+++ b/include/oboe/AudioStreamBase.h
@@ -62,9 +62,14 @@ public:
     int32_t getSampleRate() const { return mSampleRate; }
 
     /**
-     * @return the number of frames in each callback or kUnspecified.
+     * @deprecated use `getFramesPerDataCallback` instead.
      */
-    int32_t getFramesPerCallback() const { return mFramesPerCallback; }
+    int32_t getFramesPerCallback() const { return getFramesPerDataCallback(); }
+
+    /**
+     * @return the number of frames in each data callback or kUnspecified.
+     */
+    int32_t getFramesPerDataCallback() const { return mFramesPerCallback; }
 
     /**
      * @return the audio sample format (e.g. Float or I16)

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -75,6 +75,13 @@ public:
     }
 
     /**
+     * @deprecated use `setFramesPerDataCallback` instead.
+     */
+    AudioStreamBuilder *setFramesPerCallback(int framesPerCallback) {
+        return setFramesPerDataCallback(framesPerCallback);
+    }
+
+    /**
      * Request a specific number of frames for the data callback.
      *
      * Default is kUnspecified. If the value is unspecified then
@@ -88,7 +95,7 @@ public:
      * @param framesPerCallback
      * @return pointer to the builder so calls can be chained
      */
-    AudioStreamBuilder *setFramesPerCallback(int framesPerCallback) {
+    AudioStreamBuilder *setFramesPerDataCallback(int framesPerCallback) {
         mFramesPerCallback = framesPerCallback;
         return this;
     }

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -234,7 +234,7 @@ Result AudioStreamAAudio::open() {
 
     if (isDataCallbackSpecified()) {
         mLibLoader->builder_setDataCallback(aaudioBuilder, oboe_aaudio_data_callback_proc, this);
-        mLibLoader->builder_setFramesPerDataCallback(aaudioBuilder, getFramesPerCallback());
+        mLibLoader->builder_setFramesPerDataCallback(aaudioBuilder, getFramesPerDataCallback());
 
         if (!isErrorCallbackSpecified()) {
             // The app did not specify a callback so we should specify

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -82,7 +82,7 @@ AudioStream *AudioStreamBuilder::build() {
 bool AudioStreamBuilder::isCompatible(AudioStreamBase &other) {
     return (getSampleRate() == oboe::Unspecified || getSampleRate() == other.getSampleRate())
            && (getFormat() == (AudioFormat)oboe::Unspecified || getFormat() == other.getFormat())
-           && (getFramesPerCallback() == oboe::Unspecified || getFramesPerCallback() == other.getFramesPerCallback())
+           && (getFramesPerDataCallback() == oboe::Unspecified || getFramesPerDataCallback() == other.getFramesPerDataCallback())
            && (getChannelCount() == oboe::Unspecified || getChannelCount() == other.getChannelCount());
 }
 
@@ -131,8 +131,8 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
             if (getSampleRate() == oboe::Unspecified) {
                 parentBuilder.setSampleRate(tempStream->getSampleRate());
             }
-            if (getFramesPerCallback() == oboe::Unspecified) {
-                parentBuilder.setFramesPerCallback(tempStream->getFramesPerCallback());
+            if (getFramesPerDataCallback() == oboe::Unspecified) {
+                parentBuilder.setFramesPerCallback(tempStream->getFramesPerDataCallback());
             }
 
             // Use childStream in a FilterAudioStream.

--- a/src/common/DataConversionFlowGraph.cpp
+++ b/src/common/DataConversionFlowGraph.cpp
@@ -82,12 +82,12 @@ Result DataConversionFlowGraph::configure(AudioStream *sourceStream, AudioStream
     AudioFormat sourceFormat = sourceStream->getFormat();
     int32_t sourceChannelCount = sourceStream->getChannelCount();
     int32_t sourceSampleRate = sourceStream->getSampleRate();
-    int32_t sourceFramesPerCallback = sourceStream->getFramesPerCallback();
+    int32_t sourceFramesPerCallback = sourceStream->getFramesPerDataCallback();
 
     AudioFormat sinkFormat = sinkStream->getFormat();
     int32_t sinkChannelCount = sinkStream->getChannelCount();
     int32_t sinkSampleRate = sinkStream->getSampleRate();
-    int32_t sinkFramesPerCallback = sinkStream->getFramesPerCallback();
+    int32_t sinkFramesPerCallback = sinkStream->getFramesPerDataCallback();
 
     LOGI("%s() flowgraph converts channels: %d to %d, format: %d to %d"
          ", rate: %d to %d, cbsize: %d to %d, qual = %d",

--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -139,7 +139,7 @@ bool QuirksManager::isConversionNeeded(
     if (OboeGlobals::areWorkaroundsEnabled()
             && builder.willUseAAudio()
             && builder.isDataCallbackSpecified()
-            && builder.getFramesPerCallback() != 0
+            && builder.getFramesPerDataCallback() != 0
             && getSdkVersion() <= __ANDROID_API_R__) {
         LOGI("QuirksManager::%s() avoid setFramesPerCallback(n>0)", __func__);
         childBuilder.setFramesPerCallback(oboe::Unspecified);

--- a/src/common/Utilities.cpp
+++ b/src/common/Utilities.cpp
@@ -183,7 +183,7 @@ const char *convertToText<AudioStream*>(AudioStream* stream) {
      <<"BufferCapacity: "<<stream->getBufferCapacityInFrames()<<std::endl
      <<"BufferSize: "<<stream->getBufferSizeInFrames()<<std::endl
      <<"FramesPerBurst: "<< stream->getFramesPerBurst()<<std::endl
-     <<"FramesPerCallback: "<<stream->getFramesPerCallback()<<std::endl
+     <<"FramesPerDataCallback: "<<stream->getFramesPerDataCallback()<<std::endl
      <<"SampleRate: "<<stream->getSampleRate()<<std::endl
      <<"ChannelCount: "<<stream->getChannelCount()<<std::endl
      <<"Format: "<<oboe::convertToText(stream->getFormat())<<std::endl


### PR DESCRIPTION
The `*FramesPerCallback` methods are now ambiguous because there are 2 callback interfaces. This change deprecates the  `*FramesPerCallback` methods and adds `*FramesPerDataCallback` methods which are unambiguous. 