### PR TITLE
Quirks: Include Vivo and check for Oboe workaround flag

### DIFF
--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -223,11 +223,11 @@ bool QuirksManager::isConversionNeeded(
         conversionNeeded = true;
     }
 
-    // If a SAMPLE RATE is specified for low latency then let the native code choose an optimal rate.
+    // If a SAMPLE RATE is specified for low latency, let the native code choose an optimal rate.
+    // This isn't really a workaround. It is an Oboe feature that is convenient to place here.
     // TODO There may be a problem if the devices supports low latency
     //      at a higher rate than the default.
-    if (OboeGlobals::areWorkaroundsEnabled()
-            && builder.getSampleRate() != oboe::Unspecified
+    if (builder.getSampleRate() != oboe::Unspecified
             && builder.getSampleRateConversionQuality() != SampleRateConversionQuality::None
             && isLowLatency
             ) {
@@ -249,7 +249,7 @@ bool QuirksManager::isConversionNeeded(
         LOGI("QuirksManager::%s() forcing internal format to I16 for low latency", __func__);
     }
 
-    // Add quirk for float output on API <21
+    // Add quirk for float output when needed.
     if (OboeGlobals::areWorkaroundsEnabled()
             && isFloat
             && !isInput

--- a/src/common/QuirksManager.cpp
+++ b/src/common/QuirksManager.cpp
@@ -62,7 +62,7 @@ bool QuirksManager::DeviceQuirks::isAAudioMMapPossible(const AudioStreamBuilder 
             && builder.getChannelCount() <= kChannelCountStereo;
 }
 
-bool QuirksManager::DeviceQuirks::shouldConvertFloatToI16() {
+bool QuirksManager::DeviceQuirks::shouldConvertFloatToI16ForOutputStreams() {
     std::string productManufacturer = getPropertyString("ro.product.manufacturer");
     if (getSdkVersion() < __ANDROID_API_L__) {
         return true;
@@ -254,7 +254,7 @@ bool QuirksManager::isConversionNeeded(
             && isFloat
             && !isInput
             && builder.isFormatConversionAllowed()
-            && mDeviceQuirks->shouldConvertFloatToI16()
+            && mDeviceQuirks->shouldConvertFloatToI16ForOutputStreams()
             ) {
         childBuilder.setFormat(AudioFormat::I16);
         conversionNeeded = true;

--- a/src/common/QuirksManager.h
+++ b/src/common/QuirksManager.h
@@ -106,6 +106,9 @@ public:
             return true;
         }
 
+        // On some devices, Float does not work so it should be converted to I16.
+        static bool shouldConvertFloatToI16();
+
         static constexpr int32_t kDefaultBottomMarginInBursts = 0;
         static constexpr int32_t kDefaultTopMarginInBursts = 0;
 

--- a/src/common/QuirksManager.h
+++ b/src/common/QuirksManager.h
@@ -107,7 +107,7 @@ public:
         }
 
         // On some devices, Float does not work so it should be converted to I16.
-        static bool shouldConvertFloatToI16();
+        static bool shouldConvertFloatToI16ForOutputStreams();
 
         static constexpr int32_t kDefaultBottomMarginInBursts = 0;
         static constexpr int32_t kDefaultTopMarginInBursts = 0;


### PR DESCRIPTION
Fixes #201
Fixes #1589

I don't have a Vivo to test this.

I did test Oboe workarounds in OboeTester on a Pixel phone.