### PR TITLE
Improve stabilized callback timing model

### DIFF
--- a/include/oboe/StabilizedCallback.h
+++ b/include/oboe/StabilizedCallback.h
@@ -22,30 +22,23 @@
 
 namespace oboe {
 
-class StabilizedCallback : public AudioStreamCallback {
+class StabilizedCallback : public AudioStreamDataCallback {
 
 public:
-    explicit StabilizedCallback(AudioStreamCallback *callback);
+    explicit StabilizedCallback(AudioStreamDataCallback *callback);
 
     DataCallbackResult
     onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numFrames) override;
 
-    void onErrorBeforeClose(AudioStream *oboeStream, Result error) override {
-        return mCallback->onErrorBeforeClose(oboeStream, error);
-    }
-
-    void onErrorAfterClose(AudioStream *oboeStream, Result error) override {
-
-        // Reset all fields now that the stream has been closed
+    void resetTimingModel(){
         mFrameCount = 0;
         mEpochTimeNanos = 0;
         mOpsPerNano = 1;
-        return mCallback->onErrorAfterClose(oboeStream, error);
     }
 
 private:
 
-    AudioStreamCallback *mCallback = nullptr;
+    AudioStreamDataCallback *mCallback = nullptr;
     int64_t mFrameCount = 0;
     int64_t mEpochTimeNanos = 0;
     double  mOpsPerNano = 1;

--- a/include/oboe/StabilizedCallback.h
+++ b/include/oboe/StabilizedCallback.h
@@ -40,6 +40,7 @@ private:
 
     AudioStreamDataCallback *mCallback = nullptr;
     int64_t mFrameCount = 0;
+    int64_t mCallbackIndex = 0;
     int64_t mEpochTimeNanos = 0;
     double  mOpsPerNano = 1;
 

--- a/samples/MegaDrone/src/main/cpp/MegaDroneEngine.h
+++ b/samples/MegaDrone/src/main/cpp/MegaDroneEngine.h
@@ -48,6 +48,7 @@ private:
     std::shared_ptr<AudioStream> mStream;
     std::shared_ptr<TappableAudioSource> mAudioSource;
     std::unique_ptr<DefaultDataCallback> mDataCallback;
+    std::unique_ptr<StabilizedCallback> mStabilizedCallback;
     std::unique_ptr<DefaultErrorCallback> mErrorCallback;
 
     oboe::Result createPlaybackStream();

--- a/src/common/StabilizedCallback.cpp
+++ b/src/common/StabilizedCallback.cpp
@@ -23,7 +23,7 @@ constexpr float kPercentageOfCallbackToUse = 0.8;
 
 using namespace oboe;
 
-StabilizedCallback::StabilizedCallback(AudioStreamCallback *callback) : mCallback(callback){
+StabilizedCallback::StabilizedCallback(AudioStreamDataCallback *callback) : mCallback(callback){
     Trace::initialize();
 }
 


### PR DESCRIPTION
This PR updates the timing model used in `StabilizedCallback`. Essentially the epoch value is not stored until 100 callbacks have occurred. This gives the stream time to settle. 

I've tested that this code works with the MegaDrone app, however, I haven't extensively tested the impact of using original `StabilizedCallback` vs this improved version vs not using it at all. 

I wonder if we could incorporate a "variable CPU load" test into OboeTester?  

Fixes https://github.com/google/oboe/issues/1298