### PR TITLE
OboeTester: report cold start latency

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -390,14 +390,10 @@ Java_com_google_sample_oboe_manualtest_OboeAudioStream_getLastErrorCallbackResul
 }
 
 JNIEXPORT jdouble JNICALL
-Java_com_google_sample_oboe_manualtest_OboeAudioStream_getLatency(JNIEnv *env,
-        jobject instance, jint streamIndex) {
-    std::shared_ptr<oboe::AudioStream> oboeStream = engine.getCurrentActivity()->getStream(streamIndex);
-    if (oboeStream != nullptr) {
-        auto result = oboeStream->calculateLatencyMillis();
-        return (!result) ? -1.0 : result.value();
-    }
-    return -1.0;
+Java_com_google_sample_oboe_manualtest_OboeAudioStream_getTimestampLatency(JNIEnv *env,
+        jobject instance,
+        jint streamIndex) {
+    return engine.getCurrentActivity()->getTimestampLatency(streamIndex);
 }
 
 JNIEXPORT jdouble JNICALL
@@ -526,6 +522,18 @@ Java_com_google_sample_oboe_manualtest_EchoActivity_setDelayTime(JNIEnv *env,
                                                                          jobject instance,
                                                                          jdouble delayTimeSeconds) {
     engine.setDelayTime(delayTimeSeconds);
+}
+
+JNIEXPORT int JNICALL
+Java_com_google_sample_oboe_manualtest_EchoActivity_getColdStartInputMillis(JNIEnv *env,
+        jobject instance) {
+    return engine.getCurrentActivity()->getColdStartInputMillis();
+}
+
+JNIEXPORT int JNICALL
+Java_com_google_sample_oboe_manualtest_EchoActivity_getColdStartOutputMillis(JNIEnv *env,
+                                                                            jobject instance) {
+    return engine.getCurrentActivity()->getColdStartOutputMillis();
 }
 
 // ==========================================================================

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/NativeSniffer.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/NativeSniffer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sample.oboe.manualtest;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
+
+abstract class NativeSniffer implements Runnable {
+    public static final int SNIFFER_UPDATE_PERIOD_MSEC = 100;
+    public static final int SNIFFER_UPDATE_DELAY_MSEC = 200;
+    private final Activity activity;
+    protected Handler mHandler = new Handler(Looper.getMainLooper()); // UI thread
+    protected volatile boolean mEnabled = true;
+
+    public NativeSniffer(Activity activity) {
+        this.activity = activity;
+    }
+
+    public void startSniffer() {
+        long now = System.currentTimeMillis();
+        // Start the initial runnable task by posting through the handler
+        mEnabled = true;
+        mHandler.postDelayed(this, SNIFFER_UPDATE_DELAY_MSEC);
+    }
+
+    public void stopSniffer() {
+        mEnabled = false;
+        if (mHandler != null) {
+            mHandler.removeCallbacks(this);
+        }
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                updateStatusText();
+            }
+        });
+    }
+
+    public void reschedule() {
+        updateStatusText();
+        // Reschedule so this task repeats
+        if (mEnabled) {
+            mHandler.postDelayed(this, SNIFFER_UPDATE_PERIOD_MSEC);
+        }
+    }
+
+    public abstract void updateStatusText();
+
+    public String getShortReport() {
+        return "no-report";
+    }
+
+}

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioStream.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/OboeAudioStream.java
@@ -229,9 +229,9 @@ abstract class OboeAudioStream extends AudioStreamBase {
 
     @Override
     public double getLatency() {
-        return getLatency(streamIndex);
+        return getTimestampLatency(streamIndex);
     }
-    public native double getLatency(int streamIndex);
+    public native double getTimestampLatency(int streamIndex);
 
     @Override
     public double getCpuLoad() {

--- a/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/google/sample/oboe/manualtest/TestDataPathsActivity.java
@@ -16,6 +16,7 @@
 
 package com.google.sample.oboe.manualtest;
 
+import android.app.Activity;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
@@ -76,6 +77,10 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     // Periodically query for magnitude and phase from the native detector.
     protected class DataPathSniffer extends NativeSniffer {
 
+        public DataPathSniffer(Activity activity) {
+            super(activity);
+        }
+
         @Override
         public void startSniffer() {
             mMagnitude = -1.0;
@@ -128,15 +133,11 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             setAnalyzerText(mLastGlitchReport);
         }
 
-        @Override
-        public double getMaxSecondsWithNoGlitch() {
-            return -1.0;
-        }
     }
 
     @Override
     NativeSniffer createNativeSniffer() {
-        return new TestDataPathsActivity.DataPathSniffer();
+        return new TestDataPathsActivity.DataPathSniffer(this);
     }
 
     native double getMagnitude();

--- a/apps/OboeTester/app/src/main/res/layout/activity_echo.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_echo.xml
@@ -76,5 +76,15 @@
                 android:progress="1000" />
         </LinearLayout>
 
+
+        <TextView
+            android:id="@+id/text_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="11"
+            android:text="@string/echo_instructions"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
     </LinearLayout>
 </ScrollView>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -26,6 +26,10 @@
         It works with best with a loopback dongle.\n
         Set volume to medium-high.\n
     </string>
+    <string name="echo_instructions">
+        Be ready to turn down the volume\n
+        if you get feedback. \n
+    </string>
     <string name="loopback_instructions_latency">
         Click Show Settings to configure.\n
         This latency measurement uses a\n


### PR DESCRIPTION
For input, measured from call to openStream() until first frame arrives to app.
For output, measured from open until first frame hits speaker.