### PR TITLE
Show error toast on bad input combinations

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TapToToneActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TapToToneActivity.java
@@ -332,7 +332,13 @@ public class TapToToneActivity extends TestOutputActivityBase {
     }
 
     public void startTest(View view) throws IOException {
-        openAudio();
+        try {
+            openAudio();
+        } catch (IOException e) {
+            e.printStackTrace();
+            showErrorToast("Open audio failed!");
+            return;
+        }
         if (hasRecordAudioPermission()) {
             startAudioPermitted();
         } else {


### PR DESCRIPTION
Fixes #1324

OboeTester crashes when starting a OpenSL ES stream using PCM_I32/PCM_I24 formats. Fix is to simply send an error toast on invalid openStream calls instead of crashing.

Verified that the toast indeed shows on Bramble.
