### PR TITLE
Added mDeviceId to FilterAudioStream

### DIFF
--- a/src/common/FilterAudioStream.h
+++ b/src/common/FilterAudioStream.h
@@ -57,6 +57,7 @@ public:
         mPerformanceMode = mChildStream->getPerformanceMode();
         mInputPreset = mChildStream->getInputPreset();
         mFramesPerBurst = mChildStream->getFramesPerBurst();
+        mDeviceId = mChildStream->getDeviceId();
     }
 
     virtual ~FilterAudioStream() = default;


### PR DESCRIPTION
Fixed a missing parameter in FilterAudioStream. Without this change, when getDeviceId() is called, the device id is set to 0, as it uses the default value. With this change, mDeviceId correctly uses the value from the child stream.

I verified that the issue repros before the change and the fix does indeed fix the problem