### PR TITLE
OboeTester: bump to V2.0.0

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         // Also update the versions in the AndroidManifest.xml file.
-        versionCode 47
-        versionName "1.6.5"
+        versionCode 48
+        versionName "2.0.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mobileer.oboetester"
-    android:versionCode="47"
-    android:versionName="1.6.5">
+    android:versionCode="48"
+    android:versionName="2.0.0">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
 
     <uses-feature android:name="android.hardware.microphone" android:required="false" />


### PR DESCRIPTION
This is because we changed the package names when we released
OboeTester on Play Store. That caused a breaking change in the
Automated Test related commands.