### PR TITLE
Quirk: disable MMAP on SDM8150

### DIFF
--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -63,15 +63,12 @@ bool QuirksManager::DeviceQuirks::isAAudioMMapPossible(const AudioStreamBuilder 
 }
 
 /**
- * This is mostly for Exynos quirks. Samsung Mobile uses Qualcomm chips so
+ * This is for Samsung Exynos quirks. Samsung Mobile uses Qualcomm chips so
  * the QualcommDeviceQuirks would apply.
  */
-class SamsungDeviceQuirks : public  QuirksManager::DeviceQuirks {
+class SamsungExynosDeviceQuirks : public  QuirksManager::DeviceQuirks {
 public:
-    SamsungDeviceQuirks() {
-        std::string arch = getPropertyString("ro.arch");
-        isExynos = (arch.rfind("exynos", 0) == 0); // starts with?
-
+    SamsungExynosDeviceQuirks() {
         std::string chipname = getPropertyString("ro.hardware.chipname");
         isExynos9810 = (chipname == "exynos9810");
         isExynos990 = (chipname == "exynos990");
@@ -80,11 +77,10 @@ public:
         mBuildChangelist = getPropertyInteger("ro.build.changelist", 0);
     }
 
-    virtual ~SamsungDeviceQuirks() = default;
+    virtual ~SamsungExynosDeviceQuirks() = default;
 
     int32_t getExclusiveBottomMarginInBursts() const override {
-        // TODO Make this conditional on build version when MMAP timing improves.
-        return isExynos ? kBottomMarginExynos : kBottomMarginOther;
+        return kBottomMargin;
     }
 
     int32_t getExclusiveTopMarginInBursts() const override {
@@ -129,10 +125,8 @@ public:
 
 private:
     // Stay farther away from DSP position on Exynos devices.
-    static constexpr int32_t kBottomMarginExynos = 2;
-    static constexpr int32_t kBottomMarginOther = 1;
+    static constexpr int32_t kBottomMargin = 2;
     static constexpr int32_t kTopMargin = 1;
-    bool isExynos = false;
     bool isExynos9810 = false;
     bool isExynos990 = false;
     bool isExynos850 = false;
@@ -148,29 +142,40 @@ public:
 
     virtual ~QualcommDeviceQuirks() = default;
 
+    int32_t getExclusiveBottomMarginInBursts() const override {
+        return kBottomMargin;
+    }
+
     bool isMMapSafe(const AudioStreamBuilder &builder) override {
         // See https://github.com/google/oboe/issues/1121#issuecomment-897957749
-        bool mmapBroken = false;
+        bool isMMapBroken = false;
         if (isSM8150 && (getSdkVersion() <= __ANDROID_API_P__)) {
             LOGI("QuirksManager::%s() MMAP not actually supported on this chip."
                  " Switching off MMAP.", __func__);
-            mmapBroken = true;
+            isMMapBroken = true;
         }
 
-        return !mmapBroken;
+        return !isMMapBroken;
     }
 
 private:
     bool isSM8150 = false;
+    static constexpr int32_t kBottomMargin = 1;
 };
 
 QuirksManager::QuirksManager() {
     std::string productManufacturer = getPropertyString("ro.product.manufacturer");
     if (productManufacturer == "samsung") {
-        mDeviceQuirks = std::make_unique<SamsungDeviceQuirks>();
-    } else {
+        std::string arch = getPropertyString("ro.arch");
+        bool isExynos = (arch.rfind("exynos", 0) == 0); // starts with?
+        if (isExynos) {
+            mDeviceQuirks = std::make_unique<SamsungExynosDeviceQuirks>();
+        }
+    }
+    if (!mDeviceQuirks) {
         std::string socManufacturer = getPropertyString("ro.soc.manufacturer");
         if (socManufacturer == "Qualcomm") {
+            // This may include Samsung Mobile devices.
             mDeviceQuirks = std::make_unique<QualcommDeviceQuirks>();
         } else {
             mDeviceQuirks = std::make_unique<DeviceQuirks>();


### PR DESCRIPTION
MMAP not supported before Q.
But some phones tried to use it.

Fixes #1121