### PR TITLE
Fix failing unit tests on pre-L devices

### DIFF
--- a/tests/UnitTestRunner/app/src/main/java/com/google/oboe/tests/unittestrunner/MainActivity.java
+++ b/tests/UnitTestRunner/app/src/main/java/com/google/oboe/tests/unittestrunner/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends AppCompatActivity {
         if (!isRecordPermissionGranted()){
             requestPermissions();
         } else {
-
+            Log.d(TAG, "Got RECORD_AUDIO permission");
             Thread commandThread = new Thread(new UnitTestCommand());
             commandThread.start();
         }

--- a/tests/UnitTestRunner/build.gradle
+++ b/tests/UnitTestRunner/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha10'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,4 +130,4 @@ echo "Starting app - Check your device for test results"
 adb shell am start ${TEST_RUNNER_PACKAGE_NAME}/.MainActivity 
 
 sleep 1
-adb logcat --pid=`adb shell pidof -s ${TEST_RUNNER_PACKAGE_NAME}`
+adb logcat ${TEST_RUNNER_PACKAGE_NAME}


### PR DESCRIPTION
I've also split the unit test fixtures into `StreamOpenOutput` and `StreamOpenInput` so that it's easy to run these tests in isolation using: 

```
testOboe --gtest_filter=StreamOpenOutput.*
```

This is useful when testing on the emulator which doesn't allow input streams to be opened, and thus causes all the associated tests to fail. 