### PR TITLE
Bump Oboe version to 1.6.2

### DIFF
--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 6
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 1
+#define OBOE_VERSION_PATCH 2
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)


### PR DESCRIPTION
To distinguish patches since 1.6.1 release.

Fixes #1433