### PR TITLE
oboe: add quirk for S20 input

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -26,7 +26,7 @@
 #include "common/OboeDebug.h"
 #include "oboe/Oboe.h"
 
-#include "AAudioExtensions.h"
+#include "aaudio/AAudioExtensions.h"
 #include "AudioStreamGateway.h"
 
 #include "flowunits/ImpulseOscillator.h"

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -89,12 +89,12 @@ Java_com_google_sample_oboe_manualtest_OboeAudioOutputStream_setAmplitude(JNIEnv
 
 JNIEXPORT jboolean JNICALL
 Java_com_google_sample_oboe_manualtest_NativeEngine_isMMapSupported(JNIEnv *env, jclass type) {
-    return AAudioExtensions::getInstance().isMMapSupported();
+    return oboe::AAudioExtensions::getInstance().isMMapSupported();
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_google_sample_oboe_manualtest_NativeEngine_isMMapExclusiveSupported(JNIEnv *env, jclass type) {
-    return AAudioExtensions::getInstance().isMMapExclusiveSupported();
+    return oboe::AAudioExtensions::getInstance().isMMapExclusiveSupported();
 }
 
 JNIEXPORT void JNICALL

--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -65,19 +65,19 @@ public:
     }
 
     bool isMMapUsed(AAudioStream *aaudioStream) {
-        if (open()) return false;
+        if (loadSymbols()) return false;
         if (mAAudioStream_isMMap == nullptr) return false;
         return mAAudioStream_isMMap(aaudioStream);
     }
 
     int32_t setMMapEnabled(bool enabled) {
-        if (open()) return AAUDIO_ERROR_UNAVAILABLE;
+        if (loadSymbols()) return AAUDIO_ERROR_UNAVAILABLE;
         if (mAAudio_setMMapPolicy == nullptr) return false;
         return mAAudio_setMMapPolicy(enabled ? AAUDIO_POLICY_AUTO : AAUDIO_POLICY_NEVER);
     }
 
     bool isMMapEnabled() {
-        if (open()) return false;
+        if (loadSymbols()) return false;
         if (mAAudio_getMMapPolicy == nullptr) return false;
         int32_t policy = mAAudio_getMMapPolicy();
         return isPolicyEnabled(policy);
@@ -116,7 +116,7 @@ private:
      *
      * @return 0 if successful or negative error.
      */
-    aaudio_result_t open() {
+    aaudio_result_t loadSymbols() {
         if (mAAudio_getMMapPolicy != nullptr) {
             return 0;
         }

--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -70,6 +70,14 @@ public:
         return mAAudioStream_isMMap(aaudioStream);
     }
 
+    /**
+     * Controls whether the MMAP data path can be selected when opening a stream.
+     * It has no effect after the stream has been opened.
+     * It only affects the application that calls it. Other apps are not affected.
+     *
+     * @param enabled
+     * @return 0 or a negative error code
+     */
     int32_t setMMapEnabled(bool enabled) {
         if (loadSymbols()) return AAUDIO_ERROR_UNAVAILABLE;
         if (mAAudio_setMMapPolicy == nullptr) return false;

--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -20,6 +20,15 @@
 #include <dlfcn.h>
 #include <stdint.h>
 
+#include <sys/system_properties.h>
+
+#include "common/OboeDebug.h"
+#include "oboe/Oboe.h"
+#include "AAudioLoader.h"
+
+
+namespace oboe {
+
 #define LIB_AAUDIO_NAME          "libaaudio.so"
 #define FUNCTION_IS_MMAP         "AAudioStream_isMMapUsed"
 #define FUNCTION_SET_MMAP_POLICY "AAudio_setMMapPolicy"
@@ -50,20 +59,24 @@ public:
     }
 
     bool isMMapUsed(oboe::AudioStream *oboeStream) {
-        if (!loadLibrary()) return false;
-        if (mAAudioStream_isMMap == nullptr) return false;
         AAudioStream *aaudioStream = (AAudioStream *) oboeStream->getUnderlyingStream();
+        return isMMapUsed(aaudioStream);
+    }
+
+    bool isMMapUsed(AAudioStream *aaudioStream) {
+        if (open()) return false;
+        if (mAAudioStream_isMMap == nullptr) return false;
         return mAAudioStream_isMMap(aaudioStream);
     }
 
-    bool setMMapEnabled(bool enabled) {
-        if (!loadLibrary()) return false;
+    int32_t setMMapEnabled(bool enabled) {
+        if (open()) return -1;
         if (mAAudio_setMMapPolicy == nullptr) return false;
         return mAAudio_setMMapPolicy(enabled ? AAUDIO_POLICY_AUTO : AAUDIO_POLICY_NEVER);
     }
 
     bool isMMapEnabled() {
-        if (!loadLibrary()) return false;
+        if (open()) return false;
         if (mAAudio_getMMapPolicy == nullptr) return false;
         int32_t policy = mAAudio_getMMapPolicy();
         return isPolicyEnabled(policy);
@@ -95,47 +108,56 @@ private:
         return result;
     }
 
-    // return true if it succeeds
-    bool loadLibrary() {
-        if (mFirstTime) {
-            mFirstTime = false;
-            mLibHandle = dlopen(LIB_AAUDIO_NAME, 0);
-            if (mLibHandle == nullptr) {
-                LOGI("%s() could not find " LIB_AAUDIO_NAME, __func__);
-                return false;
-            }
-
-            mAAudioStream_isMMap = (bool (*)(AAudioStream *stream))
-                    dlsym(mLibHandle, FUNCTION_IS_MMAP);
-            if (mAAudioStream_isMMap == nullptr) {
-                LOGI("%s() could not find " FUNCTION_IS_MMAP, __func__);
-                return false;
-            }
-
-            mAAudio_setMMapPolicy = (int32_t (*)(aaudio_policy_t policy))
-                    dlsym(mLibHandle, FUNCTION_SET_MMAP_POLICY);
-            if (mAAudio_setMMapPolicy == nullptr) {
-                LOGI("%s() could not find " FUNCTION_SET_MMAP_POLICY, __func__);
-                return false;
-            }
-
-            mAAudio_getMMapPolicy = (aaudio_policy_t (*)())
-                    dlsym(mLibHandle, FUNCTION_GET_MMAP_POLICY);
-            if (mAAudio_getMMapPolicy == nullptr) {
-                LOGI("%s() could not find " FUNCTION_GET_MMAP_POLICY, __func__);
-                return false;
-            }
+    /**
+     * Load the function pointers.
+     * This can be called multiple times.
+     * It should only be called from one thread.
+     *
+     * @return 0 if successful or negative error.
+     */
+    int open() {
+        if (mAAudio_getMMapPolicy != nullptr) {
+            return 0;
         }
-        return (mLibHandle != nullptr);
+
+        void *libHandle = AAudioLoader::getInstance()->getLibHandle();
+        if (libHandle == nullptr) {
+            LOGI("%s() could not find " LIB_AAUDIO_NAME, __func__);
+            return -1;
+        }
+
+        mAAudioStream_isMMap = (bool (*)(AAudioStream *stream))
+                dlsym(libHandle, FUNCTION_IS_MMAP);
+        if (mAAudioStream_isMMap == nullptr) {
+            LOGI("%s() could not find " FUNCTION_IS_MMAP, __func__);
+            return -1;
+        }
+
+        mAAudio_setMMapPolicy = (int32_t (*)(aaudio_policy_t policy))
+                dlsym(libHandle, FUNCTION_SET_MMAP_POLICY);
+        if (mAAudio_setMMapPolicy == nullptr) {
+            LOGI("%s() could not find " FUNCTION_SET_MMAP_POLICY, __func__);
+            return -1;
+        }
+
+        mAAudio_getMMapPolicy = (aaudio_policy_t (*)())
+                dlsym(libHandle, FUNCTION_GET_MMAP_POLICY);
+        if (mAAudio_getMMapPolicy == nullptr) {
+            LOGI("%s() could not find " FUNCTION_GET_MMAP_POLICY, __func__);
+            return -1;
+        }
+
+        return 0;
     }
 
-    bool      mFirstTime = true;
-    void     *mLibHandle = nullptr;
+    bool      mMMapSupported = false;
+    bool      mMMapExclusiveSupported = false;
+
     bool    (*mAAudioStream_isMMap)(AAudioStream *stream) = nullptr;
     int32_t (*mAAudio_setMMapPolicy)(aaudio_policy_t policy) = nullptr;
     aaudio_policy_t (*mAAudio_getMMapPolicy)() = nullptr;
-    bool      mMMapSupported = false;
-    bool      mMMapExclusiveSupported = false;
 };
+
+} // namespace oboe
 
 #endif //OBOETESTER_AAUDIO_EXTENSIONS_H

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -97,8 +97,6 @@ int AAudioLoader::open() {
 
     stream_getTimestamp        = load_I_PSKPLPL("AAudioStream_getTimestamp");
 
-    stream_isMMapUsed          = load_B_PS("AAudioStream_isMMapUsed");
-
     stream_getChannelCount     = load_I_PS("AAudioStream_getChannelCount");
     if (stream_getChannelCount == nullptr) {
         // Use old alias if needed.

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -69,7 +69,6 @@ typedef int32_t aaudio_session_id_t;
 
 namespace oboe {
 
-
 /**
  * The AAudio API was not available in early versions of Android.
  * To avoid linker errors, we dynamically link with the functions by name using dlsym().
@@ -139,6 +138,8 @@ class AAudioLoader {
      */
     int open();
 
+    void *getLibHandle() const { return mLibHandle; }
+
     // Function pointers into the AAudio shared library.
     signature_I_PPB   createStreamBuilder = nullptr;
 
@@ -172,8 +173,6 @@ class AAudioLoader {
     signature_I_PSTPTL  stream_waitForStateChange = nullptr;
 
     signature_I_PSKPLPL stream_getTimestamp = nullptr;
-
-    signature_B_PS      stream_isMMapUsed = nullptr;
 
     signature_I_PS   stream_close = nullptr;
 

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -23,6 +23,7 @@
 #include "common/AudioClock.h"
 #include "common/OboeDebug.h"
 #include "oboe/Utilities.h"
+#include "AAudioExtensions.h"
 
 #ifdef __ANDROID__
 #include <sys/system_properties.h>
@@ -677,7 +678,7 @@ ResultWithValue<double> AudioStreamAAudio::calculateLatencyMillis() {
 bool AudioStreamAAudio::isMMapUsed() {
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
-        return mLibLoader->stream_isMMapUsed(stream);
+        return AAudioExtensions::getInstance().isMMapUsed(stream);
     } else {
         return false;
     }

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -157,15 +157,20 @@ Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
         }
     }
 
-    bool isMMapEnabled = AAudioExtensions::getInstance().isMMapEnabled();
-    if (isMMapEnabled) {
+    // If MMAP has a problem in this case then disable it temporarily.
+    bool wasMMapOriginallyEnabled = AAudioExtensions::getInstance().isMMapEnabled();
+    bool wasMMapTemporarilyDisabled = false;
+    if (wasMMapOriginallyEnabled) {
         bool isMMapSafe = QuirksManager::getInstance().isMMapSafe(childBuilder);
         if (!isMMapSafe) {
             AAudioExtensions::getInstance().setMMapEnabled(false);
+            wasMMapTemporarilyDisabled = true;
         }
     }
     result = streamP->open();
-    AAudioExtensions::getInstance().setMMapEnabled(isMMapEnabled); // restore original setting
+    if (wasMMapTemporarilyDisabled) {
+        AAudioExtensions::getInstance().setMMapEnabled(wasMMapOriginallyEnabled); // restore original
+    }
     if (result == Result::OK) {
 
         int32_t  optimalBufferSize = -1;

--- a/src/common/QuirksManager.h
+++ b/src/common/QuirksManager.h
@@ -102,6 +102,10 @@ public:
 
         virtual bool isAAudioMMapPossible(const AudioStreamBuilder &builder) const;
 
+        virtual bool isMMapSafe(const AudioStreamBuilder & /* builder */ ) {
+            return true;
+        }
+
         static constexpr int32_t kDefaultBottomMarginInBursts = 0;
         static constexpr int32_t kDefaultTopMarginInBursts = 0;
 
@@ -111,6 +115,8 @@ public:
         static constexpr int32_t kLegacyBottomMarginInBursts = 1;
         static constexpr int32_t kCommonNativeRate = 48000; // very typical native sample rate
     };
+
+    bool isMMapSafe(AudioStreamBuilder &builder);
 
 private:
 


### PR DESCRIPTION
The S20 input had some glitches in an early version.
So we turn off MMAP in that case.

We also moved the AAudioExtensions class from OboeTester into Oboe.

Fixes #892