### PR TITLE
(OboeTester) Fix sawtooth waves with test output

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -390,8 +390,12 @@ void ActivityTestOutput::configureForStart() {
         for (int i = 0; i < mChannelCount; i++) {
             sineOscillators[i].setSampleRate(outputStream->getSampleRate());
             sineOscillators[i].frequency.setValue(frequency);
-            frequency *= 4.0 / 3.0; // each sine is at a higher frequency
             sineOscillators[i].amplitude.setValue(AMPLITUDE_SINE);
+            sawtoothOscillators[i].setSampleRate(outputStream->getSampleRate());
+            sawtoothOscillators[i].frequency.setValue(frequency);
+            sawtoothOscillators[i].amplitude.setValue(AMPLITUDE_SAWTOOTH);
+
+            frequency *= 4.0 / 3.0; // each wave is at a higher frequency
             setChannelEnabled(i, true);
         }
     }


### PR DESCRIPTION
In OboeTester, sawtooth waves are not played correctly. This Pull Request fixes this.

Fixes #1391 