### PR TITLE
oboe: return correct InputPreset when modified

### DIFF
--- a/src/common/FilterAudioStream.h
+++ b/src/common/FilterAudioStream.h
@@ -55,6 +55,7 @@ public:
         // Copy parameters that may not match builder.
         mBufferCapacityInFrames = mChildStream->getBufferCapacityInFrames();
         mPerformanceMode = mChildStream->getPerformanceMode();
+        mInputPreset = mChildStream->getInputPreset();
     }
 
     virtual ~FilterAudioStream() = default;

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -156,6 +156,10 @@ Result AudioInputStreamOpenSLES::open() {
         LOGW("%s() GetInterface(SL_IID_ANDROIDCONFIGURATION) failed with %s",
              __func__, getSLErrStr(result));
     } else {
+        if (getInputPreset() == InputPreset::VoicePerformance) {
+            LOGD("OpenSL ES does not support InputPreset::VoicePerformance. Use VoiceRecognition.");
+            mInputPreset = InputPreset::VoiceRecognition;
+        }
         SLuint32 presetValue = OpenSLES_convertInputPreset(getInputPreset());
         result = (*configItf)->SetConfiguration(configItf,
                                          SL_ANDROID_KEY_RECORDING_PRESET,


### PR DESCRIPTION
The InputPreset can be coerced from VoicePerformance to
VoiceRecognition. But getInputPreset() returned the wrong value.
Fixed for FilterAudioStream and OpenSL ES.

Fixes #1090