### PR TITLE
[hello-oboe] Add format conversion for output API <21 and input API <23

### DIFF
--- a/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
+++ b/samples/hello-oboe/src/main/cpp/HelloOboeEngine.cpp
@@ -124,6 +124,7 @@ oboe::Result HelloOboeEngine::openPlaybackStream() {
     oboe::Result result = builder.setSharingMode(oboe::SharingMode::Exclusive)
         ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
         ->setFormat(oboe::AudioFormat::Float)
+        ->setFormatConversionAllowed(true)
         ->setDataCallback(mLatencyCallback.get())
         ->setErrorCallback(mErrorCallback.get())
         ->setAudioApi(mAudioApi)


### PR DESCRIPTION
Fixes #1261 by proving that float->int16 conversion does work as intended on API <21. 