### PR TITLE
OboeTester: remove log spew from debugging

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -260,7 +260,7 @@ oboe::Result ActivityContext::start() {
         dataThread = new std::thread(threadCallback, this);
     }
 
-#ifdef DEBUG_CLOSE_RACE
+#if DEBUG_CLOSE_RACE
     // Also put a sleep for 400 msec in AudioStreamAAudio::updateFramesRead().
     if (outputStream != nullptr) {
         std::thread raceDebugger([outputStream]() {


### PR DESCRIPTION
Changed #ifdef to #if