### PR TITLE
fxlab: Restore effect UI when placement changes and on screen rotation

### DIFF
--- a/apps/fxlab/app/build.gradle
+++ b/apps/fxlab/app/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId "com.mobileer.androidfxlab"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/apps/fxlab/app/src/main/AndroidManifest.xml
+++ b/apps/fxlab/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name="com.mobileer.androidfxlab.MainActivity">
+        <activity android:name="com.mobileer.androidfxlab.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/apps/fxlab/app/src/main/AndroidManifest.xml
+++ b/apps/fxlab/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity android:name="com.mobileer.androidfxlab.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/apps/fxlab/app/src/main/java/com/mobileer/androidfxlab/EffectsAdapter.kt
+++ b/apps/fxlab/app/src/main/java/com/mobileer/androidfxlab/EffectsAdapter.kt
@@ -92,8 +92,9 @@ object EffectsAdapter :
                 minLabelView.text = floatFormat.format(param.minValue)
                 maxLabelView.text = floatFormat.format(param.maxValue)
                 seekBar.progress =
-                    ((param.defaultValue - param.minValue) * 100 / (param.maxValue - param.minValue)).toInt()
-                curLabelView.text = floatFormat.format(param.defaultValue)
+                    ((effectList[index].paramValues[counter] - param.minValue) * 100 / (param.maxValue
+                            - param.minValue)).toInt()
+                curLabelView.text = floatFormat.format(effectList[index].paramValues[counter])
                 // Bind param listeners to effects
                 seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
                     val paramInd = counter

--- a/apps/fxlab/build.gradle
+++ b/apps/fxlab/build.gradle
@@ -17,14 +17,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta02'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/apps/fxlab/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/fxlab/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
This PR fixes two bugs relating to fxlab settings not being persistent.
1. Using effectList[index].paramValues[counter] instead of param.defaultValue allows UI to restore on placement swaps.
2. Adding android:configChanges="orientation|screenSize|keyboardHidden" allows effects to stay and audio engine to not be restarted when screen is rotated.

Fixes #1120
Fixes #834