### PR TITLE
AAudio: add locks around reading and writing

### DIFF
--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -472,6 +472,7 @@ Result AudioStreamAAudio::requestStop_l(AAudioStream *stream) {
 ResultWithValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
                                      int32_t numFrames,
                                      int64_t timeoutNanoseconds) {
+    std::shared_lock<std::shared_mutex> lock(mAAudioStreamLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         int32_t result = mLibLoader->stream_write(mAAudioStream, buffer,
@@ -485,6 +486,7 @@ ResultWithValue<int32_t>   AudioStreamAAudio::write(const void *buffer,
 ResultWithValue<int32_t>   AudioStreamAAudio::read(void *buffer,
                                  int32_t numFrames,
                                  int64_t timeoutNanoseconds) {
+    std::shared_lock<std::shared_mutex> lock(mAAudioStreamLock);
     AAudioStream *stream = mAAudioStream.load();
     if (stream != nullptr) {
         int32_t result = mLibLoader->stream_read(mAAudioStream, buffer,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
         testStreamStates.cpp
         testStreamFramesProcessed.cpp
         testReturnStop.cpp
+        testStreamStopWrite.cpp
         )
 
 target_link_libraries(testOboe gtest oboe)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(
         testStreamStates.cpp
         testStreamFramesProcessed.cpp
         testReturnStop.cpp
-        testStreamStopWrite.cpp
+        testStreamStop.cpp
         )
 
 target_link_libraries(testOboe gtest oboe)

--- a/tests/UnitTestRunner/app/build.gradle
+++ b/tests/UnitTestRunner/app/build.gradle
@@ -15,10 +15,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    externalNativeBuild {
+        cmake {
+            path file('../../CMakeLists.txt')
+        }
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }

--- a/tests/UnitTestRunner/app/src/main/AndroidManifest.xml
+++ b/tests/UnitTestRunner/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity" android:screenOrientation="landscape">
+        <activity android:name=".MainActivity" android:exported="true" android:screenOrientation="landscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/UnitTestRunner/app/src/main/java/com/google/oboe/tests/unittestrunner/MainActivity.java
+++ b/tests/UnitTestRunner/app/src/main/java/com/google/oboe/tests/unittestrunner/MainActivity.java
@@ -60,6 +60,10 @@ public class MainActivity extends AppCompatActivity {
 
         StringBuffer output = new StringBuffer();
         String abi = Build.CPU_ABI;
+        String extraStringForDebugBuilds = "-hwasan";
+        if (abi.endsWith(extraStringForDebugBuilds)) {
+            abi = abi.substring(0, abi.length() - extraStringForDebugBuilds.length());
+        }
         String filesDir = getFilesDir().getPath();
         String testBinaryPath = abi + "/" + TEST_BINARY_FILEANAME;
 

--- a/tests/UnitTestRunner/build.gradle
+++ b/tests/UnitTestRunner/build.gradle
@@ -1,24 +1,26 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
     repositories {
-        google()
-        jcenter()
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
-        
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.1.1'
     }
 }
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -18,6 +18,10 @@
 #include <oboe/Oboe.h>
 #include <android/api-level.h>
 
+#ifndef __ANDROID_API_S__
+#define __ANDROID_API_S__ 31
+#endif
+
 using namespace oboe;
 
 class CallbackSizeMonitor : public AudioStreamCallback {

--- a/tests/testStreamStop.cpp
+++ b/tests/testStreamStop.cpp
@@ -69,7 +69,7 @@ protected:
         int16_t buffer[kFramesToWrite] = {};
 
         std::thread stopper([str] {
-            int64_t estimatedCompletionTimeUs = kSecondsPerMicroSecond * kFramesToWrite / str->getSampleRate();
+            int64_t estimatedCompletionTimeUs = kMicroSecondsPerSecond * kFramesToWrite / str->getSampleRate();
             usleep(estimatedCompletionTimeUs / 2); // Stop halfway during the read/write
             str->close();
         });
@@ -94,7 +94,7 @@ protected:
     AudioStreamBuilder mBuilder;
     AudioStream *mStream = nullptr;
     static constexpr int kTimeoutInNanos = 1000 * kNanosPerMillisecond;
-    static constexpr int64_t kSecondsPerMicroSecond = 1000000;
+    static constexpr int64_t kMicroSecondsPerSecond = 1000000;
     static constexpr int kFramesToWrite = 10000;
 
 };

--- a/tests/testStreamStop.cpp
+++ b/tests/testStreamStop.cpp
@@ -56,7 +56,7 @@ protected:
         return (r == Result::OK);
     }
 
-    void stopWhileUsingLargeBuffer(bool shouldWrite) {
+    void stopWhileUsingLargeBuffer() {
         StreamState next = StreamState::Unknown;
         auto r = mStream->requestStart();
         EXPECT_EQ(r, Result::OK);
@@ -105,7 +105,7 @@ TEST_P(TestStreamStop, VerifyTestStreamStop) {
     const PerformanceMode performanceMode = std::get<2>(GetParam());
 
     ASSERT_TRUE(openStream(direction, audioApi, performanceMode));
-    stopWhileUsingLargeBuffer(direction == Direction::Output);
+    stopWhileUsingLargeBuffer();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/testStreamStopWrite.cpp
+++ b/tests/testStreamStopWrite.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <oboe/Oboe.h>
+
+using namespace oboe;
+
+class TestStreamStopWrite : public ::testing::Test {
+
+protected:
+
+    void SetUp(){
+        mBuilder.setPerformanceMode(PerformanceMode::None);
+        mBuilder.setDirection(Direction::Output);
+    }
+
+    bool openStream(Direction direction, PerformanceMode perfMode) {
+        mBuilder.setDirection(direction);
+        mBuilder.setPerformanceMode(perfMode);
+        Result r = mBuilder.openStream(&mStream);
+        EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
+        if (r != Result::OK)
+            return false;
+
+        Direction d = mStream->getDirection();
+        EXPECT_EQ(d, direction) << convertToText(mStream->getDirection());
+        return (d == direction);
+    }
+
+    bool openStream(AudioStreamBuilder &builder) {
+        Result r = builder.openStream(&mStream);
+        EXPECT_EQ(r, Result::OK) << "Failed to open stream " << convertToText(r);
+        return (r == Result::OK);
+    }
+
+    bool closeStream() {
+        Result r = mStream->close();
+        EXPECT_TRUE(r == Result::OK || r == Result::ErrorClosed) <<
+            "Failed to close stream. " << convertToText(r);
+        return (r == Result::OK || r == Result::ErrorClosed);
+    }
+
+    void stopWhileWritingLargeBuffer() {
+        StreamState next = StreamState::Unknown;
+        auto r = mStream->requestStart();
+        EXPECT_EQ(r, Result::OK);
+        r = mStream->waitForStateChange(StreamState::Starting, &next, kTimeoutInNanos);
+        EXPECT_EQ(r, Result::OK);
+        EXPECT_EQ(next, StreamState::Started) << "next = " << convertToText(next);
+
+        AudioStream *str = mStream;
+        std::thread stopper([str] {
+            usleep(2 * 1000);
+            str->requestStop();
+        });
+
+        int16_t buffer[100000] = {};
+        r = mStream->write(&buffer, 100000, kTimeoutInNanos);
+        if (r != Result::OK) {
+            FAIL() << "Could not write to audio stream";
+        }
+
+        r = mStream->waitForStateChange(StreamState::Started, &next,
+                                        1000 * kNanosPerMillisecond);
+        stopper.join();
+        EXPECT_EQ(r, Result::OK);
+        // May have caught in stopping transition. Wait for full stop.
+        if (next == StreamState::Stopping) {
+            r = mStream->waitForStateChange(StreamState::Stopping, &next,
+                                            1000 * kNanosPerMillisecond);
+            EXPECT_EQ(r, Result::OK);
+        }
+        ASSERT_EQ(next, StreamState::Stopped) << "next = " << convertToText(next);
+    }
+
+    AudioStreamBuilder mBuilder;
+    AudioStream *mStream = nullptr;
+    static constexpr int kTimeoutInNanos = 1000 * kNanosPerMillisecond;
+
+};
+
+TEST_F(TestStreamStopWrite, OutputLowLatency) {
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::LowLatency));
+    stopWhileWritingLargeBuffer();
+    ASSERT_TRUE(closeStream());
+}
+
+TEST_F(TestStreamStopWrite, OutputNone) {
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::None));
+    stopWhileWritingLargeBuffer();
+    ASSERT_TRUE(closeStream());
+}
+
+TEST_F(TestStreamStopWrite, OutputPowerSavings) {
+    ASSERT_TRUE(openStream(Direction::Output, PerformanceMode::PowerSaving));
+    stopWhileWritingLargeBuffer();
+    ASSERT_TRUE(closeStream());
+}


### PR DESCRIPTION
This PR fixes an issue where AAudio segfaults if the stream is closed while read or write occurs. The main work done here is a 2 line change adding shared locks for read and write. This is relatively safe as these locks are only used as exclusive for close(), which should wait for all operations to finish in the first place.

I've updated a few things related to unit tests.
1. The unit tests to use a newer version of gradle.
2. I added tests to account to test the new AAudio shared read/write locks.
3. Unit tests wouldn't run for devices built with hardware sanitizer, so I've added a check.

Fixes #1484 