### PR TITLE
OpenSL ES: Call processBufferCallback before setting the playstate to playing

### DIFF
--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -298,23 +298,16 @@ Result AudioOutputStreamOpenSLES::requestStart() {
     setDataCallbackEnabled(true);
 
     setState(StreamState::Starting);
-
-    if (getBufferDepth(mSimpleBufferQueueInterface) == 0) {
-        // Enqueue the first buffer if needed to start the streaming.
-        // We may need to stop the current stream.
-        bool shouldStopStream = processBufferCallback(mSimpleBufferQueueInterface);
-        if (shouldStopStream) {
-            LOGD("Stopping the current stream.");
-            if (requestStop_l() != Result::OK) {
-                LOGW("Failed to flush the stream. Error %s", convertToText(flush()));
-            }
-        }
-    }
-
+    int bufferDepthBeforeSettingPlayState = getBufferDepth(mSimpleBufferQueueInterface);
     Result result = setPlayState_l(SL_PLAYSTATE_PLAYING);
     if (result == Result::OK) {
         setState(StreamState::Started);
         mLock.unlock();
+        if (bufferDepthBeforeSettingPlayState == 0) {
+            // Enqueue the first buffer if needed to start the streaming.
+            // This might call requestStop() so try to avoid a recursive lock.
+            processBufferCallback(mSimpleBufferQueueInterface);
+        }
     } else {
         setState(initialState);
         mLock.unlock();
@@ -385,12 +378,6 @@ Result AudioOutputStreamOpenSLES::requestFlush_l() {
 }
 
 Result AudioOutputStreamOpenSLES::requestStop() {
-    std::lock_guard<std::mutex> lock(mLock);
-    return requestStop_l();
-}
-
-
-Result AudioOutputStreamOpenSLES::requestStop_l() {
     LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
     std::lock_guard<std::mutex> lock(mLock);
 

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -298,16 +298,26 @@ Result AudioOutputStreamOpenSLES::requestStart() {
     setDataCallbackEnabled(true);
 
     setState(StreamState::Starting);
-    int bufferDepthBeforeSettingPlayState = getBufferDepth(mSimpleBufferQueueInterface);
+
+    if (getBufferDepth(mSimpleBufferQueueInterface) == 0) {
+        // Enqueue the first buffer if needed to start the streaming.
+        // We may need to stop the current stream.
+        bool shouldStopStream = processBufferCallback(mSimpleBufferQueueInterface);
+        if (shouldStopStream) {
+            LOGD("Stopping the current stream.");
+            if (requestStop_l() != Result::OK) {
+                LOGW("Failed to flush the stream. Error %s", convertToText(flush()));
+            }
+            setState(initialState);
+            mLock.unlock();
+            return Result::ErrorClosed;
+        }
+    }
+
     Result result = setPlayState_l(SL_PLAYSTATE_PLAYING);
     if (result == Result::OK) {
         setState(StreamState::Started);
         mLock.unlock();
-        if (bufferDepthBeforeSettingPlayState == 0) {
-            // Enqueue the first buffer if needed to start the streaming.
-            // This might call requestStop() so try to avoid a recursive lock.
-            processBufferCallback(mSimpleBufferQueueInterface);
-        }
     } else {
         setState(initialState);
         mLock.unlock();
@@ -378,8 +388,12 @@ Result AudioOutputStreamOpenSLES::requestFlush_l() {
 }
 
 Result AudioOutputStreamOpenSLES::requestStop() {
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
     std::lock_guard<std::mutex> lock(mLock);
+    return requestStop_l();
+}
+
+Result AudioOutputStreamOpenSLES::requestStop_l() {
+    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
 
     StreamState initialState = getState();
     switch (initialState) {

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -61,6 +61,8 @@ private:
 
     Result requestFlush_l();
 
+    Result requestStop_l();
+
     /**
      * Set OpenSL ES PLAYSTATE.
      *

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -61,8 +61,6 @@ private:
 
     Result requestFlush_l();
 
-    Result requestStop_l();
-
     /**
      * Set OpenSL ES PLAYSTATE.
      *

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -313,8 +313,8 @@ int32_t AudioStreamOpenSLES::getBufferDepth(SLAndroidSimpleBufferQueueItf bq) {
     return (result == SL_RESULT_SUCCESS) ? queueState.count : -1;
 }
 
-bool AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq) {
-    bool shouldStopStream = false;
+void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq) {
+    bool stopStream = false;
     // Ask the app callback to process the buffer.
     DataCallbackResult result =
             fireDataCallback(mCallbackBuffer[mCallbackBufferIndex].get(), mFramesPerCallback);
@@ -323,7 +323,7 @@ bool AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
         SLresult enqueueResult = enqueueCallbackBuffer(bq);
         if (enqueueResult != SL_RESULT_SUCCESS) {
             LOGE("%s() returned %d", __func__, enqueueResult);
-            shouldStopStream = true;
+            stopStream = true;
         }
         // Update Oboe client position with frames handled by the callback.
         if (getDirection() == Direction::Input) {
@@ -333,15 +333,15 @@ bool AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
         }
     } else if (result == DataCallbackResult::Stop) {
         LOGD("Oboe callback returned Stop");
-        shouldStopStream = true;
+        stopStream = true;
     } else {
         LOGW("Oboe callback returned unexpected value = %d", result);
-        shouldStopStream = true;
+        stopStream = true;
     }
-    if (shouldStopStream) {
+    if (stopStream) {
+        requestStop();
         mCallbackBufferIndex = 0;
     }
-    return shouldStopStream;
 }
 
 // This callback handler is called every time a buffer has been processed by OpenSL ES.

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -313,8 +313,8 @@ int32_t AudioStreamOpenSLES::getBufferDepth(SLAndroidSimpleBufferQueueItf bq) {
     return (result == SL_RESULT_SUCCESS) ? queueState.count : -1;
 }
 
-void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq) {
-    bool stopStream = false;
+bool AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq) {
+    bool shouldStopStream = false;
     // Ask the app callback to process the buffer.
     DataCallbackResult result =
             fireDataCallback(mCallbackBuffer[mCallbackBufferIndex].get(), mFramesPerCallback);
@@ -323,7 +323,7 @@ void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
         SLresult enqueueResult = enqueueCallbackBuffer(bq);
         if (enqueueResult != SL_RESULT_SUCCESS) {
             LOGE("%s() returned %d", __func__, enqueueResult);
-            stopStream = true;
+            shouldStopStream = true;
         }
         // Update Oboe client position with frames handled by the callback.
         if (getDirection() == Direction::Input) {
@@ -333,20 +333,24 @@ void AudioStreamOpenSLES::processBufferCallback(SLAndroidSimpleBufferQueueItf bq
         }
     } else if (result == DataCallbackResult::Stop) {
         LOGD("Oboe callback returned Stop");
-        stopStream = true;
+        shouldStopStream = true;
     } else {
         LOGW("Oboe callback returned unexpected value = %d", result);
-        stopStream = true;
+        shouldStopStream = true;
     }
-    if (stopStream) {
-        requestStop();
+    if (shouldStopStream) {
         mCallbackBufferIndex = 0;
     }
+    return shouldStopStream;
 }
 
 // This callback handler is called every time a buffer has been processed by OpenSL ES.
 static void bqCallbackGlue(SLAndroidSimpleBufferQueueItf bq, void *context) {
-    (reinterpret_cast<AudioStreamOpenSLES *>(context))->processBufferCallback(bq);
+    bool shouldStopStream = (reinterpret_cast<AudioStreamOpenSLES *>(context))
+            ->processBufferCallback(bq);
+    if (shouldStopStream) {
+        (reinterpret_cast<AudioStreamOpenSLES *>(context))->requestStop();
+    }
 }
 
 SLresult AudioStreamOpenSLES::registerBufferQueueCallback() {

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -67,10 +67,8 @@ public:
      * Called by by OpenSL ES framework.
      *
      * This is public, but don't call it directly.
-     *
-     * @return whether the current stream should be stopped.
      */
-    bool processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
+    void processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
 
     Result waitForStateChange(StreamState currentState,
                               StreamState *nextState,

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -66,6 +66,8 @@ public:
      * Process next OpenSL ES buffer.
      * Called by by OpenSL ES framework.
      *
+     * This is public, but don't call it directly.
+     *
      * @return whether the current stream should be stopped.
      */
     bool processBufferCallback(SLAndroidSimpleBufferQueueItf bq);

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -67,8 +67,10 @@ public:
      * Called by by OpenSL ES framework.
      *
      * This is public, but don't call it directly.
+     *
+     * @return whether the current stream should be stopped.
      */
-    void processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
+    bool processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
 
     Result waitForStateChange(StreamState currentState,
                               StreamState *nextState,

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -66,9 +66,9 @@ public:
      * Process next OpenSL ES buffer.
      * Called by by OpenSL ES framework.
      *
-     * This is public, but don't call it directly.
+     * @return whether the current stream should be stopped.
      */
-    void processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
+    bool processBufferCallback(SLAndroidSimpleBufferQueueItf bq);
 
     Result waitForStateChange(StreamState currentState,
                               StreamState *nextState,


### PR DESCRIPTION
Fixes #1567

If processBufferCallback() is called after setPlayState_l(SL_PLAYSTATE_PLAYING), there could be cases where onAudioReady() is called from two threads.

We should not release the lock just for processBufferCallback(), so there is a minor refactor here. processBufferCallback() now returns a bool and that bool is used to determine whether requestStop_l() should be called.