### PR TITLE
opensles: clean up after failed open

### DIFF
--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -234,6 +234,7 @@ Result AudioOutputStreamOpenSLES::open() {
     return Result::OK;
 
 error:
+    close();  // Clean up various OpenSL objects and prevent resource leaks.
     return Result::ErrorInternal; // TODO convert error from SLES to OBOE
 }
 
@@ -249,7 +250,7 @@ Result AudioOutputStreamOpenSLES::close() {
     if (getState() == StreamState::Closed){
         result = Result::ErrorClosed;
     } else {
-        requestPause_l();
+        (void) requestPause_l();
         // invalidate any interfaces
         mPlayInterface = nullptr;
         result = AudioStreamOpenSLES::close_l();
@@ -326,6 +327,7 @@ Result AudioOutputStreamOpenSLES::requestPause_l() {
         case StreamState::Pausing:
         case StreamState::Paused:
             return Result::OK;
+        case StreamState::Uninitialized:
         case StreamState::Closed:
             return Result::ErrorClosed;
         default:
@@ -383,6 +385,7 @@ Result AudioOutputStreamOpenSLES::requestStop() {
         case StreamState::Stopping:
         case StreamState::Stopped:
             return Result::OK;
+        case StreamState::Uninitialized:
         case StreamState::Closed:
             return Result::ErrorClosed;
         default:

--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -54,8 +54,8 @@ void AudioStreamBuffered::allocateFifo() {
                 capacityFrames = numBursts * getFramesPerBurst();
             }
         }
-        // TODO consider using std::make_unique if we require c++14
-        mFifoBuffer.reset(new FifoBuffer(getBytesPerFrame(), capacityFrames));
+
+        mFifoBuffer = std::make_unique<FifoBuffer>(getBytesPerFrame(), capacityFrames);
         mBufferCapacityInFrames = capacityFrames;
     }
 }

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -78,6 +78,7 @@ Result AudioStreamOpenSLES::open() {
 
     Result oboeResult = AudioStreamBuffered::open();
     if (oboeResult != Result::OK) {
+        EngineOpenSLES::getInstance().close();
         return oboeResult;
     }
     // Convert to defaults if UNSPECIFIED


### PR DESCRIPTION
There were resource leaks if the open failed.
So now it calls close() internally if open fails.

Fixes #1541