### PR TITLE
Add API to set sleep time before close.

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -533,6 +533,10 @@ protected:
         mDataCallbackEnabled = enabled;
     }
 
+    /**
+     * This should only be called as a stream is being opened.
+     * Otherwise we might override setDelayBeforeCloseMillis().
+     */
     void calculateDefaultDelayBeforeCloseMillis();
 
     /**

--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 6
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 2
+#define OBOE_VERSION_PATCH 3
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -117,9 +117,12 @@ private:
      */
     void launchStopThread();
 
-    // Time to sleep in order to prevent a race condition with a callback after a close().
-    // Two milliseconds may be enough but 10 msec is even safer.
-    static constexpr int kDelayBeforeCloseMillis = 10;
+public:
+    int32_t getMDelayBeforeCloseMillis() const;
+
+    void setDelayBeforeCloseMillis(int32_t mDelayBeforeCloseMillis);
+
+private:
 
     std::atomic<bool>    mCallbackThreadEnabled;
     std::atomic<bool>    mStopThreadAllowed{false};

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -196,4 +196,13 @@ ResultWithValue<FrameTimestamp> AudioStream::getTimestamp(clockid_t clockId) {
     }
 }
 
+void AudioStream::calculateDefaultDelayBeforeCloseMillis() {
+    // Calculate delay time before close based on burst duration.
+    // Start with a burst duration then add 1 msec as a safety margin.
+    mDelayBeforeCloseMillis = std::max(kMinDelayBeforeCloseMillis,
+                                       1 + ((mFramesPerBurst * 1000) / getSampleRate()));
+    LOGD("calculateDefaultDelayBeforeCloseMillis() default = %d",
+         static_cast<int>(mDelayBeforeCloseMillis));
+}
+
 } // namespace oboe

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -195,22 +195,10 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
-    result = AudioStreamOpenSLES::registerBufferQueueCallback();
+    result = finishCommonOpen(configItf);
     if (SL_RESULT_SUCCESS != result) {
         goto error;
     }
-
-    result = updateStreamParameters(configItf);
-    if (SL_RESULT_SUCCESS != result) {
-        goto error;
-    }
-
-    oboeResult = configureBufferSizes(mSampleRate);
-    if (Result::OK != oboeResult) {
-        goto error;
-    }
-
-    allocateFifo();
 
     setState(StreamState::Open);
     return Result::OK;

--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -216,6 +216,9 @@ Result AudioInputStreamOpenSLES::close() {
         result = Result::ErrorClosed;
     } else {
         (void) requestStop_l();
+        if (OboeGlobals::areWorkaroundsEnabled()) {
+            sleepBeforeClose();
+        }
         // invalidate any interfaces
         mRecordInterface = nullptr;
         result = AudioStreamOpenSLES::close_l();

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -99,6 +99,30 @@ Result AudioStreamOpenSLES::open() {
     return Result::OK;
 }
 
+
+SLresult AudioStreamOpenSLES::finishCommonOpen(SLAndroidConfigurationItf configItf) {
+    SLresult result = registerBufferQueueCallback();
+    if (SL_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    result = updateStreamParameters(configItf);
+    if (SL_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    Result oboeResult = configureBufferSizes(mSampleRate);
+    if (Result::OK != oboeResult) {
+        return (SLresult) oboeResult;
+    }
+
+    allocateFifo();
+
+    calculateDefaultDelayBeforeCloseMillis();
+
+    return SL_RESULT_SUCCESS;
+}
+
 Result AudioStreamOpenSLES::configureBufferSizes(int32_t sampleRate) {
     LOGD("AudioStreamOpenSLES:%s(%d) initial mFramesPerBurst = %d, mFramesPerCallback = %d",
             __func__, sampleRate, mFramesPerBurst, mFramesPerCallback);

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -78,6 +78,14 @@ public:
 
 protected:
 
+    /**
+     * Finish setting up the stream. Common for INPUT and OUTPUT.
+     *
+     * @param configItf
+     * @return SL_RESULT_SUCCESS if OK.
+     */
+    SLresult finishCommonOpen(SLAndroidConfigurationItf configItf);
+
     // This must be called under mLock.
     Result close_l();
 
@@ -88,20 +96,14 @@ protected:
 
     static SLuint32 getDefaultByteOrder();
 
-    SLresult registerBufferQueueCallback();
-
     int32_t getBufferDepth(SLAndroidSimpleBufferQueueItf bq);
 
     SLresult enqueueCallbackBuffer(SLAndroidSimpleBufferQueueItf bq);
 
     SLresult configurePerformanceMode(SLAndroidConfigurationItf configItf);
 
-    SLresult updateStreamParameters(SLAndroidConfigurationItf configItf);
-
     PerformanceMode convertPerformanceMode(SLuint32 openslMode) const;
     SLuint32 convertPerformanceMode(PerformanceMode oboeMode) const;
-
-    Result configureBufferSizes(int32_t sampleRate);
 
     void logUnsupportedAttributes();
 
@@ -123,6 +125,10 @@ protected:
     MonotonicCounter              mPositionMillis; // for tracking OpenSL ES service position
 
 private:
+    SLresult registerBufferQueueCallback();
+    SLresult updateStreamParameters(SLAndroidConfigurationItf configItf);
+    Result configureBufferSizes(int32_t sampleRate);
+
     std::unique_ptr<uint8_t[]>    mCallbackBuffer[kBufferQueueLength];
     int                           mCallbackBufferIndex = 0;
     std::atomic<StreamState>      mState{StreamState::Uninitialized};

--- a/tests/testStreamClosedMethods.cpp
+++ b/tests/testStreamClosedMethods.cpp
@@ -50,6 +50,43 @@ protected:
         return (s == StreamState::Closed);
     }
 
+    static int64_t getNanoseconds() {
+        struct timespec time;
+        int result = clock_gettime(CLOCK_MONOTONIC, &time);
+        if (result < 0) {
+            return result;
+        }
+        return (time.tv_sec * (int64_t)1e9) + time.tv_nsec;
+    }
+
+    int32_t mElapsedTimeMillis = 0; // used for passing back a value from a test function.
+	// ASSERT_* requires a void return type.
+    void measureCloseTime(int32_t delayMillis) {
+        ASSERT_TRUE(openStream());
+        mStream->setDelayBeforeCloseMillis(delayMillis);
+        ASSERT_EQ(delayMillis, mStream->getDelayBeforeCloseMillis());
+        // Measure time it takes to close.
+        int64_t startTimeMillis = getNanoseconds() / 1e6;
+        ASSERT_TRUE(closeStream());
+        int64_t stopTimeMillis = getNanoseconds() / 1e6;
+        int32_t elapsedTimeMillis = (int32_t)(stopTimeMillis - startTimeMillis);
+        ASSERT_GE(elapsedTimeMillis, delayMillis);
+        mElapsedTimeMillis = elapsedTimeMillis;
+    }
+
+    void testDelayBeforeClose() {
+        const int32_t delayMillis = 100;
+        measureCloseTime(0);
+        int32_t elapsedTimeMillis1 = mElapsedTimeMillis;
+        // Do it again with a longer sleep using setDelayBeforeCloseMillis.
+        // The increase in elapsed time should match the added delay.
+        measureCloseTime(delayMillis);
+        int32_t elapsedTimeMillis2 = mElapsedTimeMillis;
+        int32_t extraElapsedTime = elapsedTimeMillis2 - elapsedTimeMillis1;
+        // Expect the additional elapsed time to be close to the added delay.
+        ASSERT_LE(abs(extraElapsedTime - delayMillis), delayMillis / 5);
+    }
+
     AudioStreamBuilder mBuilder;
     AudioStream       *mStream = nullptr;
 
@@ -335,4 +372,30 @@ TEST_F(StreamClosedReturnValues, WriteReturnsClosed){
     int buffer[8]{0};
     auto r = mStream->write(buffer, 1, 0);
     ASSERT_EQ(r.error(), Result::ErrorClosed);
+}
+
+TEST_F(StreamClosedReturnValues, DelayBeforeCloseInput){
+    if (AudioStreamBuilder::isAAudioRecommended()) {
+        mBuilder.setDirection(Direction::Input);
+        testDelayBeforeClose();
+    }
+}
+
+TEST_F(StreamClosedReturnValues, DelayBeforeCloseOutput){
+    if (AudioStreamBuilder::isAAudioRecommended()) {
+        mBuilder.setDirection(Direction::Output);
+        testDelayBeforeClose();
+    }
+}
+
+TEST_F(StreamClosedReturnValues, DelayBeforeCloseInputOpenSL){
+    mBuilder.setAudioApi(AudioApi::OpenSLES);
+    mBuilder.setDirection(Direction::Input);
+    testDelayBeforeClose();
+}
+
+TEST_F(StreamClosedReturnValues, DelayBeforeCloseOutputOpenSL){
+    mBuilder.setAudioApi(AudioApi::OpenSLES);
+    mBuilder.setDirection(Direction::Output);
+    testDelayBeforeClose();
 }


### PR DESCRIPTION
Add: AudioStream::setDelayBeforeCloseMillis(delay)

This can be used to avoid use-after-free bugs
cause by callbacks running when close is called.

Fixes #1500