### PR TITLE
fix: [android sample] fix a crash when calling LiveEffectEngine.setEf…

### DIFF
--- a/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
+++ b/samples/LiveEffect/src/main/cpp/FullDuplexStream.cpp
@@ -112,6 +112,8 @@ oboe::Result FullDuplexStream::stop() {
     if (mInputStream) {
         inputResult = mInputStream->requestStop();
     }
+    setOutputStream(nullptr);
+    setInputStream(nullptr);
     if (outputResult != oboe::Result::OK) {
         return outputResult;
     } else {


### PR DESCRIPTION
fix: [android sample] fix a crash when calling LiveEffectEngine.setEffectOn(false) in MainActivity.onPause()