### PR TITLE
Update RhythmGame sample to use format conversion for API 16 compatibility + fix libraries

### DIFF
--- a/samples/RhythmGame/CMakeLists.txt
+++ b/samples/RhythmGame/CMakeLists.txt
@@ -35,7 +35,7 @@ if(${USE_FFMPEG})
 
     # Add the local path to FFmpeg, you can use the ${ANDROID_ABI} variable to specify the ABI name
     # e.g. /Users/donturner/Code/ffmpeg/build/${ANDROID_ABI}
-    set(FFMPEG_DIR "/path/to/ffmpeg")
+    set(FFMPEG_DIR /Users/donturner/Code/ffmpeg/build/${ANDROID_ABI})
 
     include_directories(native-lib ${FFMPEG_DIR}/include)
 

--- a/samples/RhythmGame/CMakeLists.txt
+++ b/samples/RhythmGame/CMakeLists.txt
@@ -35,7 +35,7 @@ if(${USE_FFMPEG})
 
     # Add the local path to FFmpeg, you can use the ${ANDROID_ABI} variable to specify the ABI name
     # e.g. /Users/donturner/Code/ffmpeg/build/${ANDROID_ABI}
-    set(FFMPEG_DIR /Users/donturner/Code/ffmpeg/build/${ANDROID_ABI})
+    set(FFMPEG_DIR "/path/to/ffmpeg")
 
     include_directories(native-lib ${FFMPEG_DIR}/include)
 

--- a/samples/RhythmGame/build.gradle
+++ b/samples/RhythmGame/build.gradle
@@ -43,11 +43,9 @@ android {
         }
         /**
          * To use FFmpeg for asset extraction do the following:
-         * - Uncomment this block
          * - Change the build variant to ffmpegExtractor
          * - Update the FFMPEG_DIR variable in CMakeLists.txt to the local FFmpeg path
         */
-        /*
         ffmpegExtractor {
             dimension "extractorLibrary"
             minSdkVersion 16
@@ -56,7 +54,7 @@ android {
                     arguments "-DUSE_FFMPEG=1"
                 }
             }
-        }*/
+        }
     }
 }
 

--- a/samples/RhythmGame/build.gradle
+++ b/samples/RhythmGame/build.gradle
@@ -26,11 +26,6 @@ android {
             path "CMakeLists.txt"
         }
     }
-    sourceSets {
-        main {
-            jniLibs.srcDirs = ['libs']
-        }
-    }
     flavorDimensions "extractorLibrary"
     productFlavors {
         ndkExtractor {

--- a/samples/RhythmGame/build.gradle
+++ b/samples/RhythmGame/build.gradle
@@ -43,10 +43,11 @@ android {
         }
         /**
          * To use FFmpeg for asset extraction do the following:
+         * - Uncomment the block below
          * - Change the build variant to ffmpegExtractor
          * - Update the FFMPEG_DIR variable in CMakeLists.txt to the local FFmpeg path
         */
-        ffmpegExtractor {
+        /*ffmpegExtractor {
             dimension "extractorLibrary"
             minSdkVersion 16
             externalNativeBuild {
@@ -54,7 +55,7 @@ android {
                     arguments "-DUSE_FFMPEG=1"
                 }
             }
-        }
+        }*/
     }
 }
 

--- a/samples/RhythmGame/build.gradle
+++ b/samples/RhythmGame/build.gradle
@@ -43,11 +43,12 @@ android {
         }
         /**
          * To use FFmpeg for asset extraction do the following:
-         * - Uncomment the block below
+         * - Uncomment this block
          * - Change the build variant to ffmpegExtractor
          * - Update the FFMPEG_DIR variable in CMakeLists.txt to the local FFmpeg path
         */
-        /*ffmpegExtractor {
+        /*
+        ffmpegExtractor {
             dimension "extractorLibrary"
             minSdkVersion 16
             externalNativeBuild {
@@ -55,7 +56,8 @@ android {
                     arguments "-DUSE_FFMPEG=1"
                 }
             }
-        }*/
+        }
+        */
     }
 }
 

--- a/samples/RhythmGame/src/main/cpp/Game.cpp
+++ b/samples/RhythmGame/src/main/cpp/Game.cpp
@@ -166,8 +166,6 @@ bool Game::openStream() {
 
     // Create an audio stream
     AudioStreamBuilder builder;
-    builder.setDataCallback(this);
-    builder.setErrorCallback(this);
     builder.setFormat(AudioFormat::Float);
     builder.setFormatConversionAllowed(true);
     builder.setPerformanceMode(PerformanceMode::LowLatency);
@@ -176,7 +174,8 @@ bool Game::openStream() {
     builder.setSampleRateConversionQuality(
             SampleRateConversionQuality::Medium);
     builder.setChannelCount(2);
-
+    builder.setDataCallback(this);
+    builder.setErrorCallback(this);
     Result result = builder.openStream(mAudioStream);
     if (result != Result::OK){
         LOGE("Failed to open stream. Error: %s", convertToText(result));

--- a/samples/RhythmGame/src/main/cpp/Game.h
+++ b/samples/RhythmGame/src/main/cpp/Game.h
@@ -64,7 +64,6 @@ private:
     std::unique_ptr<Player> mClap;
     std::unique_ptr<Player> mBackingTrack;
     Mixer mMixer;
-    std::unique_ptr<float[]> mConversionBuffer { nullptr }; // For float->int16 conversion
 
     LockFreeQueue<int64_t, kMaxQueueItems> mClapEvents;
     std::atomic<int64_t> mCurrentFrame { 0 };

--- a/samples/RhythmGame/src/main/cpp/Game.h
+++ b/samples/RhythmGame/src/main/cpp/Game.h
@@ -40,7 +40,7 @@ enum class GameState {
     FailedToLoad
 };
 
-class Game : public AudioStreamCallback {
+class Game : public AudioStreamDataCallback, AudioStreamErrorCallback {
 public:
     explicit Game(AAssetManager&);
     void start();

--- a/samples/RhythmGame/src/main/cpp/audio/FFMpegExtractor.cpp
+++ b/samples/RhythmGame/src/main/cpp/audio/FFMpegExtractor.cpp
@@ -121,6 +121,8 @@ int64_t FFMpegExtractor::decode(
         uint8_t *targetData,
         AudioProperties targetProperties) {
 
+    LOGI("Decoder: FFMpeg");
+
     int returnValue = -1; // -1 indicates error
 
     // Create a buffer for FFmpeg to use for decoding (freed in the custom deleter below)

--- a/samples/RhythmGame/src/main/java/com/google/oboe/samples/rhythmgame/MainActivity.java
+++ b/samples/RhythmGame/src/main/java/com/google/oboe/samples/rhythmgame/MainActivity.java
@@ -29,10 +29,12 @@ public class MainActivity extends AppCompatActivity {
 
     // Used to load the 'native-lib' library on application startup.
     static {
-        System.loadLibrary("avutil");
-        System.loadLibrary("swresample");
-        System.loadLibrary("avcodec");
-        System.loadLibrary("avformat");
+        if (BuildConfig.FLAVOR == "ffmpegExtractor"){
+            System.loadLibrary("avutil");
+            System.loadLibrary("swresample");
+            System.loadLibrary("avcodec");
+            System.loadLibrary("avformat");
+        }
         System.loadLibrary("native-lib");
     }
 

--- a/samples/RhythmGame/src/main/java/com/google/oboe/samples/rhythmgame/MainActivity.java
+++ b/samples/RhythmGame/src/main/java/com/google/oboe/samples/rhythmgame/MainActivity.java
@@ -29,6 +29,10 @@ public class MainActivity extends AppCompatActivity {
 
     // Used to load the 'native-lib' library on application startup.
     static {
+        System.loadLibrary("avutil");
+        System.loadLibrary("swresample");
+        System.loadLibrary("avcodec");
+        System.loadLibrary("avformat");
         System.loadLibrary("native-lib");
     }
 


### PR DESCRIPTION
**Change to floats**
Change the RhythmGame sample to only use floats, relying on Oboe's own format conversion when the underlying stream is not float. This makes the code simpler and the sample possible to run on API 16 (using the FFmpeg build variant). 

**Fix the way that libraries are packaged**
The FFmpeg variant was failing to run because the Android Gradle Plugin changed the way it handles imported libraries. It was failing with the error: 

```
2 files found with path 'lib/x86/libswresample.so'.
If you are using jniLibs and CMake IMPORTED targets, see
https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

The solution was to remove the `jniLibs` block from `build.gradle` and add `System.loadLibrary` into `MainActivity` for the FFmpeg build variant.

Note: This PR includes commits from https://github.com/google/oboe/pull/1267 because it's dependent on them. Git should sort that out when they're merged. 