### PR TITLE
oboe: remove include of ndk-version.h

### DIFF
--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -60,7 +60,6 @@ typedef int32_t aaudio_session_id_t;
 #define AAUDIO_STREAM_STATE_STARTED    static_cast<aaudio_stream_state_t>(StreamState::Started)
 #else
 #include <aaudio/AAudio.h>
-#include <android/ndk-version.h>
 #endif
 
 #ifndef __NDK_MAJOR__


### PR DESCRIPTION
This is to prevent a merge conflict with Android /external/oboe.
It does not seem necessary. __NDK_MAJOR__ is getting defined somewhere else.

Fixes #1358