### PR TITLE
oboe: move __ANDROID_API_R__

### DIFF
--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -20,10 +20,6 @@
 #include "OboeDebug.h"
 #include "QuirksManager.h"
 
-#ifndef __ANDROID_API_R__
-#define __ANDROID_API_R__ 30
-#endif
-
 using namespace oboe;
 
 int32_t QuirksManager::DeviceQuirks::clipBufferSize(AudioStream &stream,

--- a/src/common/QuirksManager.h
+++ b/src/common/QuirksManager.h
@@ -21,6 +21,10 @@
 #include <oboe/AudioStreamBuilder.h>
 #include <aaudio/AudioStreamAAudio.h>
 
+#ifndef __ANDROID_API_R__
+#define __ANDROID_API_R__ 30
+#endif
+
 namespace oboe {
 
 /**


### PR DESCRIPTION
Move definition to QuirksManager.h
so it can be used by other files.

Fixes #1148