### PR TITLE
OboeTester: Glitch Activity should read from intended input channel

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -123,7 +123,7 @@ public:
     result_code processInputFrame(const float *frameData, int /* channelCount */) override {
         result_code result = RESULT_OK;
 
-        float sample = frameData[0];
+        float sample = frameData[getInputChannel()];
         float peak = mPeakFollower.process(sample);
         mInfiniteRecording.write(sample);
 


### PR DESCRIPTION
Instead of always reading from the first channel, we should read from the channel intended by the test with setInputChannel().

This code does not cause any issues currently as only setInputChannel(0) is ever called. However, we should still change fix this.