### PR TITLE
Start linear ramps at the initial volume set

### DIFF
--- a/src/flowgraph/RampLinear.cpp
+++ b/src/flowgraph/RampLinear.cpp
@@ -33,7 +33,7 @@ void RampLinear::setLengthInFrames(int32_t frames) {
 void RampLinear::setTarget(float target) {
     mTarget.store(target);
     // If the ramp has not been used then start immediately at this level.
-    if (mLastCallCount < 0) {
+    if (mLastCallCount == kInitialCallCount) {
         forceCurrent(target);
     }
 }

--- a/src/flowgraph/RampLinear.cpp
+++ b/src/flowgraph/RampLinear.cpp
@@ -32,6 +32,10 @@ void RampLinear::setLengthInFrames(int32_t frames) {
 
 void RampLinear::setTarget(float target) {
     mTarget.store(target);
+    // If the ramp has not been used then start immediately at this level.
+    if (mLastCallCount < 0) {
+        forceCurrent(target);
+    }
 }
 
 float RampLinear::interpolateCurrent() {

--- a/tests/testFlowgraph.cpp
+++ b/tests/testFlowgraph.cpp
@@ -80,31 +80,40 @@ TEST(test_flowgraph, module_mono_to_stereo) {
 }
 
 TEST(test_flowgraph, module_ramp_linear) {
+    constexpr int singleNumOutput = 1;
     constexpr int rampSize = 5;
     constexpr int numOutput = 100;
     constexpr float value = 1.0f;
-    constexpr float target = 100.0f;
+    constexpr float initialTarget = 10.0f;
+    constexpr float finalTarget = 100.0f;
+    constexpr float tolerance = 0.0001f; // arbitrary
     float output[numOutput] = {};
     RampLinear rampLinear{1};
     SinkFloat sinkFloat{1};
 
     rampLinear.input.setValue(value);
     rampLinear.setLengthInFrames(rampSize);
-    rampLinear.setTarget(target);
-    rampLinear.forceCurrent(0.0f);
-
     rampLinear.output.connect(&sinkFloat.input);
 
+    // Check that the values go to the initial target instantly.
+    rampLinear.setTarget(initialTarget);
+    int32_t singleNumRead = sinkFloat.read(output, singleNumOutput);
+    ASSERT_EQ(singleNumRead, singleNumOutput);
+    EXPECT_NEAR(value * initialTarget, output[0], tolerance);
+
+    // Now set target and check that the linear ramp works as expected.
+    rampLinear.setTarget(finalTarget);
     int32_t numRead = sinkFloat.read(output, numOutput);
+    const float incrementSize = (finalTarget - initialTarget) / rampSize;
     ASSERT_EQ(numOutput, numRead);
-    constexpr float tolerance = 0.0001f; // arbitrary
+
     int i = 0;
     for (; i < rampSize; i++) {
-        float expected = i * value * target / rampSize;
+        float expected = value * (initialTarget + i * incrementSize);
         EXPECT_NEAR(expected, output[i], tolerance);
     }
     for (; i < numOutput; i++) {
-        float expected = value * target;
+        float expected = value * finalTarget;
         EXPECT_NEAR(expected, output[i], tolerance);
     }
 }


### PR DESCRIPTION
Currently this ramp starts at 0 for the first ramp for no reason. Start this at the initial volume set.

This will help with clicking issues when pressing the volume up and down keys.

Tested via: Installed and ran updated tests via UnitTestRunner app