### PR TITLE
oboe: define missing AAUDIO constants

### DIFF
--- a/apps/OboeTester/app/CMakeLists.txt
+++ b/apps/OboeTester/app/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.1)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -std=c++14 -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -std=c++14 -DOBOE_NO_INCLUDE_AAUDIO -fvisibility=hidden")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -304,7 +304,6 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
             == AAUDIO_PERFORMANCE_MODE_POWER_SAVING, ERRMSG);
     static_assert((int32_t)PerformanceMode::LowLatency
             == AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, ERRMSG);
-#endif
 
 // The aaudio_ usage, content and input_preset types were added in NDK 17,
 // which is the first version to support Android Pie (API 28).
@@ -343,6 +342,9 @@ AAudioLoader::signature_I_PSKPLPL AAudioLoader::load_I_PSKPLPL(const char *funct
 
     static_assert((int32_t)SessionId::None == AAUDIO_SESSION_ID_NONE, ERRMSG);
     static_assert((int32_t)SessionId::Allocate == AAUDIO_SESSION_ID_ALLOCATE, ERRMSG);
-#endif
+
+#endif // __NDK_MAJOR__ >= 17
+
+#endif // AAUDIO_AAUDIO_H
 
 } // namespace oboe

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -52,6 +52,12 @@ typedef int32_t aaudio_usage_t;
 typedef int32_t aaudio_content_type_t;
 typedef int32_t aaudio_input_preset_t;
 typedef int32_t aaudio_session_id_t;
+
+// There are a few definitions used by Oboe.
+#define AAUDIO_OK                      static_cast<aaudio_result_t>(Result::OK)
+#define AAUDIO_ERROR_TIMEOUT           static_cast<aaudio_result_t>(Result::ErrorTimeout)
+#define AAUDIO_STREAM_STATE_STARTING   static_cast<aaudio_stream_state_t>(StreamState::Starting)
+#define AAUDIO_STREAM_STATE_STARTED    static_cast<aaudio_stream_state_t>(StreamState::Started)
 #else
 #include <aaudio/AAudio.h>
 #include <android/ndk-version.h>


### PR DESCRIPTION
These caused the Oboe build to fail if OBOE_NO_INCLUDE_AAUDIO
was defined.

Fixes #1122