### PR TITLE
OboeTester: Update CMakeLists to update vtables

### DIFF
--- a/apps/OboeTester/app/CMakeLists.txt
+++ b/apps/OboeTester/app/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -std=c++17 -fvisibility=hidden")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+set(CMAKE_AUTOMOC ON)
 
 link_directories(${CMAKE_CURRENT_LIST_DIR}/..)
 


### PR DESCRIPTION
From pulling main, I seem to be missing vtables for WhiteNoise.h.

From https://stackoverflow.com/a/67319420, it seems like we need to add set(CMAKE_AUTOMOC ON) to our CMakeLists so our compiler isn't confused with the new code.