### PR TITLE
Fix unused-parameter warnings

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -344,7 +344,7 @@ Result AudioStreamAAudio::close() {
     }
 }
 
-DataCallbackResult AudioStreamAAudio::callOnAudioReady(AAudioStream *stream,
+DataCallbackResult AudioStreamAAudio::callOnAudioReady(AAudioStream * /*stream*/,
                                                                  void *audioData,
                                                                  int32_t numFrames) {
     DataCallbackResult result = fireDataCallback(audioData, numFrames);

--- a/src/common/FilterAudioStream.h
+++ b/src/common/FilterAudioStream.h
@@ -182,20 +182,20 @@ public:
             void *audioData,
             int32_t numFrames) override;
 
-    bool onError(AudioStream * audioStream, Result error) override {
+    bool onError(AudioStream * /*audioStream*/, Result error) override {
         if (mErrorCallback != nullptr) {
             return mErrorCallback->onError(this, error);
         }
         return false;
     }
 
-    void onErrorBeforeClose(AudioStream *oboeStream, Result error) override {
+    void onErrorBeforeClose(AudioStream * /*oboeStream*/, Result error) override {
         if (mErrorCallback != nullptr) {
             mErrorCallback->onErrorBeforeClose(this, error);
         }
     }
 
-    void onErrorAfterClose(AudioStream *oboeStream, Result error) override {
+    void onErrorAfterClose(AudioStream * /*oboeStream*/, Result error) override {
         // Close this parent stream because the callback will only close the child.
         AudioStream::close();
         if (mErrorCallback != nullptr) {

--- a/src/flowgraph/ManyToMultiConverter.h
+++ b/src/flowgraph/ManyToMultiConverter.h
@@ -37,7 +37,7 @@ public:
 
     int32_t onProcess(int numFrames) override;
 
-    void setEnabled(bool enabled) {}
+    void setEnabled(bool /*enabled*/) {}
 
     std::vector<std::unique_ptr<flowgraph::FlowGraphPortFloatInput>> inputs;
     flowgraph::FlowGraphPortFloatOutput output;


### PR DESCRIPTION
Fixes #312

The compiler flag -Wunused-parameter outputs some warnings on a couple of files. This is fixed in this PR.

Tested via:
Temporarily added -Wunused-parameter to CMakeLists.txt in top level directory and compiled OboeTester.