### PR TITLE
OpenSL ES: Fix getBufferSizeInFrames for non-callback OpenSL ES

### DIFF
--- a/src/opensles/AudioStreamBuffered.cpp
+++ b/src/opensles/AudioStreamBuffered.cpp
@@ -18,6 +18,7 @@
 
 #include "oboe/Oboe.h"
 
+#include "common/OboeDebug.h"
 #include "opensles/AudioStreamBuffered.h"
 #include "common/AudioClock.h"
 
@@ -57,6 +58,7 @@ void AudioStreamBuffered::allocateFifo() {
 
         mFifoBuffer = std::make_unique<FifoBuffer>(getBytesPerFrame(), capacityFrames);
         mBufferCapacityInFrames = capacityFrames;
+        mBufferSizeInFrames = mBufferCapacityInFrames;
     }
 }
 

--- a/tests/testStreamOpen.cpp
+++ b/tests/testStreamOpen.cpp
@@ -432,3 +432,11 @@ TEST_F(StreamOpenInput, AAudioInputSetAttributionTag){
         ASSERT_TRUE(closeStream());
     }
 }
+
+TEST_F(StreamOpenOutput, OutputForOpenSLESPerformanceModeNoneGetBufferSizeInFrames){
+    mBuilder.setPerformanceMode(PerformanceMode::None);
+    mBuilder.setAudioApi(AudioApi::OpenSLES);
+    ASSERT_TRUE(openStream());
+    EXPECT_GT(mStream->getBufferSizeInFrames(), 0);
+    ASSERT_TRUE(closeStream());
+}


### PR DESCRIPTION
Fixes #1581

New test fails on all devices on all Android versions before tests.

This test passes after the change.