### PR TITLE
Update Spinners and CheckBoxes to clean up automatically

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -396,11 +396,16 @@ public class StreamConfigurationView extends LinearLayout {
 
     public void setChildrenEnabled(boolean enabled) {
         mNativeApiSpinner.setEnabled(enabled);
+        mRequestedMMapView.setEnabled(enabled);
         mPerformanceSpinner.setEnabled(enabled);
         mRequestedExclusiveView.setEnabled(enabled);
-        mSampleRateSpinner.setEnabled(enabled);
+        mChannelConversionBox.setEnabled(enabled);
+        mFormatConversionBox.setEnabled(enabled);
         mChannelCountSpinner.setEnabled(enabled);
+        mInputPresetSpinner.setEnabled(enabled);
         mFormatSpinner.setEnabled(enabled);
+        mSampleRateSpinner.setEnabled(enabled);
+        mRateConversionQualitySpinner.setEnabled(enabled);
         mDeviceSpinner.setEnabled(enabled);
         mRequestAudioEffect.setEnabled(enabled);
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -403,6 +403,7 @@ public class StreamConfigurationView extends LinearLayout {
         mFormatConversionBox.setEnabled(enabled);
         mChannelCountSpinner.setEnabled(enabled);
         mInputPresetSpinner.setEnabled(enabled);
+        mUsageSpinner.setEnabled(enabled);
         mFormatSpinner.setEnabled(enabled);
         mSampleRateSpinner.setEnabled(enabled);
         mRateConversionQualitySpinner.setEnabled(enabled);


### PR DESCRIPTION
setChildrenEnabled is called whenever the state changes between open, started, paused, stopped, and closed. When the stream is closed, all the spinners and checkboxes should work as expected. Otherwise, disable all of them.

This change fixes the user complaints about MMAP not working as expected when the checkbox is toggled by removing the ability to toggle the checkbox