### PR TITLE
OboeTester: Hide mmap settings if not enabled after stream stop.

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -327,9 +327,9 @@ public class StreamConfigurationView extends LinearLayout {
 
     public void setChildrenEnabled(boolean enabled) {
         mNativeApiSpinner.setEnabled(enabled);
-        mRequestedMMapView.setEnabled(enabled);
         mPerformanceSpinner.setEnabled(enabled);
-        mRequestedExclusiveView.setEnabled(enabled);
+        mRequestedMMapView.setEnabled(enabled && NativeEngine.isMMapSupported());
+        mRequestedExclusiveView.setEnabled(enabled && NativeEngine.isMMapExclusiveSupported());
         mChannelConversionBox.setEnabled(enabled);
         mFormatConversionBox.setEnabled(enabled);
         mChannelCountSpinner.setEnabled(enabled);


### PR DESCRIPTION
Fixes #1428

I tested that changes work as expected on Pixel 6 after changing mmap settings.