### PR TITLE
(HelloOboe) Add Bluetooth SCO sample

### DIFF
--- a/samples/hello-oboe/src/main/java/com/google/oboe/samples/hellooboe/MainActivity.java
+++ b/samples/hello-oboe/src/main/java/com/google/oboe/samples/hellooboe/MainActivity.java
@@ -17,9 +17,13 @@
 package com.google.oboe.samples.hellooboe;
 
 import android.app.Activity;
+import android.content.Context;
+import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.RequiresApi;
 import androidx.core.view.MotionEventCompat;
 
 import android.view.MotionEvent;
@@ -59,6 +63,7 @@ public class MainActivity extends Activity {
     private Spinner mBufferSizeSpinner;
     private TextView mLatencyText;
     private Timer mLatencyUpdater;
+    private boolean mScoStarted = false;
 
     /*
      * Hook to user control to start / stop audio playback:
@@ -106,6 +111,11 @@ public class MainActivity extends Activity {
         mBufferSizeSpinner.setSelection(SPINNER_DEFAULT_OPTION_INDEX);
         mAudioApiSpinner.setSelection(SPINNER_DEFAULT_OPTION_INDEX);
 
+        if (mScoStarted) {
+            stopBluetoothSco();
+            mScoStarted = false;
+        }
+
         int result = PlaybackEngine.start();
         if (result != 0) {
             showToast("Error opening stream = " + result);
@@ -119,6 +129,12 @@ public class MainActivity extends Activity {
         if (result != 0) {
             showToast("Error stopping stream = " + result);
         }
+
+        if (mScoStarted) {
+            stopBluetoothSco();
+            mScoStarted = false;
+        }
+
         PlaybackEngine.delete();
         super.onPause();
     }
@@ -172,6 +188,14 @@ public class MainActivity extends Activity {
             mPlaybackDeviceSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                    // Start Bluetooth SCO if needed.
+                    if (isScoDevice(getPlaybackDeviceId()) && !mScoStarted) {
+                        startBluetoothSco();
+                        mScoStarted = true;
+                    } else if (!isScoDevice(getPlaybackDeviceId()) && mScoStarted) {
+                        stopBluetoothSco();
+                        mScoStarted = false;
+                    }
                     PlaybackEngine.setAudioDeviceId(getPlaybackDeviceId());
                 }
 
@@ -288,7 +312,6 @@ public class MainActivity extends Activity {
         return audioApiOptions;
     }
 
-
     protected void showToast(final String message) {
         runOnUiThread(new Runnable() {
             @Override
@@ -298,5 +321,33 @@ public class MainActivity extends Activity {
                         Toast.LENGTH_SHORT).show();
             }
         });
+    }
+
+    /**
+     * @param deviceId
+     * @return true if the device is TYPE_BLUETOOTH_SCO
+     */
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private boolean isScoDevice(int deviceId) {
+        if (deviceId == 0) return false; // Unspecified
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        final AudioDeviceInfo[] devices;
+        devices = audioManager.getDevices(AudioManager.GET_DEVICES_ALL);
+        for (AudioDeviceInfo device : devices) {
+            if (device.getId() == deviceId) {
+                return device.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_SCO;
+            }
+        }
+        return false;
+    }
+
+    private void startBluetoothSco() {
+        AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        myAudioMgr.startBluetoothSco();
+    }
+
+    private void stopBluetoothSco() {
+        AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        myAudioMgr.stopBluetoothSco();
     }
 }

--- a/samples/hello-oboe/src/main/java/com/google/oboe/samples/hellooboe/MainActivity.java
+++ b/samples/hello-oboe/src/main/java/com/google/oboe/samples/hellooboe/MainActivity.java
@@ -111,11 +111,6 @@ public class MainActivity extends Activity {
         mBufferSizeSpinner.setSelection(SPINNER_DEFAULT_OPTION_INDEX);
         mAudioApiSpinner.setSelection(SPINNER_DEFAULT_OPTION_INDEX);
 
-        if (mScoStarted) {
-            stopBluetoothSco();
-            mScoStarted = false;
-        }
-
         int result = PlaybackEngine.start();
         if (result != 0) {
             showToast("Error opening stream = " + result);


### PR DESCRIPTION
Fixes #909

This PR adds an ability to toggle Bluetooth SCO when it is actually set. We should also update the Wiki to document Bluetooth after this PR is submitted.

Tested on Pixel 4a and Pixel Series A.
Verified that SCO does not play correctly before this change.
Toggled between SCO and A2DP and verified that the sound changes with this change.
