### PR TITLE
OboeTester: fix closest test search

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         // Also update the versions in the AndroidManifest.xml file.
-        versionCode 55
-        versionName "2.2.0"
+        versionCode 56
+        versionName "2.2.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mobileer.oboetester"
-    android:versionCode="55"
-    android:versionName="2.2.0">
+    android:versionCode="56"
+    android:versionName="2.2.1">
     <!-- versionCode and versionName also have to be updated in build.gradle -->
     <uses-feature
         android:name="android.hardware.microphone"

--- a/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
@@ -88,7 +88,7 @@ public class AudioDeviceInfoConverter {
      *             e.g. AudioDeviceInfo.TYPE_BUILT_IN_SPEAKER
      * @return string which describes the type of audio device
      */
-    static String typeToString(int type){
+    public static String typeToString(int type){
         switch (type) {
             case AudioDeviceInfo.TYPE_AUX_LINE:
                 return "auxiliary line-level connectors";

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
@@ -94,7 +94,7 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
     @Override
     public void runTest() {
         try {
-            logExtraInfo();
+            logDeviceInfo();
 
             mTestResults.clear();
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import java.text.DateFormat;
@@ -27,6 +28,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
     private Button       mStopButton;
     private Button       mShareButton;
     private TextView     mAutoTextView;
+    private ScrollView   mAutoTextScroller;
     private TextView     mSingleTestIndex;
     private StringBuffer mFailedSummary;
     private StringBuffer mSummary;
@@ -104,8 +106,8 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
 
         mSingleTestIndex = (TextView) findViewById(R.id.single_test_index);
 
-        mAutoTextView = (TextView) findViewById(R.id.text_log);
-        mAutoTextView.setMovementMethod(new ScrollingMovementMethod());
+        mAutoTextScroller = (ScrollView) findViewById(R.id.text_log_auto_scroller);
+        mAutoTextView = (TextView) findViewById(R.id.text_log_auto);
     }
 
     private void updateStartStopButtons(boolean running) {
@@ -124,6 +126,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
     public void appendFailedSummary(String text) {
         mFailedSummary.append(text);
     }
+
     public void appendSummary(String text) {
         mSummary.append(text);
     }
@@ -143,11 +146,17 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         if (text == null) return;
         Log.d(TestAudioActivity.TAG, "LOG - " + text);
         mCachedTextView.append(text + "\n");
+        scrollToBottom();
+    }
+
+    public void scrollToBottom() {
+        mAutoTextScroller.fullScroll(View.FOCUS_DOWN);
     }
 
     // Flush any logs that are stuck in the cache.
     public void flushLog() {
         mCachedTextView.flush();
+        scrollToBottom();
     }
 
     private void logClear() {
@@ -278,6 +287,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
                 @Override
                 public void run() {
                     onTestFinished();
+                    scrollToBottom();
                 }
             });
         }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -26,6 +26,8 @@ import android.media.MicrophoneInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.method.ScrollingMovementMethod;
+import android.view.View;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.mobileer.audio_device.AudioDeviceInfoConverter;
@@ -69,9 +71,7 @@ public class DeviceReportActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_device_report);
-        mAutoTextView = (TextView) findViewById(R.id.text_log);
-        mAutoTextView.setMovementMethod(new ScrollingMovementMethod());
-
+        mAutoTextView = (TextView) findViewById(R.id.text_log_device_report);
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -272,6 +272,8 @@ public class GlitchActivity extends AnalyzerActivity {
     @Override
     protected void onStart() {
         super.onStart();
+        setInputChannel(0);
+        setOutputChannel(0);
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -10,12 +10,39 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.mobileer.oboetester.TestDataPathsActivity">
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/checkbox_paths_input_presets"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="InPre" />
+
+        <CheckBox
+            android:id="@+id/checkbox_paths_input_devices"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="InDev" />
+
+        <CheckBox
+            android:id="@+id/checkbox_paths_output_devices"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="OutDev" />
+    </LinearLayout>
+
     <TextView
         android:id="@+id/text_instructions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:lines="1"
-        android:text="@string/test_disconnect_instructions"
+        android:lines="2"
+        android:text="@string/test_datapath_instructions"
         android:textColor="#F44336"
         android:textSize="18sp"
         android:textStyle="bold" />

--- a/apps/OboeTester/app/src/main/res/layout/activity_device_report.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_device_report.xml
@@ -10,8 +10,12 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.mobileer.oboetester.DeviceReportActivity">
 
+    <ScrollView
+        android:id="@+id/text_log_device_scroller"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
     <TextView
-        android:id="@+id/text_log"
+        android:id="@+id/text_log_device_report"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fontFamily="monospace"
@@ -19,5 +23,6 @@
         android:scrollbars="vertical"
         android:text="@string/device_report"
         />
+    </ScrollView>
 
 </LinearLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
@@ -14,7 +14,7 @@
         android:id="@+id/text_instructions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:lines="1"
+        android:lines="2"
         android:text="@string/test_disconnect_instructions"
         android:textColor="#F44336"
         android:textSize="18sp"

--- a/apps/OboeTester/app/src/main/res/layout/auto_test_runner.xml
+++ b/apps/OboeTester/app/src/main/res/layout/auto_test_runner.xml
@@ -63,14 +63,18 @@
         android:textSize="18sp"
         android:textStyle="bold"
         />
-
+    <ScrollView
+        android:id="@+id/text_log_auto_scroller"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
     <TextView
-        android:id="@+id/text_log"
+        android:id="@+id/text_log_auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars = "vertical"
         android:gravity="bottom"
         android:text="@string/log_of_test_results"
         />
+    </ScrollView>
 
 </LinearLayout>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -186,7 +186,8 @@
     <string name="average">Average</string>
     <string name="failTest">Fail</string>
     <string name="skipTest">Skip</string>
-    <string name="test_disconnect_instructions">Unplug headsets, volume up, [START]</string>
+    <string name="test_datapath_instructions">Disconnect all headsets.\nIn quiet room, volume up, [START]</string>
+    <string name="test_disconnect_instructions">Disconnect all headsets.\nPress [START]</string>
     <string name="title_external_tap">External Tap To Tone</string>
     <string name="analyze">Analyze</string>
 


### PR DESCRIPTION
Search loop was not updating minDifferences.
Now show all tests at seme level of closeness.
Add checkboxes for data path subtests.
Improve instructions for DISCONNECT and DATA PATHS.
Reenable VoiceCommunication tests.
Fix GLITCH test after DATA PATHs. Mono was broken because
the outputChannel was left at 1.
Add Inertial scrolling of test results.

Bump OboeTester to 2.2.1

Fixes #1371