### PR TITLE
RhythmGame FFMpegExtractor - for clearing packet use av_packet_unref

### DIFF
--- a/samples/RhythmGame/src/main/cpp/audio/FFMpegExtractor.cpp
+++ b/samples/RhythmGame/src/main/cpp/audio/FFMpegExtractor.cpp
@@ -254,8 +254,7 @@ int64_t FFMpegExtractor::decode(
             if (result == AVERROR(EAGAIN)) {
                 // The codec needs more data before it can decode
                 LOGI("avcodec_receive_frame returned EAGAIN");
-                avPacket.size = 0;
-                avPacket.data = nullptr;
+                av_packet_unref(&avPacket);
                 continue;
             } else if (result != 0) {
                 LOGE("avcodec_receive_frame error: %s", av_err2str(result));
@@ -289,8 +288,7 @@ int64_t FFMpegExtractor::decode(
             bytesWritten += bytesToWrite;
             av_freep(&buffer1);
 
-            avPacket.size = 0;
-            avPacket.data = nullptr;
+            av_packet_unref(&avPacket);
         }
     }
 


### PR DESCRIPTION
Currently in FFMpegExtractor for clearing out packets the following two lines are being used,

```
avPacket.size = 0;
avPacket.data = nullptr;
```

This might create memory leak if someone tries to reuse this implementation in some other project. I am writing an application which is reading data from device storage and decoding using FFMpeg. I did found this implementation very compact, organised and ready to be used. But when I used it and profiled memory, I got below,

<img width="1739" alt="Screen Shot 2564-03-16 at 01 59 20" src="https://user-images.githubusercontent.com/10719657/111206682-440e3780-85fb-11eb-85a9-7ffa414a2388.png">

Memory block equal to the same size of the decompressed audio remains as ghost memory in RAM.

Doing with the appropriate function,

```
av_packet_unref(&avPacket);
```

Does not leave any memory leak like below,

<img width="1739" alt="Screen Shot 2564-03-16 at 02 03 27" src="https://user-images.githubusercontent.com/10719657/111207149-d6164000-85fb-11eb-8d35-bbf290efec53.png">

I know this is a very small contribution, but I hope it will be merged. :)