### PR TITLE
Build libs with debug info. Fixes #1301.

### DIFF
--- a/build_all_android.sh
+++ b/build_all_android.sh
@@ -30,7 +30,7 @@ BUILD_DIR=build
 
 CMAKE_ARGS="-H. \
   -DBUILD_SHARED_LIBS=true \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DANDROID_TOOLCHAIN=clang \
   -DANDROID_STL=c++_shared \
   -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \


### PR DESCRIPTION
Change build type from `Release` to `RelWithDebInfo`. This will include debugging information in the resulting shared libraries, making it easier for our users to pinpoint problems with Oboe during development.

Whilst this increases the resulting file size dramatically, this debug information is stripped by the Android Gradle Plugin when building an APK so there's no size impact on end users. 