### PR TITLE
Flowgraph: Use INT32_MIN for clamp32FromFloat()

### DIFF
--- a/src/flowgraph/FlowgraphUtilities.h
+++ b/src/flowgraph/FlowgraphUtilities.h
@@ -39,9 +39,9 @@ static int32_t clamp32FromFloat(float f)
     static const float limneg = -1.;
 
     if (f <= limneg) {
-        return INT_MIN;
+        return INT32_MIN;
     } else if (f >= limpos) {
-        return INT_MAX;
+        return INT32_MAX;
     }
     f *= scale;
     /* integer conversion is through truncation (though int to float is not).

--- a/src/flowgraph/FlowgraphUtilities.h
+++ b/src/flowgraph/FlowgraphUtilities.h
@@ -39,9 +39,9 @@ static int32_t clamp32FromFloat(float f)
     static const float limneg = -1.;
 
     if (f <= limneg) {
-        return -0x80000000; /* or 0x80000000 */
+        return INT_MIN;
     } else if (f >= limpos) {
-        return 0x7fffffff;
+        return INT_MAX;
     }
     f *= scale;
     /* integer conversion is through truncation (though int to float is not).

--- a/tests/testFlowgraph.cpp
+++ b/tests/testFlowgraph.cpp
@@ -176,14 +176,8 @@ TEST(test_flowgraph, module_sinki32) {
         1.0f, 0.5f, -0.25f, -1.0f,
         0.0f, 53.9f, -87.2f, -1.02f};
     static const int32_t expected[] = {
-        INT32_MAX,
-        (int32_t)(((int64_t)INT32_MAX+1)/2),
-        INT32_MIN/4,
-        INT32_MIN,
-        0,
-        INT32_MAX,
-        INT32_MIN,
-        INT32_MIN};
+        INT32_MAX, 1 << 30, INT32_MIN / 4, INT32_MIN,
+        0, INT32_MAX, INT32_MIN, INT32_MIN};
     int32_t output[kNumSamples + 10]; // larger than input
 
     SourceFloat sourceFloat{1};

--- a/tests/testFlowgraph.cpp
+++ b/tests/testFlowgraph.cpp
@@ -33,6 +33,7 @@
 #include "flowgraph/SinkFloat.h"
 #include "flowgraph/SinkI16.h"
 #include "flowgraph/SinkI24.h"
+#include "flowgraph/SinkI32.h"
 #include "flowgraph/SourceI16.h"
 #include "flowgraph/SourceI24.h"
 
@@ -169,3 +170,32 @@ TEST(test_flowgraph, module_clip_to_range) {
     }
 }
 
+TEST(test_flowgraph, module_sinki32) {
+    static constexpr int kNumSamples = 8;
+    static const float input[] = {
+        1.0f, 0.5f, -0.25f, -1.0f,
+        0.0f, 53.9f, -87.2f, -1.02f};
+    static const int32_t expected[] = {
+        INT32_MAX,
+        (int32_t)(((int64_t)INT32_MAX+1)/2),
+        INT32_MIN/4,
+        INT32_MIN,
+        0,
+        INT32_MAX,
+        INT32_MIN,
+        INT32_MIN};
+    int32_t output[kNumSamples + 10]; // larger than input
+
+    SourceFloat sourceFloat{1};
+    SinkI32 sinkI32{1};
+
+    sourceFloat.setData(input, kNumSamples);
+    sourceFloat.output.connect(&sinkI32.input);
+
+    int numOutputFrames = sizeof(output) / sizeof(int32_t);
+    int32_t numRead = sinkI32.read(output, numOutputFrames);
+    ASSERT_EQ(kNumSamples, numRead);
+    for (int i = 0; i < numRead; i++) {
+        EXPECT_EQ(expected[i], output[i]) << ", i = " << i;
+    }
+}


### PR DESCRIPTION
Fixes #1539

Note the new test passes both before and after the clamp32FromFloat code change.