### PR TITLE
OboeTester: cleanup latency test

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -587,6 +587,12 @@ Java_com_mobileer_oboetester_RoundTripLatencyActivity_getMeasuredConfidence(JNIE
 }
 
 JNIEXPORT jdouble JNICALL
+Java_com_mobileer_oboetester_RoundTripLatencyActivity_getMeasuredCorrelation(JNIEnv *env,
+                                                                            jobject instance) {
+    return engine.mActivityRoundTripLatency.getLatencyAnalyzer()->getMeasuredCorrelation();
+}
+
+JNIEXPORT jdouble JNICALL
 Java_com_mobileer_oboetester_RoundTripLatencyActivity_measureTimestampLatency(JNIEnv *env,
                                                                             jobject instance) {
     return engine.mActivityRoundTripLatency.measureTimestampLatency();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
@@ -291,6 +291,8 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
 
         message += String.format("rms.signal = %7.5f\n", getSignalRMS());
         message += String.format("rms.noise = %7.5f\n", getBackgroundRMS());
+        message += String.format("correlation = " + CONFIDENCE_FORMAT + "\n",
+                getMeasuredCorrelation());
         double timestampLatency = getTimestampLatencyMillis();
         message += String.format("timestamp.latency.msec = " + LATENCY_FORMAT + "\n",
                 timestampLatency);
@@ -320,6 +322,7 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
     native int getMeasuredLatency();
     native double measureTimestampLatency();
     native double getMeasuredConfidence();
+    native double getMeasuredCorrelation();
     native double getBackgroundRMS();
     native double getSignalRMS();
 


### PR DESCRIPTION
Disambiguate correlation and confidence.
Display correlation in Activity.
Make getMeasuredConfidence() public.