### PR TITLE
Measure timestamp latency for full duplex stream.

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -8,7 +8,7 @@ android {
         targetSdkVersion 31
         // Also update the versions in the AndroidManifest.xml file.
         versionCode 57
-        versionName "2.2.2"
+        versionName "2.2.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
@@ -53,10 +53,21 @@ public:
         mRecording = recording;
     }
 
+    bool isWriteReadDeltaValid() {
+        return mWriteReadDeltaValid;
+    }
+
+    int64_t getWriteReadDelta() {
+        return mWriteReadDelta;
+    }
+
 private:
     MultiChannelRecording  *mRecording = nullptr;
 
     LoopbackProcessor * const mLoopbackProcessor;
+
+    std::atomic<bool> mWriteReadDeltaValid{false};
+    std::atomic<int64_t> mWriteReadDelta{0};
 };
 
 

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -659,14 +659,6 @@ jdouble ActivityRoundTripLatency::measureTimestampLatency() {
     int32_t sampleRate = mFullDuplexLatency->getOutputStream()->getSampleRate();
     int64_t mappedTimeNanos = outputTimeNanos + ((mappedPosition - ouputPosition) * 1e9) / sampleRate;
 
-//    LOGD("ActivityRoundTripLatency::%s() writeReadDelta = %ld ", __func__, writeReadDelta);
-//    LOGD("ActivityRoundTripLatency::%s() inputPosition = %ld ", __func__, inputPosition);
-//    LOGD("ActivityRoundTripLatency::%s() inputTimeNanos = %ld ", __func__, inputTimeNanos);
-//    LOGD("ActivityRoundTripLatency::%s() ouputPosition = %ld ", __func__, ouputPosition);
-//    LOGD("ActivityRoundTripLatency::%s() outputTimeNanos = %ld ", __func__, outputTimeNanos);
-//    LOGD("ActivityRoundTripLatency::%s() mappedPosition = %ld ", __func__, mappedPosition);
-//    LOGD("ActivityRoundTripLatency::%s() mappedTimeNanos = %ld ", __func__, mappedTimeNanos);
-
     // Latency is the difference in time between when a frame was recorded and
     // when its corresponding echo was played.
     return (mappedTimeNanos - inputTimeNanos) * 1.0e-6; // convert nanos to millis

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -632,6 +632,46 @@ void ActivityRoundTripLatency::finishOpen(bool isInput, AudioStream *oboeStream)
     }
 }
 
+// The timestamp latency is the difference between the input
+// and output times for a specific frame.
+// Start with the position and time from an input timestamp.
+// Map the input position to the corresponding position in output
+// and calculate its time.
+// Use the difference between framesWritten and framesRead to
+// convert input positions to output positions.
+jdouble ActivityRoundTripLatency::measureTimestampLatency() {
+    if (!mFullDuplexLatency->isWriteReadDeltaValid()) return -1.0;
+
+    int64_t writeReadDelta = mFullDuplexLatency->getWriteReadDelta();
+    auto inputTimestampResult = mFullDuplexLatency->getInputStream()->getTimestamp(CLOCK_MONOTONIC);
+    if (!inputTimestampResult) return -1.0;
+    auto outputTimestampResult = mFullDuplexLatency->getOutputStream()->getTimestamp(CLOCK_MONOTONIC);
+    if (!outputTimestampResult) return -1.0;
+
+    int64_t inputPosition = inputTimestampResult.value().position;
+    int64_t inputTimeNanos = inputTimestampResult.value().timestamp;
+    int64_t ouputPosition = outputTimestampResult.value().position;
+    int64_t outputTimeNanos = outputTimestampResult.value().timestamp;
+
+    // Map input frame position to the corresponding output frame.
+    int64_t mappedPosition = inputPosition + writeReadDelta;
+    // Calculate when that frame will play.
+    int32_t sampleRate = mFullDuplexLatency->getOutputStream()->getSampleRate();
+    int64_t mappedTimeNanos = outputTimeNanos + ((mappedPosition - ouputPosition) * 1e9) / sampleRate;
+
+//    LOGD("ActivityRoundTripLatency::%s() writeReadDelta = %ld ", __func__, writeReadDelta);
+//    LOGD("ActivityRoundTripLatency::%s() inputPosition = %ld ", __func__, inputPosition);
+//    LOGD("ActivityRoundTripLatency::%s() inputTimeNanos = %ld ", __func__, inputTimeNanos);
+//    LOGD("ActivityRoundTripLatency::%s() ouputPosition = %ld ", __func__, ouputPosition);
+//    LOGD("ActivityRoundTripLatency::%s() outputTimeNanos = %ld ", __func__, outputTimeNanos);
+//    LOGD("ActivityRoundTripLatency::%s() mappedPosition = %ld ", __func__, mappedPosition);
+//    LOGD("ActivityRoundTripLatency::%s() mappedTimeNanos = %ld ", __func__, mappedTimeNanos);
+
+    // Latency is the difference in time between when a frame was recorded and
+    // when its corresponding echo was played.
+    return (mappedTimeNanos - inputTimeNanos) * 1.0e-6; // convert nanos to millis
+}
+
 // ======================================================================= ActivityGlitches
 void ActivityGlitches::configureBuilder(bool isInput, oboe::AudioStreamBuilder &builder) {
     ActivityFullDuplex::configureBuilder(isInput, builder);

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -564,6 +564,8 @@ public:
         return false;
     }
 
+    jdouble measureTimestampLatency();
+
 protected:
     void finishOpen(bool isInput, oboe::AudioStream *oboeStream) override;
 

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -582,8 +582,14 @@ Java_com_mobileer_oboetester_RoundTripLatencyActivity_getMeasuredLatency(JNIEnv 
 
 JNIEXPORT jdouble JNICALL
 Java_com_mobileer_oboetester_RoundTripLatencyActivity_getMeasuredConfidence(JNIEnv *env,
-                                                                                      jobject instance) {
+                                                                            jobject instance) {
     return engine.mActivityRoundTripLatency.getLatencyAnalyzer()->getMeasuredConfidence();
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_mobileer_oboetester_RoundTripLatencyActivity_measureTimestampLatency(JNIEnv *env,
+                                                                            jobject instance) {
+    return engine.mActivityRoundTripLatency.measureTimestampLatency();
 }
 
 JNIEXPORT jdouble JNICALL

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DoubleStatistics.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DoubleStatistics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.oboetester;
+
+import java.util.ArrayList;
+
+class DoubleStatistics {
+    ArrayList<Double> mValues = new ArrayList<Double>();
+    private double mMin = Double.MAX_VALUE;
+    private double mMax = Double.MIN_VALUE;
+    private double mSum = 0.0;
+
+    // Number of measurements.
+    public int count() {
+        return mValues.size();
+    }
+
+    public void add(double value) {
+        mValues.add(value);
+        mMin = Math.min(value, mMin);
+        mMax = Math.max(value, mMax);
+        mSum += value;
+    }
+
+    public double calculateMeanAbsoluteDeviation(double mean) {
+        double deviationSum = 0.0;
+        for (double value : mValues) {
+            deviationSum += Math.abs(value - mean);
+        }
+        return deviationSum / mValues.size();
+    }
+
+    // This will crash if there are no values added.
+    public double calculateMean() {
+        return mSum / mValues.size();
+    }
+
+    public double getMin() {
+        return mMin;
+    }
+
+    public double getMax() {
+        return mMax;
+    }
+
+    public double getSum() {
+        return mSum;
+    }
+
+    // This will crash if there are no values added.
+    public double getLast() {
+        return mValues.get(mValues.size() - 1);
+    }
+}


### PR DESCRIPTION
Compare with measured acoustic latency.
This will allow us to measure the accuracy of
the timestamps.

The reported value is "timestamp.latency.msec".

Fixes #1498