### PR TITLE
(LiveEffect) Disable setting playback or recording devices with OpenSL ES

### DIFF
--- a/samples/LiveEffect/README.md
+++ b/samples/LiveEffect/README.md
@@ -21,6 +21,8 @@ If you want to customize the effects processing then modify the
 onBothStreamsReady() method in "src/main/cpp/FullDuplexPass.h"
 
 ### Caveats
+OpenES SL does not allow setting the recording or playback device.
+
 Synchronizing input and output streams for full-duplex operation is tricky.  
 
 Input and output have different startup times. The input side may have to charge up the microphone circuit.

--- a/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
+++ b/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
@@ -137,10 +137,10 @@ public class MainActivity extends Activity
         } else {
             findViewById(R.id.aaudioButton).setEnabled(enable);
         }
-        setSpinnersEnabled(enable);
 
         ((RadioGroup)findViewById(R.id.apiSelectionGroup))
           .check(apiSelection == OBOE_API_AAUDIO ? R.id.aaudioButton : R.id.slesButton);
+        setSpinnersEnabled(enable);
     }
 
     @Override

--- a/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
+++ b/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
@@ -118,10 +118,6 @@ public class MainActivity extends Activity
             public void onClick(View v) {
                 if (((RadioButton)v).isChecked()) {
                     apiSelection = OBOE_API_OPENSL_ES;
-
-                    // OpenSL ES does not allow us to select a specific device
-                    playbackDeviceSpinner.setSelection(0);
-                    recordingDeviceSpinner.setSelection(0);
                     setSpinnersEnabled(false);
                 }
             }
@@ -141,6 +137,7 @@ public class MainActivity extends Activity
         } else {
             findViewById(R.id.aaudioButton).setEnabled(enable);
         }
+        setSpinnersEnabled(enable);
 
         ((RadioGroup)findViewById(R.id.apiSelectionGroup))
           .check(apiSelection == OBOE_API_AAUDIO ? R.id.aaudioButton : R.id.slesButton);
@@ -186,7 +183,6 @@ public class MainActivity extends Activity
 
         boolean success = LiveEffectEngine.setEffectOn(true);
         if (success) {
-            setSpinnersEnabled(false);
             statusText.setText(R.string.status_playing);
             toggleEffectButton.setText(R.string.stop_effect);
             isPlaying = true;
@@ -203,11 +199,16 @@ public class MainActivity extends Activity
         resetStatusView();
         toggleEffectButton.setText(R.string.start_effect);
         isPlaying = false;
-        setSpinnersEnabled(true);
         EnableAudioApiUI(true);
     }
 
     private void setSpinnersEnabled(boolean isEnabled){
+        if (((RadioButton)findViewById(R.id.slesButton)).isChecked())
+        {
+            isEnabled = false;
+            playbackDeviceSpinner.setSelection(0);
+            recordingDeviceSpinner.setSelection(0);
+        }
         recordingDeviceSpinner.setEnabled(isEnabled);
         playbackDeviceSpinner.setEnabled(isEnabled);
     }

--- a/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
+++ b/samples/LiveEffect/src/main/java/com/google/oboe/samples/liveEffect/MainActivity.java
@@ -109,6 +109,7 @@ public class MainActivity extends Activity
             public void onClick(View v) {
                 if (((RadioButton)v).isChecked()) {
                     apiSelection = OBOE_API_AAUDIO;
+                    setSpinnersEnabled(true);
                 }
             }
         });
@@ -117,6 +118,11 @@ public class MainActivity extends Activity
             public void onClick(View v) {
                 if (((RadioButton)v).isChecked()) {
                     apiSelection = OBOE_API_OPENSL_ES;
+
+                    // OpenSL ES does not allow us to select a specific device
+                    playbackDeviceSpinner.setSelection(0);
+                    recordingDeviceSpinner.setSelection(0);
+                    setSpinnersEnabled(false);
                 }
             }
         });

--- a/samples/LiveEffect/src/main/res/layout-v21/activity_main.xml
+++ b/samples/LiveEffect/src/main/res/layout-v21/activity_main.xml
@@ -22,6 +22,40 @@
     tools:context="com.google.oboe.samples.liveEffect.MainActivity"
     tools:layout_editor_absoluteY="81dp">
 
+    <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/apiSelectionGroup"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:orientation="horizontal"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/apiTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apiSelection" />
+
+        <RadioButton
+            android:id="@+id/aaudioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:text="@string/aaudio" />
+
+        <RadioButton
+            android:id="@+id/slesButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:text="@string/sles" />
+    </RadioGroup>
+
     <TextView
         android:id="@+id/recDeviceLabel"
         android:layout_width="wrap_content"
@@ -31,7 +65,7 @@
         android:layout_marginTop="@dimen/activity_vertical_margin"
         android:text="@string/recording_device"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/apiSelectionGroup"/>
 
     <com.google.oboe.samples.audio_device.AudioDeviceSpinner
         android:id="@+id/recording_devices_spinner"
@@ -64,41 +98,6 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/playDeviceLabel" />
 
-    <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/apiSelectionGroup"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@+id/playback_devices_spinner"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <TextView
-            android:id="@+id/apiTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/apiSelection" />
-
-        <RadioButton
-            android:id="@+id/aaudioButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:text="@string/aaudio" />
-
-        <RadioButton
-            android:id="@+id/slesButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:text="@string/sles" />
-    </RadioGroup>
-
     <Button
         android:id="@+id/button_toggle_effect"
         android:layout_width="wrap_content"
@@ -110,7 +109,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.53"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/apiSelectionGroup" />
+        app:layout_constraintTop_toBottomOf="@+id/playback_devices_spinner" />
 
     <TextView
         android:id="@+id/status_view_text"

--- a/samples/LiveEffect/src/main/res/layout/activity_main.xml
+++ b/samples/LiveEffect/src/main/res/layout/activity_main.xml
@@ -22,6 +22,40 @@
     tools:context="com.google.oboe.samples.liveEffect.MainActivity"
     tools:layout_editor_absoluteY="81dp">
 
+    <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/apiSelectionGroup"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:orientation="horizontal"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/apiTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apiSelection" />
+
+        <RadioButton
+            android:id="@+id/aaudioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:text="@string/aaudio" />
+
+        <RadioButton
+            android:id="@+id/slesButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:text="@string/sles" />
+    </RadioGroup>
+
     <TextView
         android:id="@+id/recDeviceLabel"
         android:layout_width="wrap_content"
@@ -31,7 +65,7 @@
         android:layout_marginTop="@dimen/activity_vertical_margin"
         android:text="@string/recording_device"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/apiSelectionGroup"/>
 
     <com.google.oboe.samples.audio_device.AudioDeviceSpinner
         android:id="@+id/recording_devices_spinner"
@@ -64,41 +98,6 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/playDeviceLabel" />
 
-    <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/apiSelectionGroup"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@+id/playback_devices_spinner"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <TextView
-            android:id="@+id/apiTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/apiSelection" />
-
-        <RadioButton
-            android:id="@+id/aaudioButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:text="@string/aaudio" />
-
-        <RadioButton
-            android:id="@+id/slesButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:text="@string/sles" />
-    </RadioGroup>
-
     <Button
         android:id="@+id/button_toggle_effect"
         android:layout_width="wrap_content"
@@ -108,8 +107,7 @@
         android:textAllCaps="false"
         android:text="@string/start_effect"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/apiSelectionGroup" />
+        app:layout_constraintTop_toBottomOf="@+id/playback_devices_spinner" />
 
     <TextView
         android:id="@+id/status_view_text"


### PR DESCRIPTION
Fixes #1419

Also slightly restructured the UI to have API selection on top. See how the playback/recording device selection is now disabled when OpenES SL is selected.

![Screenshot_20211019-132151](https://user-images.githubusercontent.com/85952307/137985547-79846b9f-a101-4af9-a803-e4d1cd8fa3b7.png)
