### PR TITLE
OboeTester: fix MIDI and crash

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         // Also update the versions in the AndroidManifest.xml file.
-        versionCode 52
-        versionName "2.1.2"
+        versionCode 53
+        versionName "2.1.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mobileer.oboetester"
-    android:versionCode="52"
-    android:versionName="2.1.2">
+    android:versionCode="53"
+    android:versionName="2.1.3">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
     <uses-feature
         android:name="android.hardware.microphone"

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MidiTapTester.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MidiTapTester.java
@@ -31,6 +31,9 @@ import java.util.ArrayList;
  * Report the results back to the TestListeners.
  */
 public class MidiTapTester extends MidiDeviceService {
+    // These must match the values in service_device_info.xml
+    public static final String PRODUCT_NAME = "MidiTapLatencyTester";
+    public static final String MANUFACTURER_NAME = "Mobileer";
 
     // Sometimes the service can be run without the MainActivity being run!
     static {
@@ -43,7 +46,6 @@ public class MidiTapTester extends MidiDeviceService {
     private MidiFramer mMidiFramer = new MidiFramer(mReceiver);
 
     private static MidiTapTester mInstance;
-
 
     public static interface NoteListener {
         public void onNoteOn(int pitch);
@@ -75,7 +77,7 @@ public class MidiTapTester extends MidiDeviceService {
         super.onDestroy();
     }
 
-    public static MidiTapTester getInstance() {
+    public static MidiTapTester getInstanceOrNull() {
         return mInstance;
     }
 

--- a/apps/OboeTester/app/src/main/res/xml/service_device_info.xml
+++ b/apps/OboeTester/app/src/main/res/xml/service_device_info.xml
@@ -12,7 +12,8 @@
 -->
 
 <devices>
-    <device manufacturer="AndroidTest" product="AudioLatencyTester">
+    <!-- These must match the values in MidiTaptester.java -->
+    <device manufacturer="Mobileer" product="MidiTapLatencyTester">
         <input-port name="input" />
     </device>
 </devices>


### PR DESCRIPTION
Fixed crash caused by opening Tap-to-Tone when an old
version of OboeTester was also installed.

Fixed the use of MIDI in Tap-to-Tone.

Fixes #1360