### PR TITLE
OboeTester: use 2 burst min for glitch test

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -257,6 +257,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             // Set output size to a level that will avoid glitches.
             AudioStreamBase outStream = mAudioOutTester.getCurrentAudioStream();
             int sizeFrames = outStream.getBufferCapacityInFrames() / 2;
+            sizeFrames = Math.max(sizeFrames, 2 * outStream.getFramesPerBurst());
             outStream.setBufferSizeInFrames(sizeFrames);
             AudioStreamBase inStream = mAudioInputTester.getCurrentAudioStream();
             log("  " + getConfigText(actualInConfig));


### PR DESCRIPTION
Was using 1/2 capacity, which is sometimes only one burst.

Fixes #1560