### PR TITLE
Include <algorithm> explicitly

### DIFF
--- a/src/flowgraph/resampler/PolyphaseResampler.cpp
+++ b/src/flowgraph/resampler/PolyphaseResampler.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <math.h>
+#include <algorithm>
 #include "IntegerRatio.h"
 #include "PolyphaseResampler.h"
 

--- a/src/flowgraph/resampler/SincResampler.cpp
+++ b/src/flowgraph/resampler/SincResampler.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <math.h>
+#include <algorithm>
 #include "SincResampler.h"
 
 using namespace resampler;

--- a/src/flowgraph/resampler/SincResamplerStereo.cpp
+++ b/src/flowgraph/resampler/SincResamplerStereo.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <math.h>
+#include <algorithm>
 
 #include "SincResamplerStereo.h"
 


### PR DESCRIPTION
A compilation error occurs on latest LLVM libcxx (tested on https://github.com/llvm/llvm-project/commit/6e2c6c9def394c79a65bb216ac3d5261d39cc960) due to the C++ stdlib header `<algorithm>` being a transitive dependency that is no longer included on the latest LLVM libcxx (as of https://reviews.llvm.org/D119667), this causes breakage for instances of `std::find`/`std::find_if` as they cannot be resolved. This PR explicitly includes the `<algorithm>` header wherever necessary to compile without errors but it is generally a good practice to avoid transitive dependencies.