### PR TITLE
Fix permission issues for test glitches

### DIFF
--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
The automatic glitch test runs fine until it tries to save the results. At that point, a toast shows up mentioning how there is a lack of permissions to save the results. The error message is similar to that mentioned here: https://stackoverflow.com/questions/61406818/filenotfoundexception-open-failed-eperm-operation-not-permitted-during-saving

The fix is to add android:requestLegacyExternalStorage="true" into the app manifest