### PR TITLE
(OboeTester) Create automatic data paths tests

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -32,6 +32,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
     private TextView     mSingleTestIndex;
     private StringBuffer mFailedSummary;
     private StringBuffer mSummary;
+    private StringBuffer mFullSummary;
     private int          mTestCount;
     private int          mPassCount;
     private int          mFailCount;
@@ -108,6 +109,10 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
 
         mAutoTextScroller = (ScrollView) findViewById(R.id.text_log_auto_scroller);
         mAutoTextView = (TextView) findViewById(R.id.text_log_auto);
+
+        mFailedSummary = new StringBuffer();
+        mSummary = new StringBuffer();
+        mFullSummary = new StringBuffer();
     }
 
     private void updateStartStopButtons(boolean running) {
@@ -146,6 +151,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         if (text == null) return;
         Log.d(TestAudioActivity.TAG, "LOG - " + text);
         mCachedTextView.append(text + "\n");
+        mFullSummary.append(text + "\n");
         scrollToBottom();
     }
 
@@ -161,6 +167,17 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
 
     private void logClear() {
         mCachedTextView.clear();
+        mFullSummary.delete(0, mFullSummary.length());
+        mSummary.delete(0, mSummary.length());
+        mFailedSummary.delete(0, mFailedSummary.length());
+    }
+
+    public String getFullLogs() {
+        return mFullSummary.toString();
+    }
+
+    public void clickStartButton() {
+        mStartButton.callOnClick();
     }
 
     private void startAutoThread() {
@@ -248,8 +265,6 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         log(MainActivity.getVersiontext());
         log(Build.MANUFACTURER + ", " + Build.MODEL + ", " + Build.PRODUCT);
         log(Build.DISPLAY);
-        mFailedSummary = new StringBuffer();
-        mSummary = new StringBuffer();
         appendFailedSummary("Summary\n");
         mTestCount = 0;
         mPassCount = 0;

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -172,12 +172,8 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         mFailedSummary.delete(0, mFailedSummary.length());
     }
 
-    public String getFullLogs() {
+    protected String getFullLogs() {
         return mFullSummary.toString();
-    }
-
-    public void clickStartButton() {
-        mStartButton.callOnClick();
     }
 
     private void startAutoThread() {
@@ -198,6 +194,14 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
             }
         } catch (InterruptedException e) {
             e.printStackTrace();
+        }
+    }
+
+    protected void setTestIndexText(int newTestIndex) {
+        if (newTestIndex >= 0) {
+            mSingleTestIndex.setText(String.valueOf(newTestIndex));
+        } else {
+            mSingleTestIndex.setText("");
         }
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -43,6 +43,7 @@ public class MainActivity extends BaseOboeTesterActivity {
     private static final String KEY_TEST_NAME = "test";
     public static final String VALUE_TEST_NAME_LATENCY = "latency";
     public static final String VALUE_TEST_NAME_GLITCH = "glitch";
+    public static final String VALUE_TEST_NAME_DATA_PATHS = "data_paths";
 
     static {
         // Must match name in CMakeLists.txt
@@ -176,6 +177,10 @@ public class MainActivity extends BaseOboeTesterActivity {
                 startActivity(intent);
             } else if (VALUE_TEST_NAME_GLITCH.equals(testName)) {
                 Intent intent = new Intent(this, ManualGlitchActivity.class);
+                intent.putExtras(mBundleFromIntent);
+                startActivity(intent);
+            } else if (VALUE_TEST_NAME_DATA_PATHS.equals(testName)) {
+                Intent intent = new Intent(this, TestDataPathsActivity.class);
                 intent.putExtras(mBundleFromIntent);
                 startActivity(intent);
             }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -16,17 +16,22 @@
 
 package com.mobileer.oboetester;
 
+import android.content.Intent;
 import android.app.Activity;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
 import com.mobileer.audio_device.AudioDeviceInfoConverter;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 
 /**
@@ -44,6 +49,15 @@ import java.lang.reflect.Field;
  * This test requires a quiet room but no other hardware.
  */
 public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
+
+    public static final String KEY_USE_INPUT_PRESETS = "use_input_presets";
+    public static final boolean VALUE_DEFAULT_USE_INPUT_PRESETS = true;
+
+    public static final String KEY_USE_INPUT_DEVICES = "use_input_devices";
+    public static final boolean VALUE_DEFAULT_USE_INPUT_DEVICES = true;
+
+    public static final String KEY_USE_OUTPUT_DEVICES = "use_output_devices";
+    public static final boolean VALUE_DEFAULT_USE_OUTPUT_DEVICES = true;
 
     public static final int DURATION_SECONDS = 3;
     private final static double MIN_REQUIRED_MAGNITUDE = 0.001;
@@ -70,6 +84,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     private CheckBox mCheckBoxInputPresets;
     private CheckBox mCheckBoxInputDevices;
     private CheckBox mCheckBoxOutputDevices;
+
+    private boolean mTestRunningByIntent;
+    private Bundle mBundleFromIntent;
 
     private static final int[] INPUT_PRESETS = {
             // VOICE_RECOGNITION gets tested in testInputs()
@@ -154,7 +171,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         @Override
         public void updateStatusText() {
             mLastGlitchReport = getCurrentStatusReport();
-            setAnalyzerText(mLastGlitchReport);
+            runOnUiThread(() -> {
+                setAnalyzerText(mLastGlitchReport);
+            });
         }
     }
 
@@ -175,12 +194,48 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mBundleFromIntent = getIntent().getExtras();
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         mCheckBoxInputPresets = (CheckBox)findViewById(R.id.checkbox_paths_input_presets);
         mCheckBoxInputDevices = (CheckBox)findViewById(R.id.checkbox_paths_input_devices);
         mCheckBoxOutputDevices = (CheckBox)findViewById(R.id.checkbox_paths_output_devices);
     }
 
+    @Override
+    public void onResume(){
+        super.onResume();
+        processBundleFromIntent();
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        mBundleFromIntent = intent.getExtras();
+    }
+
+    private void processBundleFromIntent() {
+        if (mBundleFromIntent == null) {
+            return;
+        }
+        if (mTestRunningByIntent) {
+            return;
+        }
+
+        mResultFileName = null;
+        if (mBundleFromIntent.containsKey(KEY_FILE_NAME)) {
+            mTestRunningByIntent = true;
+            mResultFileName = mBundleFromIntent.getString(KEY_FILE_NAME);
+
+            // Delay the test start to avoid race conditions.
+            Handler handler = new Handler(Looper.getMainLooper()); // UI thread
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    startAutomaticTest();
+                }
+            }, 500); // TODO where is the race, close->open?
+
+        }
+    }
     @Override
     public String getTestName() {
         return "DataPaths";
@@ -316,7 +371,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                          int outputChannel,
                          boolean mmapEnabled
                    ) throws InterruptedException {
-
         setupDeviceCombo(numInputChannels, inputChannel, numOutputChannels, outputChannel);
 
         StreamConfiguration requestedInConfig = mAudioInputTester.requestedConfiguration;
@@ -553,27 +607,43 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             log("max.allowed.jitter = " + MAX_ALLOWED_JITTER);
             log("test.gap.msec = " + mGapMillis);
 
+            runOnUiThread(() -> {
+                mCheckBoxInputPresets.setEnabled(false);
+                mCheckBoxInputDevices.setEnabled(false);
+                mCheckBoxOutputDevices.setEnabled(false);
+            });
+
             mTestResults.clear();
             mDurationSeconds = DURATION_SECONDS;
 
             if (mCheckBoxInputPresets.isChecked()) {
-                runOnUiThread(() -> mCheckBoxInputPresets.setEnabled(false));
                 testInputPresets();
             }
             if (mCheckBoxInputDevices.isChecked()) {
-                runOnUiThread(() -> mCheckBoxInputDevices.setEnabled(false));
                 testInputDevices();
             }
             if (mCheckBoxOutputDevices.isChecked()) {
-                runOnUiThread(() -> mCheckBoxOutputDevices.setEnabled(false));
                 testOutputDevices();
             }
 
             analyzeTestResults();
 
+            if (mTestRunningByIntent) {
+                String report = mAutomatedTestRunner.getFullLogs();
+                maybeWriteTestResult(report);
+                mTestRunningByIntent = false;
+                mBundleFromIntent = null;
+            }
+
         } catch (InterruptedException e) {
             analyzeTestResults();
 
+            if (mTestRunningByIntent) {
+                String report = mAutomatedTestRunner.getFullLogs();
+                maybeWriteTestResult(report);
+                mTestRunningByIntent = false;
+                mBundleFromIntent = null;
+            }
         } catch (Exception e) {
             log(e.getMessage());
             showErrorToast(e.getMessage());
@@ -586,5 +656,22 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         }
     }
 
+    void startAutomaticTest() {
+        configureStreamsFromBundle(mBundleFromIntent);
 
+        boolean shouldUseInputPresets = mBundleFromIntent.getBoolean(KEY_USE_INPUT_PRESETS,
+                VALUE_DEFAULT_USE_INPUT_PRESETS);
+        boolean shouldUseInputDevices = mBundleFromIntent.getBoolean(KEY_USE_INPUT_DEVICES,
+                VALUE_DEFAULT_USE_INPUT_DEVICES);
+        boolean shouldUseOutputDevices = mBundleFromIntent.getBoolean(KEY_USE_OUTPUT_DEVICES,
+                VALUE_DEFAULT_USE_OUTPUT_DEVICES);
+
+        runOnUiThread(() -> {
+            mCheckBoxInputPresets.setChecked(shouldUseInputPresets);
+            mCheckBoxInputDevices.setChecked(shouldUseInputDevices);
+            mCheckBoxOutputDevices.setChecked(shouldUseOutputDevices);
+        });
+
+        mAutomatedTestRunner.startTest();
+    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -609,23 +609,20 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             log("min.required.magnitude = " + MIN_REQUIRED_MAGNITUDE);
             log("max.allowed.jitter = " + MAX_ALLOWED_JITTER);
             log("test.gap.msec = " + mGapMillis);
-
-            runOnUiThread(() -> {
-                mCheckBoxInputPresets.setEnabled(false);
-                mCheckBoxInputDevices.setEnabled(false);
-                mCheckBoxOutputDevices.setEnabled(false);
-            });
-
+            
             mTestResults.clear();
             mDurationSeconds = DURATION_SECONDS;
 
             if (mCheckBoxInputPresets.isChecked()) {
+                runOnUiThread(() -> mCheckBoxInputPresets.setEnabled(false));
                 testInputPresets();
             }
             if (mCheckBoxInputDevices.isChecked()) {
+                runOnUiThread(() -> mCheckBoxInputDevices.setEnabled(false));
                 testInputDevices();
             }
             if (mCheckBoxOutputDevices.isChecked()) {
+                runOnUiThread(() -> mCheckBoxOutputDevices.setEnabled(false));
                 testOutputDevices();
             }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -59,6 +59,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     public static final String KEY_USE_OUTPUT_DEVICES = "use_output_devices";
     public static final boolean VALUE_DEFAULT_USE_OUTPUT_DEVICES = true;
 
+    public static final String KEY_SINGLE_TEST_INDEX = "single_test_index";
+    public static final int VALUE_DEFAULT_SINGLE_TEST_INDEX = -1;
+
     public static final int DURATION_SECONDS = 3;
     private final static double MIN_REQUIRED_MAGNITUDE = 0.001;
     private final static double MAX_SINE_FREQUENCY = 1000.0;
@@ -665,11 +668,14 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 VALUE_DEFAULT_USE_INPUT_DEVICES);
         boolean shouldUseOutputDevices = mBundleFromIntent.getBoolean(KEY_USE_OUTPUT_DEVICES,
                 VALUE_DEFAULT_USE_OUTPUT_DEVICES);
+        int singleTestIndex = mBundleFromIntent.getInt(KEY_SINGLE_TEST_INDEX,
+                VALUE_DEFAULT_SINGLE_TEST_INDEX);
 
         runOnUiThread(() -> {
             mCheckBoxInputPresets.setChecked(shouldUseInputPresets);
             mCheckBoxInputDevices.setChecked(shouldUseInputDevices);
             mCheckBoxOutputDevices.setChecked(shouldUseOutputDevices);
+            mAutomatedTestRunner.setTestIndexText(singleTestIndex);
         });
 
         mAutomatedTestRunner.startTest();

--- a/apps/OboeTester/docs/AutomatedTesting.md
+++ b/apps/OboeTester/docs/AutomatedTesting.md
@@ -39,17 +39,26 @@ For example:
 
     --ei buffer_bursts 8
 
+Boolean parameters are sent using:
+
+    --ez {parameterName} {parameterValue}
+
+For example:
+
+    --ez use_input_devices false
+
 ## Parameters
 
 There are two required parameters:
 
-    --es test {latency, glitch}
+    --es test {latency, glitch, data_paths}
             The "latency" test will perform a Round Trip Latency test.
             It will request EXCLUSIVE mode for minimal latency.
             The "glitch" test will perform a single Glitch test.
+            The "data_paths" test will go through multiple data paths to test rarely tested configurations.
     --es file {full path for resulting file}
 
-There are several optional parameter in common for all tests:
+There are several optional parameter in common for glitch and latency tests:
 
     --ei buffer_bursts      {bursts}     // number of bursts in the buffer, 2 for "double buffered"
     --es in_api             {"unspecified", "opensles", "aaudio"}  // native input API, default is "unspecified"
@@ -69,6 +78,13 @@ There are several optional parameters for just the "glitch" test:
     --ei duration           {seconds}    // glitch test duration, default is 10 seconds
                             // input preset, default is "voicerec"
     --es in_preset          ("generic", "camcorder", "voicerec", "voicecomm", "unprocessed", "performance"}
+
+There are several optional parameters for just the "data_paths" test:
+
+    --ez use_input_presets  {boolean}  // Whether to test various input presets. Note use of "-ez"
+    --ez use_input_devices  {boolean}  // Whether to test various input devices. Note use of "-ez"
+    --ez use_output_devices {boolean}  // Whether to test various output devices. Note use of "-ez"
+    --ei single_test_index  {testId}   // Index for testing one specific test
 
 For example, a complete command for a "latency" test might be:
 
@@ -92,6 +108,15 @@ or for a "glitch" test:
         --ef tolerance 0.123 \
         --ei in_channels 2 \
 
+or for a "data_paths" test:
+
+    adb shell am start -n com.mobileer.oboetester/.MainActivity \
+        --es test data_paths \
+        --es file /sdcard/data_paths20190903.txt
+        --ez use_input_presets true
+        --ez use_input_devices false
+        --ez use_output_devices true
+
 ## Interpreting Test Results
 
 Test results are simple files with "name = value" pairs.
@@ -99,7 +124,7 @@ The test results can be obtained using adb pull.
 
     adb pull /sdcard/test20190611.txt .
 
-The beginning of the report is common to all tests:
+The beginning of the report is common to latency and glitch tests:
 
     build.fingerprint = google/bonito/bonito:10/QP1A.190711.017/5771233:userdebug/dev-keys
     test.version = 1.5.10
@@ -177,3 +202,7 @@ Here is a report from a test that failed because the output was muted. Note the 
     glitch.frames = 0
     reset.count = 1
     time.total =     9.95 seconds
+
+### Data Paths Report
+
+The report first goes through the info about the specific device before going through input preset tests, input devices tests, and output tests. Each will show the specific configuration of a test before showing whether it passed or failed. At the end of the report, a summary will list the number of passed/failed/skipped tests before trying to give actionable feedback on failed tests.


### PR DESCRIPTION
Add automatic data paths tests with the following parameters:

> --ez use_input_presets  {boolean}  // Whether to test various input presets. Note use of "-ez"
> --ez use_input_devices  {boolean}  // Whether to test various input devices. Note use of "-ez"
> --ez use_output_devices {boolean}  // Whether to test various output devices. Note use of "-ez"
> --ei single_test_index  {testId}   // Index for testing one specific test

I've updated the markdown file in the docs directory since we have added a new test of tests 

Fixes #1294 