### PR TITLE
Support float on jellybean

### DIFF
--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -184,6 +184,17 @@ bool QuirksManager::isConversionNeeded(
         LOGI("QuirksManager::%s() forcing internal format to I16 for low latency", __func__);
     }
 
+    // Add quirk for float output on API <21
+    if (isFloat
+            && !isInput
+            && getSdkVersion() < __ANDROID_API_L__ && builder.isFormatConversionAllowed()) {
+        childBuilder.setFormat(AudioFormat::I16);
+        conversionNeeded = true;
+        LOGI("QuirksManager::%s() float was requested but not supported on pre-L devices, "
+             "creating an underlying I16 stream and using format conversion to provide a float "
+             "stream", __func__);
+    }
+
     // Channel Count conversions
     if (OboeGlobals::areWorkaroundsEnabled()
             && builder.isChannelConversionAllowed()

--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -187,7 +187,9 @@ bool QuirksManager::isConversionNeeded(
     // Add quirk for float output on API <21
     if (isFloat
             && !isInput
-            && getSdkVersion() < __ANDROID_API_L__ && builder.isFormatConversionAllowed()) {
+            && getSdkVersion() < __ANDROID_API_L__
+            && builder.isFormatConversionAllowed()
+            ) {
         childBuilder.setFormat(AudioFormat::I16);
         conversionNeeded = true;
         LOGI("QuirksManager::%s() float was requested but not supported on pre-L devices, "

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -38,7 +38,7 @@ class StreamOpen : public ::testing::Test {
 protected:
 
     bool openStream() {
-        mStream = nullptr;
+        EXPECT_EQ(mStream, nullptr);
         Result r = mBuilder.openStream(&mStream);
         EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
         EXPECT_EQ(0, openCount) << "Should start with a fresh object every time.";

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -331,6 +331,17 @@ TEST_F(StreamOpenOutput, PlaybackFormatFloatReturnsErrorBeforeLollipop){
     }
 }
 
+TEST_F(StreamOpenOutput, PlaybackFormatFloatReturnsFloatBeforeLollipopWithFormatConversionAllowed){
+    if (getSdkVersion() < __ANDROID_API_L__){
+        mBuilder.setDirection(Direction::Output);
+        mBuilder.setFormat(AudioFormat::Float);
+        mBuilder.setFormatConversionAllowed(true);
+        ASSERT_TRUE(openStream());
+        ASSERT_EQ(mStream->getFormat(), AudioFormat::Float);
+        ASSERT_TRUE(closeStream());
+    }
+}
+
 TEST_F(StreamOpenOutput, PlaybackFormatFloatReturnsFloatOnLollipopAndLater){
 
     if (getSdkVersion() >= __ANDROID_API_L__){


### PR DESCRIPTION
Add quirk to allow float playback streams to be created on pre-L devices by using format conversion. 