### PR TITLE
Liveeffect: fix crash on exit

### DIFF
--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -16,19 +16,36 @@
 
 #ifndef SAMPLES_FULLDUPLEXPASS_H
 #define SAMPLES_FULLDUPLEXPASS_H
+
 #include "FullDuplexStream.h"
 
 class FullDuplexPass : public FullDuplexStream {
 public:
     virtual oboe::DataCallbackResult
-    onBothStreamsReady(const void *inputData, int numInputFrames, void *outputData,
-                       int numOutputFrames) {
-        size_t bytesPerFrame = this->getOutputStream()->getBytesPerFrame();
-        size_t bytesToWrite = numInputFrames * bytesPerFrame;
-        size_t byteDiff = (numOutputFrames - numInputFrames) * bytesPerFrame;
-        size_t bytesToZero = (byteDiff > 0) ? byteDiff : 0;
-        memcpy(outputData, inputData, bytesToWrite);
-        memset((u_char*) outputData + bytesToWrite, 0, bytesToZero);
+    onBothStreamsReady(
+            std::shared_ptr<oboe::AudioStream> inputStream,
+            const void *inputData,
+            int   numInputFrames,
+            std::shared_ptr<oboe::AudioStream> outputStream,
+            void *outputData,
+            int   numOutputFrames) {
+        // Copy the input samples to the output with a little arbitrary gain change.
+        // This code assumes the data format for both streams is Float.
+        const float *inputFloats = static_cast<const float *>(inputData);
+        float *outputFloats = static_cast<float *>(outputData);
+        // It also assume the channel count for each stream is the same.
+        int32_t samplesPerFrame = outputStream->getChannelCount();
+        int32_t numInputSamples = numInputFrames * samplesPerFrame;
+        int32_t numOutputSamples = numInputFrames * samplesPerFrame;
+        // It is possible that there may be fewer input than output samples.
+        int32_t samplesToProcess = std::min(numInputSamples, numOutputSamples);
+        for (int32_t i = 0; i < samplesToProcess; i++) {
+            *outputFloats++ = *inputFloats++ * 0.95; // do some arbitrary processing
+        }
+        int32_t samplesLeft = numOutputSamples - numInputSamples;
+        for (int32_t i = 0; i < samplesLeft; i++) {
+            *outputFloats++ = 0.0; // silence
+        }
         return oboe::DataCallbackResult::Continue;
     }
 };

--- a/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexPass.h
@@ -30,22 +30,28 @@ public:
             void *outputData,
             int   numOutputFrames) {
         // Copy the input samples to the output with a little arbitrary gain change.
+
         // This code assumes the data format for both streams is Float.
         const float *inputFloats = static_cast<const float *>(inputData);
         float *outputFloats = static_cast<float *>(outputData);
-        // It also assume the channel count for each stream is the same.
+
+        // It also assumes the channel count for each stream is the same.
         int32_t samplesPerFrame = outputStream->getChannelCount();
         int32_t numInputSamples = numInputFrames * samplesPerFrame;
         int32_t numOutputSamples = numInputFrames * samplesPerFrame;
+
         // It is possible that there may be fewer input than output samples.
         int32_t samplesToProcess = std::min(numInputSamples, numOutputSamples);
         for (int32_t i = 0; i < samplesToProcess; i++) {
             *outputFloats++ = *inputFloats++ * 0.95; // do some arbitrary processing
         }
+
+        // If there are fewer input samples then clear the rest of the buffer.
         int32_t samplesLeft = numOutputSamples - numInputSamples;
         for (int32_t i = 0; i < samplesLeft; i++) {
             *outputFloats++ = 0.0; // silence
         }
+
         return oboe::DataCallbackResult::Continue;
     }
 };

--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.h
@@ -27,19 +27,12 @@ public:
     FullDuplexStream() {}
     virtual ~FullDuplexStream() = default;
 
-    void setInputStream(oboe::AudioStream *stream) {
+    void setInputStream(std::shared_ptr<oboe::AudioStream> stream) {
         mInputStream = stream;
     }
 
-    oboe::AudioStream *getInputStream() {
-        return mInputStream;
-    }
-
-    void setOutputStream(oboe::AudioStream *stream) {
+    void setOutputStream(std::shared_ptr<oboe::AudioStream> stream) {
         mOutputStream = stream;
-    }
-    oboe::AudioStream *getOutputStream() {
-        return mOutputStream;
     }
 
     virtual oboe::Result start();
@@ -51,8 +44,10 @@ public:
      * App should override this method.
      */
     virtual oboe::DataCallbackResult onBothStreamsReady(
+            std::shared_ptr<oboe::AudioStream> inputStream,
             const void *inputData,
             int   numInputFrames,
+            std::shared_ptr<oboe::AudioStream> outputStream,
             void *outputData,
             int   numOutputFrames
             ) = 0;
@@ -96,8 +91,8 @@ private:
     // Discard some callbacks so the input and output reach equilibrium.
     int32_t              mCountCallbacksToDiscard = kNumCallbacksToDiscard;
 
-    oboe::AudioStream   *mInputStream = nullptr;
-    oboe::AudioStream   *mOutputStream = nullptr;
+    std::shared_ptr<oboe::AudioStream> mInputStream;
+    std::shared_ptr<oboe::AudioStream> mOutputStream;
 
     int32_t              mBufferSize = 0;
     std::unique_ptr<float[]> mInputBuffer;

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.cpp
@@ -113,6 +113,7 @@ oboe::Result  LiveEffectEngine::openStreams() {
  * playback stream.
  *
  * @param builder The recording stream builder
+ * @param sampleRate The desired sample rate of the recording stream
  */
 oboe::AudioStreamBuilder *LiveEffectEngine::setupRecordingStreamParameters(
     oboe::AudioStreamBuilder *builder, int32_t sampleRate) {

--- a/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
+++ b/samples/LiveEffect/src/main/cpp/LiveEffectEngine.h
@@ -24,11 +24,12 @@
 #include "FullDuplexPass.h"
 
 class LiveEffectEngine : public oboe::AudioStreamCallback {
-   public:
+public:
     LiveEffectEngine();
-    ~LiveEffectEngine();
+
     void setRecordingDeviceId(int32_t deviceId);
     void setPlaybackDeviceId(int32_t deviceId);
+
     /**
      * @param isOn
      * @return true if it succeeds
@@ -50,28 +51,30 @@ class LiveEffectEngine : public oboe::AudioStreamCallback {
     bool setAudioApi(oboe::AudioApi);
     bool isAAudioSupported(void);
 
-   private:
-    FullDuplexPass mFullDuplexPass;
-    bool mIsEffectOn = false;
-    int32_t mRecordingDeviceId = oboe::kUnspecified;
-    int32_t mPlaybackDeviceId = oboe::kUnspecified;
-    oboe::AudioFormat mFormat = oboe::AudioFormat::I16;
-    int32_t mSampleRate = oboe::kUnspecified;
-    int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
-    int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
+private:
+    FullDuplexPass    mFullDuplexPass;
+    bool              mIsEffectOn = false;
+    int32_t           mRecordingDeviceId = oboe::kUnspecified;
+    int32_t           mPlaybackDeviceId = oboe::kUnspecified;
+    const oboe::AudioFormat mFormat = oboe::AudioFormat::Float; // for easier processing
+    oboe::AudioApi    mAudioApi = oboe::AudioApi::AAudio;
+    int32_t           mSampleRate = oboe::kUnspecified;
+    const int32_t     mInputChannelCount = oboe::ChannelCount::Stereo;
+    const int32_t     mOutputChannelCount = oboe::ChannelCount::Stereo;
 
     std::shared_ptr<oboe::AudioStream> mRecordingStream;
     std::shared_ptr<oboe::AudioStream> mPlayStream;
 
-    oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
-
     oboe::Result openStreams();
+
+    void closeStreams();
+
     void closeStream(std::shared_ptr<oboe::AudioStream> &stream);
 
     oboe::AudioStreamBuilder *setupCommonStreamParameters(
         oboe::AudioStreamBuilder *builder);
     oboe::AudioStreamBuilder *setupRecordingStreamParameters(
-        oboe::AudioStreamBuilder *builder);
+        oboe::AudioStreamBuilder *builder, int32_t sampleRate);
     oboe::AudioStreamBuilder *setupPlaybackStreamParameters(
         oboe::AudioStreamBuilder *builder);
     void warnIfNotLowLatency(std::shared_ptr<oboe::AudioStream> &stream);

--- a/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
+++ b/samples/LiveEffect/src/main/cpp/jni_bridge.cpp
@@ -38,8 +38,11 @@ Java_com_google_oboe_samples_liveEffect_LiveEffectEngine_create(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_google_oboe_samples_liveEffect_LiveEffectEngine_delete(JNIEnv *env,
                                                                jclass) {
-    delete engine;
-    engine = nullptr;
+    if (engine) {
+        engine->setEffectOn(false);
+        delete engine;
+        engine = nullptr;
+    }
 }
 
 JNIEXPORT jboolean JNICALL


### PR DESCRIPTION
Use std::shared_ptr in FullDuplexStream.
Explicitly process the samples in the callback instead
of just using memcpy. This will be easier to modify.

Fixes #1113
Fixes #852