### PR TITLE
OpenSL ES: Set usages if unspecified

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -87,6 +87,12 @@ Result AudioStreamOpenSLES::open() {
     if (mChannelCount == kUnspecified) {
         mChannelCount = DefaultStreamValues::ChannelCount;
     }
+    if (mContentType == kUnspecified) {
+        mContentType = ContentType::Music;
+    }
+    if (static_cast<const int32_t>(mUsage) == kUnspecified) {
+        mUsage = Usage::Media;
+    }
 
     mSharingMode = SharingMode::Shared;
 


### PR DESCRIPTION
Fixes #1536

OboeTester output streams that set Unspecified works as intended now.