### PR TITLE
remove duplicated header

### DIFF
--- a/tests/testAAudio.cpp
+++ b/tests/testAAudio.cpp
@@ -1,4 +1,4 @@
-#include <oboe/Oboe.h>/*
+/*
  * Copyright 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -1,4 +1,4 @@
-#include <oboe/Oboe.h>/*
+/*
  * Copyright 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
It seems to be a small mistake.

testAAudio.cpp and testStreamOpen.cpp have dupilicated "#include"