### PR TITLE
Fix switching between SCO and A2DP

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -75,7 +75,6 @@ abstract class TestAudioActivity extends Activity {
     private MyStreamSniffer mStreamSniffer;
     private CheckBox mCallbackReturnStopBox;
     private int mSampleRate;
-    private boolean mScoStarted;
     private int mSingleTestIndex = -1;
     private static boolean mBackgroundEnabled;
 
@@ -460,7 +459,7 @@ abstract class TestAudioActivity extends Activity {
         requestedConfig.setFramesPerBurst(audioManagerFramesPerBurst);
 
         // Start Bluetooth SCO if needed.
-        if (isScoDevice(requestedConfig.getDeviceId()) && !mScoStarted) {
+        if (isScoDevice(requestedConfig.getDeviceId())) {
             startBluetoothSco();
         }
 
@@ -565,9 +564,7 @@ abstract class TestAudioActivity extends Activity {
             }
         }
 
-        if (mScoStarted) {
-            stopBluetoothSco();
-        }
+        stopBluetoothSco();
 
         mAudioState = AUDIO_STATE_CLOSED;
         updateEnabledWidgets();
@@ -576,13 +573,11 @@ abstract class TestAudioActivity extends Activity {
     void startBluetoothSco() {
         AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         myAudioMgr.startBluetoothSco();
-        mScoStarted = true;
     }
 
     void stopBluetoothSco() {
         AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         myAudioMgr.stopBluetoothSco();
-        mScoStarted = false;
     }
 
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -462,7 +462,6 @@ abstract class TestAudioActivity extends Activity {
         // Start Bluetooth SCO if needed.
         if (isScoDevice(requestedConfig.getDeviceId()) && !mScoStarted) {
             startBluetoothSco();
-            mScoStarted = true;
         }
 
         streamContext.tester.open(); // OPEN the stream
@@ -568,7 +567,6 @@ abstract class TestAudioActivity extends Activity {
 
         if (mScoStarted) {
             stopBluetoothSco();
-            mScoStarted = false;
         }
 
         mAudioState = AUDIO_STATE_CLOSED;
@@ -578,11 +576,13 @@ abstract class TestAudioActivity extends Activity {
     void startBluetoothSco() {
         AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         myAudioMgr.startBluetoothSco();
+        mScoStarted = true;
     }
 
     void stopBluetoothSco() {
         AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         myAudioMgr.stopBluetoothSco();
+        mScoStarted = false;
     }
 
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -458,11 +458,6 @@ abstract class TestAudioActivity extends Activity {
         StreamConfiguration actualConfig = streamContext.tester.actualConfiguration;
         requestedConfig.setFramesPerBurst(audioManagerFramesPerBurst);
 
-        // Start Bluetooth SCO if needed.
-        if (isScoDevice(requestedConfig.getDeviceId())) {
-            startBluetoothSco();
-        }
-
         streamContext.tester.open(); // OPEN the stream
 
         mSampleRate = actualConfig.getSampleRate();
@@ -563,8 +558,6 @@ abstract class TestAudioActivity extends Activity {
                 streamContext.tester.close();
             }
         }
-
-        stopBluetoothSco();
 
         mAudioState = AUDIO_STATE_CLOSED;
         updateEnabledWidgets();


### PR DESCRIPTION
In MainActivity.java, there is code to toggle SCO on and off.

```
    public void onStartStopBluetoothSco(View view) {
        CheckBox checkBox = (CheckBox) view;
        AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
        if (checkBox.isChecked()) {
            myAudioMgr.startBluetoothSco();
        } else {
            myAudioMgr.stopBluetoothSco();
        }
    }
```

This code used in conjunction with the use of startBluetoothSco() and stopBluetoothSco() causes several weird cases with SCO and A2DP. The main one is that when SCO was toggled on, TestAudioActivity would not know and SCO would never turn off.

Oboe's overarching philosophy is to let failures happen, so we removed the automatic sco adjustment in this Pull Request

Tested with Boltune and Sony devices on Pixel 4a 5G device