### PR TITLE
opensles: use dlsym() to link

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId = "com.mobileer.oboetester"
-        minSdkVersion 30
+        minSdkVersion 23
         targetSdkVersion 31
         // Also update the versions in the AndroidManifest.xml file.
         versionCode 57

--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId = "com.mobileer.oboetester"
-        minSdkVersion 23
+        minSdkVersion 30
         targetSdkVersion 31
         // Also update the versions in the AndroidManifest.xml file.
         versionCode 57

--- a/include/oboe/Definitions.h
+++ b/include/oboe/Definitions.h
@@ -244,11 +244,14 @@ namespace oboe {
 
         /**
          * Use OpenSL ES.
+         * Note that OpenSL ES is deprecated in Android 13, API 30 and above.
          */
         OpenSLES,
 
         /**
          * Try to use AAudio. Fail if unavailable.
+         * AAudio was first supported in Android 8, API 26 and above.
+         * It is only recommended for API 27 and above.
          */
         AAudio
     };

--- a/src/opensles/EngineOpenSLES.cpp
+++ b/src/opensles/EngineOpenSLES.cpp
@@ -14,25 +14,60 @@
  * limitations under the License.
  */
 
+#include <dlfcn.h>
 #include "common/OboeDebug.h"
 #include "EngineOpenSLES.h"
 #include "OpenSLESUtilities.h"
 
 using namespace oboe;
 
+// OpenSL ES is deprecated in SDK 30.
+// So we use custom dynamic linking to access the library.
+#define LIB_OPENSLES_NAME "libOpenSLES.so"
+typedef SLresult  (*prototype_slCreateEngine)(
+        SLObjectItf             *pEngine,
+        SLuint32                numOptions,
+        const SLEngineOption    *pEngineOptions,
+        SLuint32                numInterfaces,
+        const SLInterfaceID     *pInterfaceIds,
+        const SLboolean         *pInterfaceRequired
+);
+static prototype_slCreateEngine gFunction_slCreateEngine = nullptr;
+static void *gLibOpenSlesLibraryHandle = nullptr;
+
+// Load the OpenSL ES library and the one primary entry point.
+static void loadOpenSLES() {
+    if (gFunction_slCreateEngine == nullptr) {
+// Use RTLD_NOW to avoid the unpredictable behavior that RTLD_LAZY can cause.
+// Also resolving all the links now will prevent a run-time penalty later.
+        gLibOpenSlesLibraryHandle = dlopen(LIB_OPENSLES_NAME, RTLD_NOW);
+        if (gLibOpenSlesLibraryHandle == nullptr) {
+            LOGE("loadOpenSLES() could not find " LIB_OPENSLES_NAME);
+        } else {
+            gFunction_slCreateEngine = (prototype_slCreateEngine) dlsym(gLibOpenSlesLibraryHandle,
+                                                                        "slCreateEngine");
+            LOGD("loadOpenSLES(): dlsym(%s) returned %p", LIB_OPENSLES_NAME,
+                 gLibOpenSlesLibraryHandle);
+        }
+    }
+}
+
 EngineOpenSLES &EngineOpenSLES::getInstance() {
     static EngineOpenSLES sInstance;
     return sInstance;
 }
+
 
 SLresult EngineOpenSLES::open() {
     std::lock_guard<std::mutex> lock(mLock);
 
     SLresult result = SL_RESULT_SUCCESS;
     if (mOpenCount++ == 0) {
+        // load the library and link to it
+        loadOpenSLES();
 
         // create engine
-        result = slCreateEngine(&mEngineObject, 0, NULL, 0, NULL, NULL);
+        result = (*gFunction_slCreateEngine)(&mEngineObject, 0, NULL, 0, NULL, NULL);
         if (SL_RESULT_SUCCESS != result) {
             LOGE("EngineOpenSLES - slCreateEngine() result:%s", getSLErrStr(result));
             goto error;

--- a/src/opensles/EngineOpenSLES.cpp
+++ b/src/opensles/EngineOpenSLES.cpp
@@ -57,7 +57,6 @@ EngineOpenSLES &EngineOpenSLES::getInstance() {
     return sInstance;
 }
 
-
 SLresult EngineOpenSLES::open() {
     std::lock_guard<std::mutex> lock(mLock);
 


### PR DESCRIPTION
Link with slCreateEngine using dlsym().
OpenSL ES is deprecated in SDK >= 30.

Fixes #1530