### PR TITLE
OboeTester: improve data paths test, fix capacity glitches

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -568,15 +568,15 @@ void ActivityTapToTone::configureForStart() {
     configureStreamGateway();
 }
 
-// ======================================================================= ActivityRoundTripLatency
+// ======================================================================= ActivityFullDuplex
 void ActivityFullDuplex::configureBuilder(bool isInput, oboe::AudioStreamBuilder &builder) {
     if (isInput) {
         // Ideally the output streams should be opened first.
         std::shared_ptr<oboe::AudioStream> outputStream = getOutputStream();
         if (outputStream != nullptr) {
-            // Make sure the capacity is bigger than two bursts.
-            int32_t burst = outputStream->getFramesPerBurst();
-            builder.setBufferCapacityInFrames(2 * burst);
+            // The input and output buffers will run in sync with input empty
+            // and output full. So set the input capacity to match the output.
+            builder.setBufferCapacityInFrames(outputStream->getBufferCapacityInFrames());
         }
     }
 }

--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -105,7 +105,7 @@ public:
             float sinOut = sinf(mOutputPhase);
             incrementOutputPhase();
             output = (sinOut * mOutputAmplitude)
-                     + (mWhiteNoise.nextRandomDouble() * mNoiseAmplitude);
+                     + (mWhiteNoise.nextRandomDouble() * getNoiseAmplitude());
             // ALOGD("sin(%f) = %f, %f\n", mOutputPhase, sinOut,  mPhaseIncrement);
         }
         for (int i = 0; i < channelCount; i++) {
@@ -135,6 +135,13 @@ public:
         return magnitude;
     }
 
+    /**
+     * Perform sin/cos analysis on each sample.
+     * Measure magnitude and phase on every period.
+     * @param sample
+     * @param referencePhase
+     * @return true if magnitude and phase updated
+     */
     bool transformSample(float sample, float referencePhase) {
         // Track incoming signal and slowly adjust magnitude to account
         // for drift in the DRC or AGC.
@@ -163,6 +170,7 @@ public:
     void reset() override {
         LoopbackProcessor::reset();
         resetAccumulator();
+        mMagnitude = 0.0;
     }
 
     void prepareToTest() override {

--- a/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
@@ -38,7 +38,7 @@ public:
 
     DataPathAnalyzer() : BaseSineAnalyzer() {
         // Add a little bit of noise to reduce blockage by speaker protection and DRC.
-        setNoiseAmplitude(0.05);
+        setNoiseAmplitude(0.02);
     }
 
     /**
@@ -53,14 +53,13 @@ public:
 
         if (transformSample(sample, mOutputPhase)) {
             resetAccumulator();
+            // Analyze magnitude and phase on every period.
+            double diff = abs(mPhaseOffset - mPreviousPhaseOffset);
+            if (diff < mPhaseTolerance) {
+                mMaxMagnitude = std::max(mMagnitude, mMaxMagnitude);
+            }
+            mPreviousPhaseOffset = mPhaseOffset;
         }
-
-        // Update MaxMagnitude if we are locked.
-        double diff = abs(mPhaseOffset - mPreviousPhaseOffset);
-        if (diff < mPhaseTolerance) {
-            mMaxMagnitude = std::max(mMagnitude, mMaxMagnitude);
-        }
-        mPreviousPhaseOffset = mPhaseOffset;
         return result;
     }
 

--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -145,6 +145,7 @@ public:
                     mDownCounter = IMMUNE_FRAME_COUNT;
                     mInputPhase = 0.0; // prevent spike at start
                     mOutputPhase = 0.0;
+                    resetAccumulator();
                 }
                 break;
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -287,7 +287,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
                 @Override
                 public void run() {
                     onTestFinished();
-                    scrollToBottom();
+                    flushLog();
                 }
             });
         }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -217,6 +217,13 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
                 + ", ch = " + channelText(channel, config.getChannelCount());
     }
 
+    protected String getStreamText(AudioStreamBase stream) {
+        return ("burst=" + stream.getFramesPerBurst()
+                + ", size=" + stream.getBufferSizeInFrames()
+                + ", cap=" + stream.getBufferCapacityInFrames()
+        );
+    }
+
     public final static int TEST_RESULT_FAILED = -2;
     public final static int TEST_RESULT_WARNING = -1;
     public final static int TEST_RESULT_SKIPPED = 0;
@@ -248,12 +255,15 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         try {
             openAudio(); // this will fill in actualConfig
             log("Actual:");
-            log("  " + getConfigText(actualInConfig));
-            log("  " + getConfigText(actualOutConfig));
             // Set output size to a level that will avoid glitches.
-            AudioStreamBase stream = mAudioOutTester.getCurrentAudioStream();
-            int sizeFrames = stream.getBufferCapacityInFrames() / 2;
-            stream.setBufferSizeInFrames(sizeFrames);
+            AudioStreamBase outStream = mAudioOutTester.getCurrentAudioStream();
+            int sizeFrames = outStream.getBufferCapacityInFrames() / 2;
+            outStream.setBufferSizeInFrames(sizeFrames);
+            AudioStreamBase inStream = mAudioInputTester.getCurrentAudioStream();
+            log("  " + getConfigText(actualInConfig));
+            log("      " + getStreamText(inStream));
+            log("  " + getConfigText(actualOutConfig));
+            log("      " + getStreamText(outStream));
         } catch (Exception e) {
             openFailed = true;
             log(e.getMessage());

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -140,6 +140,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                     + ", max = " + getMagnitudeText(mMaxMagnitude)
                     + "\nphase = " + getMagnitudeText(mPhase)
                     + ", jitter = " + getMagnitudeText(mPhaseJitter)
+                    + ", #" + mPhaseCount
                     + "\n");
             return message.toString();
         }
@@ -209,12 +210,16 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         StreamConfiguration requestedOutConfig = mAudioOutTester.requestedConfiguration;
         StreamConfiguration actualInConfig = mAudioInputTester.actualConfiguration;
         StreamConfiguration actualOutConfig = mAudioOutTester.actualConfiguration;
-        // No point running the test if we don't get the sharing mode we requested.
-        if (actualInConfig.isMMap() != requestedInConfig.isMMap()
-                || actualOutConfig.isMMap() != requestedOutConfig.isMMap()) {
-            log("Did not get requested MMap stream");
+        // No point running the test if we don't get the data path we requested.
+        if (actualInConfig.isMMap() != requestedInConfig.isMMap()) {
+            log("Did not get requested MMap input stream");
             why += "mmap";
-        }        // Did we request a device and not get that device?
+        }
+        if (actualOutConfig.isMMap() != requestedOutConfig.isMMap()) {
+            log("Did not get requested MMap output stream");
+            why += "mmap";
+        }
+        // Did we request a device and not get that device?
         if (requestedInConfig.getDeviceId() != 0
                 && (requestedInConfig.getDeviceId() != actualInConfig.getDeviceId())) {
             why += ", inDev(" + requestedInConfig.getDeviceId()
@@ -328,12 +333,10 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                     + "\n";
             appendSummary(summary);
             if (result == TEST_RESULT_FAILED) {
-                if (inputPreset == StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION) {
-                    if (getMagnitude() < 0.000001) {
-                        testResult.addComment("Maybe VoiceComm path is dead!");
-                    } else {
-                        testResult.addComment("Maybe sine wave blocked by Echo Cancellation!");
-                    }
+                if (getMagnitude() < 0.000001) {
+                    testResult.addComment("The input is completely SILENT!");
+                } else if (inputPreset == StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION) {
+                    testResult.addComment("Maybe sine wave blocked by Echo Cancellation!");
                 }
             }
         }

--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -129,9 +129,16 @@ private:
             return 0;
         }
 
+        AAudioLoader *libLoader = AAudioLoader::getInstance();
+        int openResult = libLoader->open();
+        if (openResult != 0) {
+            LOGD("%s() could not open " LIB_AAUDIO_NAME, __func__);
+            return AAUDIO_ERROR_UNAVAILABLE;
+        }
+
         void *libHandle = AAudioLoader::getInstance()->getLibHandle();
         if (libHandle == nullptr) {
-            LOGI("%s() could not find " LIB_AAUDIO_NAME, __func__);
+            LOGE("%s() could not find " LIB_AAUDIO_NAME, __func__);
             return AAUDIO_ERROR_UNAVAILABLE;
         }
 


### PR DESCRIPTION
Fix not setting MMAP policy on first test.
Fix glitches caused by input buffer capacity too small.
Reset magnitude at test beginning so silence can be detected.
Display phase measurement count.
Reduce noise signal.