### PR TITLE
OboeTester: refactor RECORD_AUDIO permissions

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         // Also update the versions in the AndroidManifest.xml file.
-        versionCode 53
-        versionName "2.1.3"
+        versionCode 54
+        versionName "2.1.4"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mobileer.oboetester"
-    android:versionCode="53"
-    android:versionName="2.1.3">
+    android:versionCode="54"
+    android:versionName="2.1.4">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
     <uses-feature
         android:name="android.hardware.microphone"

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
@@ -273,17 +273,17 @@ public class AnalyzerActivity extends TestInputActivity {
     public void onRequestPermissionsResult(int requestCode,
                                            String[] permissions,
                                            int[] grantResults) {
-        switch (requestCode) {
-            case MY_PERMISSIONS_REQUEST_EXTERNAL_STORAGE: {
-                // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    writeTestResult(mTestResults);
-                } else {
-                    showToast("Writing external storage needed for test results.");
-                }
-                return;
-            }
+
+        if (MY_PERMISSIONS_REQUEST_EXTERNAL_STORAGE != requestCode) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+        // If request is cancelled, the result arrays are empty.
+        if (grantResults.length > 0
+                && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            writeTestResult(mTestResults);
+        } else {
+            showToast("Writing external storage needed for test results.");
         }
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.oboetester;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.widget.Toast;
+
+/**
+ * Support requesting RECORD_AUDIO permission.
+ */
+
+public abstract class BaseOboeTesterActivity extends Activity
+        implements ActivityCompat.OnRequestPermissionsResultCallback {
+
+    private static final int MY_PERMISSIONS_REQUEST_RECORD_AUDIO = 938355;
+    private Class mTestClass;
+
+    protected void showErrorToast(String message) {
+        showToast("Error: " + message);
+    }
+
+    protected void showToast(final String message) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(BaseOboeTesterActivity.this,
+                        message,
+                        Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private boolean isRecordPermissionGranted() {
+        return (ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
+    }
+
+    private void requestRecordPermission(){
+        ActivityCompat.requestPermissions(
+                this,
+                new String[]{Manifest.permission.RECORD_AUDIO},
+                MY_PERMISSIONS_REQUEST_RECORD_AUDIO);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+
+        if (MY_PERMISSIONS_REQUEST_RECORD_AUDIO != requestCode) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+
+        if (grantResults.length != 1 ||
+                grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+
+            Toast.makeText(getApplicationContext(),
+                    getString(R.string.need_record_audio_permission),
+                    Toast.LENGTH_SHORT)
+                    .show();
+        } else {
+            // Permission was granted
+            beginTestThatRequiresRecording();
+        }
+    }
+
+    /**
+     * Check whether the app has RECORD_AUDIO permission.
+     * If so then call beginTestThatRequiresRecording().
+     * If not then requestpermision and and call beginTestThatRequiresRecording()
+     * when granted.
+     */
+    protected void launchTestThatDoesRecording(Class clazz) {
+        mTestClass = clazz;
+        if (!isRecordPermissionGranted()) {
+            requestRecordPermission();
+        } else {
+            beginTestThatRequiresRecording();
+        }
+    }
+
+    protected void launchTestActivity(Class clazz) {
+        Intent intent = new Intent(this, clazz);
+        startActivity(intent);
+    }
+
+    private void beginTestThatRequiresRecording() {
+        launchTestActivity(mTestClass);
+    }
+}

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
@@ -84,17 +84,14 @@ public abstract class BaseOboeTesterActivity extends Activity
     }
 
     /**
-     * Check whether the app has RECORD_AUDIO permission.
-     * If so then call beginTestThatRequiresRecording().
-     * If not then requestpermision and and call beginTestThatRequiresRecording()
-     * when granted.
+     * If needed, request recording permission before running test.
      */
     protected void launchTestThatDoesRecording(Class clazz) {
         mTestClass = clazz;
-        if (!isRecordPermissionGranted()) {
-            requestRecordPermission();
-        } else {
+        if (isRecordPermissionGranted()) {
             beginTestThatRequiresRecording();
+        } else {
+            requestRecordPermission();
         }
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
@@ -181,18 +181,14 @@ public class EchoActivity extends TestInputActivity {
         mAudioOutTester.reset();
     }
 
-    public void onStartEcho(View view) {
-        try {
-            openAudio();
-            startAudio();
-            setDelayTime(mDelayTime);
-            mStartButton.setEnabled(false);
-            mStopButton.setEnabled(true);
-            keepScreenOn(true);
-            mNativeSniffer.startSniffer();
-        } catch (IOException e) {
-            showErrorToast(e.getMessage());
-        }
+    public void onStartEcho(View view)  throws IOException {
+        openAudio();
+        startAudio();
+        setDelayTime(mDelayTime);
+        mStartButton.setEnabled(false);
+        mStopButton.setEnabled(true);
+        keepScreenOn(true);
+        mNativeSniffer.startSniffer();
     }
 
     public void onStopEcho(View view) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalTapToToneActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalTapToToneActivity.java
@@ -16,7 +16,6 @@ import java.io.IOException;
  */
 public class ExternalTapToToneActivity extends Activity {
     private static final String TAG = "OboeTester";
-    private static final int MY_PERMISSIONS_REQUEST_RECORD_AUDIO = 1235;
 
     protected TapToToneTester mTapToToneTester;
     private Button mStopButton;
@@ -54,16 +53,7 @@ public class ExternalTapToToneActivity extends Activity {
         analyseAndShowResults();
     }
 
-    public void startTest(View view)  throws IOException {
-        if (hasRecordAudioPermission()) {
-            startAudioPermitted();
-        } else {
-            requestRecordAudioPermission();
-            updateButtons(false);
-        }
-    }
-
-    private void startAudioPermitted() {
+    public void startTest(View view)  {
         try {
             mTapToToneTester.resetLatency();
             mTapToToneTester.start();
@@ -102,47 +92,5 @@ public class ExternalTapToToneActivity extends Activity {
         });
     }
 
-    private boolean hasRecordAudioPermission(){
-        boolean hasPermission = (checkSelfPermission(
-                Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
-        Log.i(TAG, "Has RECORD_AUDIO permission? " + hasPermission);
-        return hasPermission;
-    }
-
-    private void requestRecordAudioPermission(){
-
-        String requiredPermission = Manifest.permission.RECORD_AUDIO;
-
-        // If the user previously denied this permission then show a message explaining why
-        // this permission is needed
-        if (shouldShowRequestPermissionRationale(requiredPermission)) {
-            showErrorToast("This app needs to record audio through the microphone....");
-        }
-
-        // request the permission.
-        requestPermissions(new String[]{requiredPermission},
-                MY_PERMISSIONS_REQUEST_RECORD_AUDIO);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode,
-                                           String[] permissions,
-                                           int[] grantResults) {
-
-        if (MY_PERMISSIONS_REQUEST_RECORD_AUDIO != requestCode) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            return;
-        }
-
-        if (grantResults.length != 1 ||
-                grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-            Toast.makeText(getApplicationContext(),
-                    getString(R.string.need_record_audio_permission),
-                    Toast.LENGTH_SHORT)
-                    .show();
-        } else {
-            startAudioPermitted();
-        }
-    }
 
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
@@ -5,7 +5,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.view.View;
 
-public class ExtraTestsActivity extends Activity {
+public class ExtraTestsActivity extends BaseOboeTesterActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -14,15 +14,11 @@ public class ExtraTestsActivity extends Activity {
     }
 
     public void onLaunchMainActivity(View view) {
-        onLaunchTest(MainActivity.class);
+        launchTestActivity(MainActivity.class);
     }
 
     public void onLaunchExternalTapTest(View view) {
-        onLaunchTest(ExternalTapToToneActivity.class);
+        launchTestThatDoesRecording(ExternalTapToToneActivity.class);
     }
 
-    private void onLaunchTest(Class clazz) {
-        Intent intent = new Intent(this, clazz);
-        startActivity(intent);
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -16,7 +16,6 @@
 
 package com.mobileer.oboetester;
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -34,13 +33,12 @@ import android.widget.AdapterView;
 import android.widget.CheckBox;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Select various Audio tests.
  */
 
-public class MainActivity extends Activity {
+public class MainActivity extends BaseOboeTesterActivity {
 
     private static final String KEY_TEST_NAME = "test";
     public static final String VALUE_TEST_NAME_LATENCY = "latency";
@@ -208,49 +206,49 @@ public class MainActivity extends Activity {
     }
 
     public void onLaunchTestOutput(View view) {
-        onLaunchTest(TestOutputActivity.class);
+        launchTestActivity(TestOutputActivity.class);
     }
 
     public void onLaunchTestInput(View view) {
-        onLaunchTest(TestInputActivity.class);
+        launchTestThatDoesRecording(TestInputActivity.class);
     }
 
     public void onLaunchTapToTone(View view) {
-        onLaunchTest(TapToToneActivity.class);
+        launchTestThatDoesRecording(TapToToneActivity.class);
     }
 
     public void onLaunchRecorder(View view) {
-        onLaunchTest(RecorderActivity.class);
+        launchTestThatDoesRecording(RecorderActivity.class);
     }
 
     public void onLaunchEcho(View view) {
-        onLaunchTest(EchoActivity.class);
+        launchTestThatDoesRecording(EchoActivity.class);
     }
 
     public void onLaunchRoundTripLatency(View view) {
-        onLaunchTest(RoundTripLatencyActivity.class);
+        launchTestThatDoesRecording(RoundTripLatencyActivity.class);
     }
 
     public void onLaunchManualGlitchTest(View view) {
-        onLaunchTest(ManualGlitchActivity.class);
+        launchTestThatDoesRecording(ManualGlitchActivity.class);
     }
 
-    public void onLaunchAutoGlitchTest(View view) { onLaunchTest(AutomatedGlitchActivity.class); }
+    public void onLaunchAutoGlitchTest(View view) { launchTestThatDoesRecording(AutomatedGlitchActivity.class); }
 
     public void onLaunchTestDisconnect(View view) {
-        onLaunchTest(TestDisconnectActivity.class);
+        launchTestThatDoesRecording(TestDisconnectActivity.class);
     }
 
     public void onLaunchTestDataPaths(View view) {
-        onLaunchTest(TestDataPathsActivity.class);
+        launchTestThatDoesRecording(TestDataPathsActivity.class);
     }
 
     public void onLaunchTestDeviceReport(View view)  {
-        onLaunchTest(DeviceReportActivity.class);
+        launchTestActivity(DeviceReportActivity.class);
     }
 
     public void onLaunchExtratests(View view) {
-        onLaunchTest(ExtraTestsActivity.class);
+        launchTestActivity(ExtraTestsActivity.class);
     }
 
     private void applyUserOptions() {
@@ -264,30 +262,15 @@ public class MainActivity extends Activity {
         TestAudioActivity.setBackgroundEnabled(mBackgroundCheckBox.isChecked());
     }
 
-    private void onLaunchTest(Class clazz) {
+    @Override
+    protected void launchTestActivity(Class clazz) {
         applyUserOptions();
-        Intent intent = new Intent(this, clazz);
-        startActivity(intent);
+        super.launchTestActivity(clazz);
     }
 
     public void onUseCallbackClicked(View view) {
         CheckBox checkBox = (CheckBox) view;
         OboeAudioStream.setUseCallback(checkBox.isChecked());
-    }
-
-    protected void showErrorToast(String message) {
-        showToast("Error: " + message);
-    }
-
-    protected void showToast(final String message) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                Toast.makeText(MainActivity.this,
-                        message,
-                        Toast.LENGTH_SHORT).show();
-            }
-        });
     }
 
     private void updateCallbackSize() {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RecorderActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RecorderActivity.java
@@ -58,16 +58,12 @@ public class RecorderActivity extends TestInputActivity {
         return ACTIVITY_RECORD_PLAY;
     }
 
-    public void onStartRecording(View view) {
-        try {
-            openAudio();
-            startAudio();
-            mRecorderState = STATE_RECORDING;
-            mGotRecording = true;
-            updateButtons();
-        } catch (IOException e) {
-            showErrorToast(e.getMessage());
-        }
+    public void onStartRecording(View view) throws IOException {
+        openAudio();
+        startAudio();
+        mRecorderState = STATE_RECORDING;
+        mGotRecording = true;
+        updateButtons();
     }
 
     public void onStopRecordPlay(View view) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
@@ -53,6 +53,7 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
     private Bundle  mBundleFromIntent;
     private int     mBufferBursts = -1;
     private Handler mHandler = new Handler(Looper.getMainLooper()); // UI thread
+    private boolean mMeasureAverage;
 
     // Run the test several times and report the acverage latency.
     protected class LatencyAverager {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TapToToneActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TapToToneActivity.java
@@ -46,7 +46,6 @@ public class TapToToneActivity extends TestOutputActivityBase {
     public static final String OLD_PRODUCT_NAME = "AudioLatencyTester";
     public static final String OLD_MANUFACTURER_NAME = "AndroidTest";
 
-    private static final int MY_PERMISSIONS_REQUEST_RECORD_AUDIO = 1234;
     private MidiManager mMidiManager;
     private MidiInputPort mInputPort;
 
@@ -272,48 +271,6 @@ public class TapToToneActivity extends TestOutputActivityBase {
         return super.onOptionsItemSelected(item);
     }
 
-    private boolean hasRecordAudioPermission(){
-        boolean hasPermission = (checkSelfPermission(
-                Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
-        Log.i(TAG, "Has RECORD_AUDIO permission? " + hasPermission);
-        return hasPermission;
-    }
-
-    private void requestRecordAudioPermission(){
-
-        String requiredPermission = Manifest.permission.RECORD_AUDIO;
-
-        // If the user previously denied this permission then show a message explaining why
-        // this permission is needed
-        if (shouldShowRequestPermissionRationale(requiredPermission)) {
-            showErrorToast("This app needs to record audio through the microphone....");
-        }
-
-        // request the permission.
-        requestPermissions(new String[]{requiredPermission},
-                MY_PERMISSIONS_REQUEST_RECORD_AUDIO);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode,
-                                           String[] permissions,
-                                           int[] grantResults) {
-        if (MY_PERMISSIONS_REQUEST_RECORD_AUDIO != requestCode) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            return;
-        }
-
-        if (grantResults.length != 1 ||
-                grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-            Toast.makeText(getApplicationContext(),
-                    getString(R.string.need_record_audio_permission),
-                    Toast.LENGTH_SHORT)
-                    .show();
-        } else {
-            startAudioPermitted();
-        }
-    }
-
     public void startTest(View view) {
         try {
             openAudio();
@@ -322,14 +279,6 @@ public class TapToToneActivity extends TestOutputActivityBase {
             showErrorToast("Open audio failed!");
             return;
         }
-        if (hasRecordAudioPermission()) {
-            startAudioPermitted();
-        } else {
-            requestRecordAudioPermission();
-        }
-    }
-
-    private void startAudioPermitted() {
         try {
             super.startAudio();
             mTapToToneTester.resetLatency();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
@@ -38,10 +38,8 @@ import java.io.IOException;
  * Test Oboe Capture
  */
 
-public class TestInputActivity  extends TestAudioActivity
-        implements ActivityCompat.OnRequestPermissionsResultCallback {
+public class TestInputActivity  extends TestAudioActivity {
 
-    private static final int MY_PERMISSIONS_REQUEST_RECORD_AUDIO = 9371;
     protected AudioInputTester mAudioInputTester;
     private static final int NUM_VOLUME_BARS = 4;
     private VolumeBarView[] mVolumeBars = new VolumeBarView[NUM_VOLUME_BARS];
@@ -122,11 +120,16 @@ public class TestInputActivity  extends TestAudioActivity
     }
 
     @Override
-    public void openAudio() throws IOException {
-        if (!isRecordPermissionGranted()){
-            requestRecordPermission();
-            return;
+    public void openAudio(View view) {
+        try {
+            openAudio();
+        } catch (Exception e) {
+            showErrorToast(e.getMessage());
         }
+    }
+
+    @Override
+    public void openAudio() throws IOException {
         super.openAudio();
         setMinimumBurstsBeforeRead(mInputMarginBursts);
         resetVolumeBars();
@@ -143,43 +146,6 @@ public class TestInputActivity  extends TestAudioActivity
         showToast("Pause not implemented. Returned " + result);
     }
 
-    private boolean isRecordPermissionGranted() {
-        return (ActivityCompat.checkSelfPermission(this,
-                Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
-    }
-
-    private void requestRecordPermission(){
-        ActivityCompat.requestPermissions(
-                this,
-                new String[]{Manifest.permission.RECORD_AUDIO},
-                MY_PERMISSIONS_REQUEST_RECORD_AUDIO);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-
-        if (MY_PERMISSIONS_REQUEST_RECORD_AUDIO != requestCode) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            return;
-        }
-
-        if (grantResults.length != 1 ||
-                grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-
-            Toast.makeText(getApplicationContext(),
-                    getString(R.string.need_record_audio_permission),
-                    Toast.LENGTH_SHORT)
-                    .show();
-        } else {
-            // Permission was granted
-            try {
-                super.openAudio();
-            } catch (IOException e) {
-                showErrorToast(e.getMessage());
-            }
-        }
-    }
 
     public void setupAGC(int sessionId) {
         AutomaticGainControl effect =  AutomaticGainControl.create(sessionId);


### PR DESCRIPTION
Now we ask for permission in the main Activity when
the test is launched.  That allows us to keep the code in one place
but also only ask for permission when we need to record.

Fixes #1364