### PR TITLE
Workflow: Update to the newest version of CodeQL

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         java-version: 11
     - name: build samples and apps
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp
     - run: |
@@ -34,4 +34,4 @@ jobs:
         ./gradlew -q clean bundleDebug
         popd
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL Action V1 will be [deprecated](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/) in December 2022. We are updating to V2 in this PR.