### PR TITLE
Suppress warnings of unused variable.

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -546,6 +546,7 @@ public:
         int32_t sizeInBursts = std::max(2, capacityInBursts / 2);
         // Set size of buffer to minimize underruns.
         auto result = outputStream->setBufferSizeInFrames(sizeInBursts * burstInFrames);
+        static_cast<void>(result);  // Avoid unused variable.
         LOGD("ActivityDataPath: %s() capacity = %d, burst = %d, size = %d",
              __func__, capacityInFrames, burstInFrames, result.value());
     }


### PR DESCRIPTION
To suppress the undefined variable error when the LOGD line is not compiled in, we can add in an ignore command. Similar to discussion here: https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/