### PR TITLE
OboeTester: remove extra \n in xRun#

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioStreamBase.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioStreamBase.java
@@ -117,7 +117,7 @@ public abstract class AudioStreamBase {
                 int remainder = bufferSize - (numBuffers * framesPerBurst);
                 buffer.append(bufferSize + " = (" + numBuffers + " * " + framesPerBurst + ") + " + remainder);
             }
-            buffer.append(",   xRun# = " + ((xRunCount < 0) ? "?" : xRunCount) + "\n");
+            buffer.append(",   xRun# = " + ((xRunCount < 0) ? "?" : xRunCount));
 
             return buffer.toString();
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/85952307/170763814-b5657ce9-a5ea-4e8c-b942-6dd00da10da2.png)

After:
![image](https://user-images.githubusercontent.com/85952307/170763768-bee9d83c-1041-43b7-9616-d382c350d320.png)
