### PR TITLE
Check for nullptr in FilterAudioStream::getTimestamp()

### DIFF
--- a/src/common/FilterAudioStream.h
+++ b/src/common/FilterAudioStream.h
@@ -173,7 +173,10 @@ public:
             int64_t *timeNanoseconds) override {
         int64_t childPosition = 0;
         Result result = mChildStream->getTimestamp(clockId, &childPosition, timeNanoseconds);
-        *framePosition = childPosition * mRateScaler;
+        // It is OK if framePosition is null.
+        if (framePosition) {
+            *framePosition = childPosition * mRateScaler;
+        }
         return result;
     }
 

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -70,6 +70,11 @@ protected:
             usleep(50 * 1000);
             timeout--;
         }
+
+		// Catch Issue #1166
+        mStream->getTimestamp(CLOCK_MONOTONIC); // should not crash
+        mStream->getTimestamp(CLOCK_MONOTONIC, nullptr, nullptr); // should not crash
+
         ASSERT_GT(callback.callbackCount, 0);
         ASSERT_GT(callback.framesPerCallback, 0);
         ASSERT_EQ(mStream->requestStop(), Result::OK);

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -71,7 +71,7 @@ protected:
             timeout--;
         }
 
-		// Catch Issue #1166
+        // Catch Issue #1166
         mStream->getTimestamp(CLOCK_MONOTONIC); // should not crash
         mStream->getTimestamp(CLOCK_MONOTONIC, nullptr, nullptr); // should not crash
 


### PR DESCRIPTION
Was crashing.

Fixes #1166