### PR TITLE
OboeTester: Add ability to add audio effects from stream configs

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
@@ -204,8 +204,4 @@ public class EchoActivity extends TestInputActivity {
     boolean isOutput() {
         return false;
     }
-
-    @Override
-    public void setupEffects(int sessionId) {
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -365,10 +365,6 @@ public class GlitchActivity extends AnalyzerActivity {
         return false;
     }
 
-    @Override
-    public void setupEffects(int sessionId) {
-    }
-
     public double getMaxSecondsWithNoGlitch() {
         return mGlitchSniffer.getMaxSecondsWithNoGlitch();
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
@@ -444,8 +444,4 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
     boolean isOutput() {
         return false;
     }
-
-    @Override
-    public void setupEffects(int sessionId) {
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -512,6 +512,7 @@ public class StreamConfigurationView extends LinearLayout {
             mLoudnessEnhancer = new LoudnessEnhancer(sessionId);
             mLoudnessEnhancer.setTargetGain((short) mLoudnessEnhancerSeekBar.getProgress());
         } else {
+            // If AEC is not available, the checkbox will be disabled in initializeViews().
             if (mAcousticEchoCanceler.getEnabled()) {
                 mAcousticEchoCanceler = AcousticEchoCanceler.create(sessionId);
                 if (mAcousticEchoCanceler != null) {
@@ -520,6 +521,7 @@ public class StreamConfigurationView extends LinearLayout {
                     Log.e(TAG, String.format("Could not create AcousticEchoCanceler"));
                 }
             }
+            // If AGC is not available, the checkbox will be disabled in initializeViews().
             if (mAutomaticGainControl.getEnabled()) {
                 mAutomaticGainControl = AutomaticGainControl.create(sessionId);
                 if (mAutomaticGainControl != null) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -28,6 +28,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TableRow;
@@ -255,6 +256,18 @@ public class StreamConfigurationView extends LinearLayout {
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
+            }
+        });
+
+        mAutomaticGainControlCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                onAutomaticGainControlCheckBoxChanged(isChecked);
+            }
+        });
+
+        mAcousticEchoCancelerCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                onAcousticEchoCancelerCheckBoxChanged(isChecked);
             }
         });
 
@@ -513,19 +526,19 @@ public class StreamConfigurationView extends LinearLayout {
             mLoudnessEnhancer.setTargetGain((short) mLoudnessEnhancerSeekBar.getProgress());
         } else {
             // If AEC is not available, the checkbox will be disabled in initializeViews().
-            if (mAcousticEchoCanceler.getEnabled()) {
+            if (mAcousticEchoCancelerCheckBox.isEnabled()) {
                 mAcousticEchoCanceler = AcousticEchoCanceler.create(sessionId);
                 if (mAcousticEchoCanceler != null) {
-                    mAcousticEchoCanceler.setEnabled(mAcousticEchoCancelerCheckBox.isEnabled());
+                    mAcousticEchoCanceler.setEnabled(mAcousticEchoCancelerCheckBox.isChecked());
                 } else {
                     Log.e(TAG, String.format("Could not create AcousticEchoCanceler"));
                 }
             }
             // If AGC is not available, the checkbox will be disabled in initializeViews().
-            if (mAutomaticGainControl.getEnabled()) {
+            if (mAutomaticGainControlCheckBox.isEnabled()) {
                 mAutomaticGainControl = AutomaticGainControl.create(sessionId);
                 if (mAutomaticGainControl != null) {
-                    mAutomaticGainControl.setEnabled(mAutomaticGainControlCheckBox.isEnabled());
+                    mAutomaticGainControl.setEnabled(mAutomaticGainControlCheckBox.isChecked());
                 } else {
                     Log.e(TAG, String.format("Could not create AutomaticGainControl"));
                 }
@@ -545,5 +558,17 @@ public class StreamConfigurationView extends LinearLayout {
             mBassBoost.setStrength((short) progress);
         }
         mBassBoostTextView.setText("Bass Boost: " + progress);
+    }
+
+    private void onAutomaticGainControlCheckBoxChanged(boolean isChecked) {
+        if (mAutomaticGainControlCheckBox.isEnabled() && mAutomaticGainControl != null) {
+            mAutomaticGainControl.setEnabled(isChecked);
+        }
+    }
+
+    private void onAcousticEchoCancelerCheckBoxChanged(boolean isChecked) {
+        if (mAcousticEchoCancelerCheckBox.isEnabled() && mAcousticEchoCanceler != null) {
+            mAcousticEchoCanceler.setEnabled(isChecked);
+        }
     }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -227,6 +227,9 @@ public class StreamConfigurationView extends LinearLayout {
         mLoudnessEnhancerTextView = (TextView) findViewById(R.id.textLoudnessEnhancer);
         mLoudnessEnhancerSeekBar = (SeekBar) findViewById(R.id.seekBarLoudnessEnhancer);
 
+        mAutomaticGainControlCheckBox.setEnabled(AutomaticGainControl.isAvailable());
+        mAcousticEchoCancelerCheckBox.setEnabled(AcousticEchoCanceler.isAvailable());
+
         mBassBoostSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 onBassBoostSeekBarChanged(progress);
@@ -509,17 +512,21 @@ public class StreamConfigurationView extends LinearLayout {
             mLoudnessEnhancer = new LoudnessEnhancer(sessionId);
             mLoudnessEnhancer.setTargetGain((short) mLoudnessEnhancerSeekBar.getProgress());
         } else {
-            mAcousticEchoCanceler = AcousticEchoCanceler.create(sessionId);
-            if (mAcousticEchoCanceler != null) {
-                mAcousticEchoCanceler.setEnabled(mAcousticEchoCancelerCheckBox.isEnabled());
-            } else {
-                Log.e(TAG, String.format("Could not create AcousticEchoCanceler"));
+            if (mAcousticEchoCanceler.getEnabled()) {
+                mAcousticEchoCanceler = AcousticEchoCanceler.create(sessionId);
+                if (mAcousticEchoCanceler != null) {
+                    mAcousticEchoCanceler.setEnabled(mAcousticEchoCancelerCheckBox.isEnabled());
+                } else {
+                    Log.e(TAG, String.format("Could not create AcousticEchoCanceler"));
+                }
             }
-            mAutomaticGainControl = AutomaticGainControl.create(sessionId);
-            if (mAutomaticGainControl != null) {
-                mAutomaticGainControl.setEnabled(mAutomaticGainControlCheckBox.isEnabled());
-            } else {
-                Log.e(TAG, String.format("Could not create AutomaticGainControl"));
+            if (mAutomaticGainControl.getEnabled()) {
+                mAutomaticGainControl = AutomaticGainControl.create(sessionId);
+                if (mAutomaticGainControl != null) {
+                    mAutomaticGainControl.setEnabled(mAutomaticGainControlCheckBox.isEnabled());
+                } else {
+                    Log.e(TAG, String.format("Could not create AutomaticGainControl"));
+                }
             }
         }
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -558,7 +558,11 @@ abstract class TestAudioActivity extends Activity {
         int sessionId = actualConfig.getSessionId();
         if (streamContext.configurationView != null) {
             if (sessionId > 0) {
-                streamContext.configurationView.setupEffects(sessionId);
+                try {
+                    streamContext.configurationView.setupEffects(sessionId);
+                } catch (Exception e) {
+                    showErrorToast(e.getMessage());
+                }
             }
             streamContext.configurationView.updateDisplay(streamContext.tester.actualConfiguration);
         }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -436,8 +436,6 @@ abstract class TestAudioActivity extends Activity {
         }
     }
 
-    abstract public void setupEffects(int sessionId);
-
     protected void showErrorToast(String message) {
         String text = "Error: " + message;
         Log.e(TAG, text);
@@ -558,10 +556,10 @@ abstract class TestAudioActivity extends Activity {
         mSampleRate = actualConfig.getSampleRate();
         mAudioState = AUDIO_STATE_OPEN;
         int sessionId = actualConfig.getSessionId();
-        if (sessionId > 0) {
-            setupEffects(sessionId);
-        }
         if (streamContext.configurationView != null) {
+            if (sessionId > 0) {
+                streamContext.configurationView.setupEffects(sessionId);
+            }
             streamContext.configurationView.updateDisplay(streamContext.tester.actualConfiguration);
         }
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
@@ -104,10 +104,6 @@ public class TestDisconnectActivity extends TestAudioActivity {
         return true;
     }
 
-    @Override
-    public void setupEffects(int sessionId) {
-    }
-
     private void updateFailSkipButton(final boolean running) {
         runOnUiThread(new Runnable() {
             @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
@@ -144,20 +144,6 @@ public class TestInputActivity  extends TestAudioActivity {
         showToast("Pause not implemented. Returned " + result);
     }
 
-
-    public void setupAGC(int sessionId) {
-        AutomaticGainControl effect =  AutomaticGainControl.create(sessionId);
-    }
-
-    public void setupAEC(int sessionId) {
-        AcousticEchoCanceler effect =  AcousticEchoCanceler.create(sessionId);
-    }
-
-    @Override
-    public void setupEffects(int sessionId) {
-        setupAEC(sessionId);
-    }
-
     protected int saveWaveFile(File file) {
         // Pass filename to native to write WAV file
         int result = saveWaveFile(file.getAbsolutePath());

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestOutputActivityBase.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestOutputActivityBase.java
@@ -56,30 +56,4 @@ abstract class TestOutputActivityBase extends TestAudioActivity {
             mBufferSizeView.onStreamOpened((OboeAudioStream) mAudioOutTester.getCurrentAudioStream());
         }
     }
-
-    // TODO Add editor
-    public void setupEqualizer(int sessionId) {
-        Equalizer equalizer = new Equalizer(0, sessionId);
-        int numBands = equalizer.getNumberOfBands();
-        Log.d(TAG, "numBands " + numBands);
-        for (short band = 0; band < numBands; band++) {
-            String msg = "band " + band
-                    + ", center = " + equalizer.getCenterFreq(band)
-                    + ", level = " + equalizer.getBandLevel(band);
-            Log.d(TAG, msg);
-            equalizer.setBandLevel(band, (short)40);
-        }
-
-        equalizer.setBandLevel((short) 1, (short) 300);
-    }
-
-    public void setupReverb(int sessionId) {
-        PresetReverb effect = new PresetReverb(0, sessionId);
-    }
-
-    @Override
-    public void setupEffects(int sessionId) {
-        // setupEqualizer(sessionId);
-        // setupReverb(sessionId);
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestPlugLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestPlugLatencyActivity.java
@@ -139,10 +139,6 @@ public class TestPlugLatencyActivity extends TestAudioActivity {
         return true;
     }
 
-    @Override
-    public void setupEffects(int sessionId) {
-    }
-
     // Write to status and command view
     private void setInstructionsText(final String text) {
         runOnUiThread(new Runnable() {

--- a/apps/OboeTester/app/src/main/res/layout/stream_config.xml
+++ b/apps/OboeTester/app/src/main/res/layout/stream_config.xml
@@ -293,6 +293,63 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/inputEffects"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone">
+
+            <CheckBox
+                android:id="@+id/checkBoxAutomaticGainControl"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Automatic Gain Control" />
+
+            <CheckBox
+                android:id="@+id/checkBoxAcousticEchoCanceler"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Acoustic Echo Canceler" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/outputEffects"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/textBassBoost"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Bass Boost" />
+
+            <SeekBar
+                android:id="@+id/seekBarBassBoost"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="1000"
+                android:progress="0" />
+
+            <TextView
+                android:id="@+id/textLoudnessEnhancer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Loudness Enhancer" />
+
+            <SeekBar
+                android:id="@+id/seekBarLoudnessEnhancer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="5000"
+                android:progress="0" />
+        </LinearLayout>
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">


### PR DESCRIPTION
Currently, java audio effects are neither stable nor easily testable. This PR adds some basic audio effects to audio stream configs. This way, audio effects can be added to most existing tests.

Fixes #1527

Below are some screenshots:

![Screenshot_20220829-164128](https://user-images.githubusercontent.com/85952307/187317795-720c3e03-1076-4e2d-8e62-f9bb689c962f.png)
![Screenshot_20220829-164116](https://user-images.githubusercontent.com/85952307/187317803-c8f7edb2-f7d3-4324-9e19-015fa3c85b3e.png)
