### PR TITLE
OboeTester: improve latency measurement

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
@@ -49,8 +49,8 @@
 #define LOOPBACK_RESULT_TAG  "RESULT: "
 
 static constexpr int32_t kDefaultSampleRate = 48000;
-static constexpr int32_t kMillisPerSecond   = 1000;
-static constexpr int32_t kMaxLatencyMillis  = 700;  // arbitrary and generous
+static constexpr int32_t kMillisPerSecond   = 1000;  // by definition
+static constexpr int32_t kMaxLatencyMillis  = 1000;  // arbitrary and generous
 static constexpr double  kMinimumConfidence = 0.2;
 
 struct LatencyReport {

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
@@ -21,19 +21,25 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.text.method.ScrollingMovementMethod;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * Activity to measure latency on a full duplex stream.
  */
 public class RoundTripLatencyActivity extends AnalyzerActivity {
 
-    private static final int STATE_GOT_DATA = 2; // Defined in LatencyAnalyzer.h
+    // STATEs defined in LatencyAnalyzer.h
+    private static final int STATE_MEASURE_BACKGROUND = 0;
+    private static final int STATE_IN_PULSE = 1;
+    private static final int STATE_GOT_DATA = 2;
     private final static String LATENCY_FORMAT = "%4.2f";
+    // When I use 5.3g I only get one digit after the decimal point!
     private final static String CONFIDENCE_FORMAT = "%5.3f";
 
     private TextView mAnalyzerView;
@@ -51,12 +57,13 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
     // Run the test several times and report the acverage latency.
     protected class LatencyAverager {
         private final static int AVERAGE_TEST_DELAY_MSEC = 1000; // arbitrary
-        private static final int GOOD_RUNS_REQUIRED = 10; // arbitrary
-        private static final int MAX_BAD_RUNS_ALLOWED = 10; // arbitrary
+        private static final int GOOD_RUNS_REQUIRED = 5; // arbitrary
+        private static final int MAX_BAD_RUNS_ALLOWED = 5; // arbitrary
         private int mBadCount = 0; // number of bad measurements
         private int mGoodCount = 0; // number of good measurements
 
-        private double  mWeightedLatencySum;
+        ArrayList<Double> mLatencies = new ArrayList<Double>(GOOD_RUNS_REQUIRED);
+        ArrayList<Double> mConfidences = new ArrayList<Double>(GOOD_RUNS_REQUIRED);
         private double  mLatencyMin;
         private double  mLatencyMax;
         private double  mConfidenceSum;
@@ -84,7 +91,8 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
                 mGoodCount++;
                 double latency = getMeasuredLatencyMillis();
                 double confidence = getMeasuredConfidence();
-                mWeightedLatencySum += latency * confidence; // weighted average based on confidence
+                mLatencies.add(latency);
+                mConfidences.add(confidence);
                 mConfidenceSum += confidence;
                 mLatencyMin = Math.min(mLatencyMin, latency);
                 mLatencyMax = Math.max(mLatencyMax, latency);
@@ -112,11 +120,11 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
             if (mGoodCount == 0 || mConfidenceSum == 0.0) {
                 message = "num.iterations = " + mGoodCount + "\n";
             } else {
-                // When I use 5.3g I only get one digit after the decimal point!
-                final double averageLatency = mWeightedLatencySum / mConfidenceSum;
                 final double mAverageConfidence = mConfidenceSum / mGoodCount;
-                message =
-                        "average.latency.msec = " + String.format(LATENCY_FORMAT, averageLatency) + "\n"
+                double meanLatency = calculateMeanLatency();
+                double meanAbsoluteDeviation = calculateMeanAbsoluteDeviation(meanLatency);
+                message = "mean.latency.msec = " + String.format(LATENCY_FORMAT, meanLatency) + "\n"
+                        + "mean.absolute.deviation = " + String.format(LATENCY_FORMAT, meanAbsoluteDeviation) + "\n"
                         + "average.confidence = " + String.format(CONFIDENCE_FORMAT, mAverageConfidence) + "\n"
                         + "min.latency.msec = " + String.format(LATENCY_FORMAT, mLatencyMin) + "\n"
                         + "max.latency.msec = " + String.format(LATENCY_FORMAT, mLatencyMax) + "\n"
@@ -127,9 +135,26 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
             return message;
         }
 
+        private double calculateMeanAbsoluteDeviation(double meanLatency) {
+            double deviationSum = 0.0;
+            for (double latency : mLatencies) {
+                deviationSum += Math.abs(latency - meanLatency);
+            }
+            return deviationSum / mLatencies.size();
+        }
+
+        private double calculateMeanLatency() {
+            double latencySum = 0.0;
+            for (double latency : mLatencies) {
+                latencySum += latency;
+            }
+            return latencySum / mLatencies.size();
+        }
+
         // Called on UI thread.
         public void start() {
-            mWeightedLatencySum = 0.0;
+            mLatencies.clear();
+            mConfidences.clear();
             mConfidenceSum = 0.0;
             mLatencyMax = Double.MIN_VALUE;
             mLatencyMin = Double.MAX_VALUE;
@@ -165,7 +190,6 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         public static final int SNIFFER_UPDATE_PERIOD_MSEC = 150;
         public static final int SNIFFER_UPDATE_DELAY_MSEC = 300;
 
-
         // Display status info for the stream.
         private Runnable runnableCode = new Runnable() {
             @Override
@@ -173,14 +197,13 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
                 String message;
 
                 if (isAnalyzerDone()) {
-                    message = onAnalyzerDone();
-                    message += mLatencyAverager.onAnalyserDone();
+                    message = mLatencyAverager.onAnalyserDone();
+                    message += onAnalyzerDone();
                 } else {
                     message = getProgressText();
                     message += "please wait... " + counter + "\n";
-                    if (getAnalyzerState() == STATE_GOT_DATA) {
-                        message += "ANALYZING\n";
-                    }
+                    message += convertStateToString(getAnalyzerState());
+
                     // Repeat this runnable code block again.
                     mHandler.postDelayed(runnableCode, SNIFFER_UPDATE_PERIOD_MSEC);
                 }
@@ -202,11 +225,20 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         }
     }
 
+    static String convertStateToString(int state) {
+        switch (state) {
+            case STATE_MEASURE_BACKGROUND: return "BACKGROUND";
+            case STATE_IN_PULSE: return "RECORDING";
+            case STATE_GOT_DATA: return "ANALYZING";
+            default: return "DONE";
+        }
+    }
+
     private String getProgressText() {
         int progress = getAnalyzerProgress();
         int state = getAnalyzerState();
         int resetCount = getResetCount();
-        String message = String.format("progress = %d, state = %d, #resets = %d\n",
+        String message = String.format("progress = %d\nstate = %d\n#resets = %d\n",
                 progress, state, resetCount);
         message += mLatencyAverager.getLastReport();
         return message;
@@ -227,13 +259,12 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
 
     @NonNull
     private String getResultString() {
-        String message = String.format("rms.signal = %7.5f\n", getSignalRMS());
-        message += String.format("rms.noise = %7.5f\n", getBackgroundRMS());
-        int resetCount = getResetCount();
-        message += String.format("reset.count = %d\n", resetCount);
-
         int result = getMeasuredResult();
-        message += String.format("result = %d\n", result);
+        int resetCount = getResetCount();
+        double confidence = getMeasuredConfidence();
+        String message = "";
+
+        message += String.format("confidence = " + CONFIDENCE_FORMAT + "\n", confidence);
         message += String.format("result.text = %s\n", resultCodeToString(result));
 
         // Only report valid latencies.
@@ -243,13 +274,17 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
             int bufferSize = mAudioOutTester.getCurrentAudioStream().getBufferSizeInFrames();
             int latencyEmptyFrames = latencyFrames - bufferSize;
             double latencyEmptyMillis = latencyEmptyFrames * 1000.0 / getSampleRate();
-            message += String.format("latency.empty.frames = %d\n", latencyEmptyFrames);
-            message += String.format("latency.empty.msec = " + LATENCY_FORMAT + "\n", latencyEmptyMillis);
-            message += String.format("latency.frames = %d\n", latencyFrames);
             message += String.format("latency.msec = " + LATENCY_FORMAT + "\n", latencyMillis);
+            message += String.format("latency.frames = %d\n", latencyFrames);
+            message += String.format("latency.empty.msec = " + LATENCY_FORMAT + "\n", latencyEmptyMillis);
+            message += String.format("latency.empty.frames = %d\n", latencyEmptyFrames);
         }
-        double confidence = getMeasuredConfidence();
-        message += String.format("confidence = " + CONFIDENCE_FORMAT + "\n", confidence);
+
+        message += String.format("rms.signal = %7.5f\n", getSignalRMS());
+        message += String.format("rms.noise = %7.5f\n", getBackgroundRMS());
+        message += String.format("reset.count = %d\n", resetCount);
+        message += String.format("result = %d\n", result);
+
         return message;
     }
 
@@ -282,6 +317,7 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         mShareButton = (Button) findViewById(R.id.button_share);
         mShareButton.setEnabled(false);
         mAnalyzerView = (TextView) findViewById(R.id.text_status);
+        mAnalyzerView.setMovementMethod(new ScrollingMovementMethod());
         updateEnabledWidgets();
 
         hideSettingsViews();

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/RoundTripLatencyActivity.java
@@ -123,7 +123,7 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
                 final double mAverageConfidence = mConfidenceSum / mGoodCount;
                 double meanLatency = calculateMeanLatency();
                 double meanAbsoluteDeviation = calculateMeanAbsoluteDeviation(meanLatency);
-                message = "mean.latency.msec = " + String.format(LATENCY_FORMAT, meanLatency) + "\n"
+                message = "average.latency.msec = " + String.format(LATENCY_FORMAT, meanLatency) + "\n"
                         + "mean.absolute.deviation = " + String.format(LATENCY_FORMAT, meanAbsoluteDeviation) + "\n"
                         + "average.confidence = " + String.format(CONFIDENCE_FORMAT, mAverageConfidence) + "\n"
                         + "min.latency.msec = " + String.format(LATENCY_FORMAT, mLatencyMin) + "\n"

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestAudioActivity.java
@@ -31,11 +31,7 @@ import android.widget.CheckBox;
 import android.widget.Toast;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 
 /**
  * Base class for other Activities.
@@ -110,11 +106,15 @@ abstract class TestAudioActivity extends Activity {
                 boolean gotViews = false;
                 for (StreamContext streamContext : mStreamContexts) {
                     AudioStreamBase.StreamStatus status = streamContext.tester.getCurrentAudioStream().getStreamStatus();
+                    AudioStreamBase.DoubleStatistics latencyStatistics =
+                            streamContext.tester.getCurrentAudioStream().getLatencyStatistics();
                     if (streamContext.configurationView != null) {
                         // Handler runs this on the main UI thread.
                         int framesPerBurst = streamContext.tester.getCurrentAudioStream().getFramesPerBurst();
                         status.framesPerCallback = getFramesPerCallback();
-                        final String msg = status.dump(framesPerBurst);
+                        String msg = "";
+                        msg += "timestamp.latency = " + latencyStatistics.dump() + "\n";
+                        msg += status.dump(framesPerBurst);
                         streamContext.configurationView.setStatusText(msg);
                         updateStreamDisplay();
                         gotViews = true;

--- a/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
@@ -93,7 +93,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:lines="11"
-        android:text="@string/use_loopback"
+        android:text="@string/loopback_instructions_glitch"
         android:textSize="14sp"
         android:textStyle="bold" />
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
@@ -52,10 +52,11 @@
         <Button
             android:id="@+id/button_measure"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:onClick="onMeasure"
-            android:text="@string/measure" />
+            android:text="@string/measure"
+            android:textSize="12sp" />
 
         <Button
             android:id="@+id/button_average"
@@ -63,7 +64,8 @@
             android:layout_weight="1"
             android:layout_height="wrap_content"
             android:onClick="onAverage"
-            android:text="@string/average" />
+            android:text="@string/average"
+            android:textSize="12sp" />
 
         <Button
             android:id="@+id/button_cancel"
@@ -72,7 +74,8 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:onClick="onCancel"
-            android:text="@string/cancel" />
+            android:text="@string/cancel"
+            android:textSize="12sp" />
 
         <Button
             android:id="@+id/button_share"
@@ -81,7 +84,7 @@
             android:layout_height="wrap_content"
             android:onClick="onShareFile"
             android:text="@string/share"
-            />
+            android:textSize="12sp" />
     </LinearLayout>
 
     <TextView
@@ -89,7 +92,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:lines="16"
-        android:text="@string/use_loopback"
+        android:text="@string/loopback_instructions_latency"
         android:textSize="18sp"
         android:textStyle="bold" />
 

--- a/apps/OboeTester/app/src/main/res/layout/stream_config.xml
+++ b/apps/OboeTester/app/src/main/res/layout/stream_config.xml
@@ -272,7 +272,7 @@
             android:id="@+id/statusView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lines="3"
+            android:lines="4"
             android:text="@string/init_status" />
     </LinearLayout>
 

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -19,7 +19,21 @@
     <string name="auto_select">Auto select</string>
     <string name="hint_hide_settings">Hide Settings</string>
     <string name="hint_show_settings">Show Settings</string>
-    <string name="use_loopback">Click Show Settings to configure stream.\nRequires a loopback adapter!</string>
+    <string name="loopback_instructions_glitch">
+        Click Show Settings to configure.\n
+        This glitch measurement plays\n
+        and listens to a sine wave.\n
+        It works with best with a loopback dongle.\n
+        Set volume to medium-high.\n
+    </string>
+    <string name="loopback_instructions_latency">
+        Click Show Settings to configure.\n
+        This latency measurement uses a\n
+        short burst of encoded noise.\n
+        It works with speakers and mic\n
+        or a loopback dongle.\n
+        Set volume to medium-high.\n
+    </string>
 
     <string name="api_prompt">Choose an API</string>
     <string-array name="output_modes">


### PR DESCRIPTION
Measure 5 times for average.
Change average.latency.msec to mean.latency.msec
Report mean.absolute.deviation
Display min/average/max latency based on timestamp.
Increase max measurable latency to about 960 msec.