### PR TITLE
OboeTester: Add instructions for channel mask automated testing

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
@@ -67,7 +67,8 @@ public class IntentBasedTestSupport {
     public static final String VALUE_VOLUME_TYPE_SYSTEM = "system";
     public static final String VALUE_VOLUME_TYPE_VOICE_CALL = "voice_call";
 
-    public static final String KEY_CHANNEL_MASK = "channel_mask";
+    public static final String KEY_IN_CHANNEL_MASK = "in_channel_mask";
+    public static final String KEY_OUT_CHANNEL_MASK = "out_channel_mask";
     public static final String VALUE_CHANNEL_MONO = "mono";
     public static final String VALUE_CHANNEL_STEREO = "stereo";
     public static final String VALUE_CHANNEL_2POINT1 = "2.1";
@@ -79,11 +80,11 @@ public class IntentBasedTestSupport {
     public static final String VALUE_CHANNEL_3POINT0POINT2 = "3.0.2";
     public static final String VALUE_CHANNEL_3POINT1POINT2 = "3.1.2";
     public static final String VALUE_CHANNEL_QUAD = "quad";
-    public static final String VALUE_CHANNEL_QUAD_SIDE = "quadside";
+    public static final String VALUE_CHANNEL_QUAD_SIDE = "quadSide";
     public static final String VALUE_CHANNEL_SURROUND = "surround";
     public static final String VALUE_CHANNEL_PENTA = "penta";
     public static final String VALUE_CHANNEL_5POINT1 = "5.1";
-    public static final String VALUE_CHANNEL_5POINT1_SIDE = "5.1side";
+    public static final String VALUE_CHANNEL_5POINT1_SIDE = "5.1Side";
     public static final String VALUE_CHANNEL_6POINT1 = "6.1";
     public static final String VALUE_CHANNEL_7POINT1 = "7.1";
     public static final String VALUE_CHANNEL_5POINT1POINT2 = "5.1.2";
@@ -173,8 +174,8 @@ public class IntentBasedTestSupport {
         }
     }
 
-    public static int getChannelMaskFromBundle(Bundle bundle) {
-        String channelMaskText = bundle.getString(KEY_CHANNEL_MASK);
+    public static int getChannelMaskFromBundle(Bundle bundle, String channelMaskKey) {
+        String channelMaskText = bundle.getString(channelMaskKey);
         if (channelMaskText == null) {
             return StreamConfiguration.UNSPECIFIED;
         }
@@ -231,7 +232,7 @@ public class IntentBasedTestSupport {
                 return StreamConfiguration.CHANNEL_FRONT_BACK;
             default:
                 throw new IllegalArgumentException(
-                        KEY_CHANNEL_MASK + " invalid: " + channelMaskText);
+                        channelMaskKey + " invalid: " + channelMaskText);
         }
     }
 
@@ -250,7 +251,7 @@ public class IntentBasedTestSupport {
         requestedOutConfig.setNativeApi(audioApi);
 
         int outChannels = bundle.getInt(KEY_OUT_CHANNELS, VALUE_DEFAULT_CHANNELS);
-        int channelMask = getChannelMaskFromBundle(bundle);
+        int channelMask = getChannelMaskFromBundle(bundle, KEY_OUT_CHANNEL_MASK);
         // Respect channel mask when it is specified.
         if (channelMask != StreamConfiguration.UNSPECIFIED) {
             requestedOutConfig.setChannelMask(channelMask);
@@ -286,7 +287,7 @@ public class IntentBasedTestSupport {
         requestedInConfig.setNativeApi(audioApi);
 
         int inChannels = bundle.getInt(KEY_IN_CHANNELS, VALUE_DEFAULT_CHANNELS);
-        int channelMask = getChannelMaskFromBundle(bundle);
+        int channelMask = getChannelMaskFromBundle(bundle, KEY_IN_CHANNEL_MASK);
         // Respect channel mask when it is specified.
         if (channelMask != StreamConfiguration.UNSPECIFIED) {
             requestedInConfig.setChannelMask(channelMask);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
@@ -74,6 +74,7 @@ public class IntentBasedTestSupport {
     public static final String VALUE_CHANNEL_2POINT1 = "2.1";
     public static final String VALUE_CHANNEL_TRI = "tri";
     public static final String VALUE_CHANNEL_TRI_BACK = "triBack";
+    public static final String VALUE_CHANNEL_TRI_BACK_LOWERCASE = "triback";
     public static final String VALUE_CHANNEL_3POINT1 = "3.1";
     public static final String VALUE_CHANNEL_2POINT0POINT2 = "2.0.2";
     public static final String VALUE_CHANNEL_2POINT1POINT2 = "2.1.2";
@@ -81,10 +82,12 @@ public class IntentBasedTestSupport {
     public static final String VALUE_CHANNEL_3POINT1POINT2 = "3.1.2";
     public static final String VALUE_CHANNEL_QUAD = "quad";
     public static final String VALUE_CHANNEL_QUAD_SIDE = "quadSide";
+    public static final String VALUE_CHANNEL_QUAD_SIDE_LOWERCASE = "quadside";
     public static final String VALUE_CHANNEL_SURROUND = "surround";
     public static final String VALUE_CHANNEL_PENTA = "penta";
     public static final String VALUE_CHANNEL_5POINT1 = "5.1";
     public static final String VALUE_CHANNEL_5POINT1_SIDE = "5.1Side";
+    public static final String VALUE_CHANNEL_5POINT1_SIDE_LOWERCASE = "5.1side";
     public static final String VALUE_CHANNEL_6POINT1 = "6.1";
     public static final String VALUE_CHANNEL_7POINT1 = "7.1";
     public static final String VALUE_CHANNEL_5POINT1POINT2 = "5.1.2";
@@ -94,6 +97,7 @@ public class IntentBasedTestSupport {
     public static final String VALUE_CHANNEL_9POINT1POINT4 = "9.1.4";
     public static final String VALUE_CHANNEL_9POINT1POINT6 = "9.1.6";
     public static final String VALUE_CHANNEL_FRONT_BACK = "frontBack";
+    public static final String VALUE_CHANNEL_FRONT_BACK_LOWERCASE = "frontback";
 
     public static final String KEY_SIGNAL_TYPE = "signal_type";
     public static final String VALUE_SIGNAL_SINE = "sine";
@@ -178,62 +182,64 @@ public class IntentBasedTestSupport {
         String channelMaskText = bundle.getString(channelMaskKey);
         if (channelMaskText == null) {
             return StreamConfiguration.UNSPECIFIED;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_MONO)) {
-            return StreamConfiguration.CHANNEL_MONO;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_STEREO)) {
-            return StreamConfiguration.CHANNEL_STEREO;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT1)) {
-            return StreamConfiguration.CHANNEL_2POINT1;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_TRI)) {
-            return StreamConfiguration.CHANNEL_TRI;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_TRI_BACK) ||
-                channelMaskText.equals(VALUE_CHANNEL_TRI_BACK.toLowerCase())) {
-            return StreamConfiguration.CHANNEL_TRI_BACK;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT1)) {
-            return StreamConfiguration.CHANNEL_3POINT1;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT0POINT2)) {
-            return StreamConfiguration.CHANNEL_2POINT0POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT1POINT2)) {
-            return StreamConfiguration.CHANNEL_2POINT1POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT0POINT2)) {
-            return StreamConfiguration.CHANNEL_3POINT0POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT1POINT2)) {
-            return StreamConfiguration.CHANNEL_3POINT1POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_QUAD)) {
-            return StreamConfiguration.CHANNEL_QUAD;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_QUAD_SIDE) ||
-                channelMaskText.equals(VALUE_CHANNEL_QUAD_SIDE.toLowerCase())) {
-            return StreamConfiguration.CHANNEL_QUAD_SIDE;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_SURROUND)) {
-            return StreamConfiguration.CHANNEL_SURROUND;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_PENTA)) {
-            return StreamConfiguration.CHANNEL_PENTA;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1)) {
-            return StreamConfiguration.CHANNEL_5POINT1;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1_SIDE) ||
-                channelMaskText.equals(VALUE_CHANNEL_5POINT1_SIDE.toLowerCase())) {
-            return StreamConfiguration.CHANNEL_5POINT1_SIDE;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_6POINT1)) {
-            return StreamConfiguration.CHANNEL_6POINT1;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1)) {
-            return StreamConfiguration.CHANNEL_7POINT1;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1POINT2)) {
-            return StreamConfiguration.CHANNEL_5POINT1POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1POINT4)) {
-            return StreamConfiguration.CHANNEL_5POINT1POINT4;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1POINT2)) {
-            return StreamConfiguration.CHANNEL_7POINT1POINT2;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1POINT4)) {
-            return StreamConfiguration.CHANNEL_7POINT1POINT4;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_9POINT1POINT4)) {
-            return StreamConfiguration.CHANNEL_9POINT1POINT4;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_9POINT1POINT6)) {
-            return StreamConfiguration.CHANNEL_9POINT1POINT6;
-        } else if (channelMaskText.equals(VALUE_CHANNEL_FRONT_BACK) ||
-                channelMaskText.equals(VALUE_CHANNEL_FRONT_BACK.toLowerCase())) {
-            return StreamConfiguration.CHANNEL_FRONT_BACK;
-        } else {
-            throw new IllegalArgumentException(
+        }
+        switch (channelMaskText) {
+            case VALUE_CHANNEL_MONO:
+                return StreamConfiguration.CHANNEL_MONO;
+            case VALUE_CHANNEL_STEREO:
+                return StreamConfiguration.CHANNEL_STEREO;
+            case VALUE_CHANNEL_2POINT1:
+                return StreamConfiguration.CHANNEL_2POINT1;
+            case VALUE_CHANNEL_TRI:
+                return StreamConfiguration.CHANNEL_TRI;
+            case VALUE_CHANNEL_TRI_BACK:
+            case VALUE_CHANNEL_TRI_BACK_LOWERCASE:
+                return StreamConfiguration.CHANNEL_TRI_BACK;
+            case VALUE_CHANNEL_3POINT1:
+                return StreamConfiguration.CHANNEL_3POINT1;
+            case VALUE_CHANNEL_2POINT0POINT2:
+                return StreamConfiguration.CHANNEL_2POINT0POINT2;
+            case VALUE_CHANNEL_2POINT1POINT2:
+                return StreamConfiguration.CHANNEL_2POINT1POINT2;
+            case VALUE_CHANNEL_3POINT0POINT2:
+                return StreamConfiguration.CHANNEL_3POINT0POINT2;
+            case VALUE_CHANNEL_3POINT1POINT2:
+                return StreamConfiguration.CHANNEL_3POINT1POINT2;
+            case VALUE_CHANNEL_QUAD:
+                return StreamConfiguration.CHANNEL_QUAD;
+            case VALUE_CHANNEL_QUAD_SIDE:
+            case VALUE_CHANNEL_QUAD_SIDE_LOWERCASE:
+                return StreamConfiguration.CHANNEL_QUAD_SIDE;
+            case VALUE_CHANNEL_SURROUND:
+                return StreamConfiguration.CHANNEL_SURROUND;
+            case VALUE_CHANNEL_PENTA:
+                return StreamConfiguration.CHANNEL_PENTA;
+            case VALUE_CHANNEL_5POINT1:
+                return StreamConfiguration.CHANNEL_5POINT1;
+            case VALUE_CHANNEL_5POINT1_SIDE:
+            case VALUE_CHANNEL_5POINT1_SIDE_LOWERCASE:
+                return StreamConfiguration.CHANNEL_5POINT1_SIDE;
+            case VALUE_CHANNEL_6POINT1:
+                return StreamConfiguration.CHANNEL_6POINT1;
+            case VALUE_CHANNEL_7POINT1:
+                return StreamConfiguration.CHANNEL_7POINT1;
+            case VALUE_CHANNEL_5POINT1POINT2:
+                return StreamConfiguration.CHANNEL_5POINT1POINT2;
+            case VALUE_CHANNEL_5POINT1POINT4:
+                return StreamConfiguration.CHANNEL_5POINT1POINT4;
+            case VALUE_CHANNEL_7POINT1POINT2:
+                return StreamConfiguration.CHANNEL_7POINT1POINT2;
+            case VALUE_CHANNEL_7POINT1POINT4:
+                return StreamConfiguration.CHANNEL_7POINT1POINT4;
+            case VALUE_CHANNEL_9POINT1POINT4:
+                return StreamConfiguration.CHANNEL_9POINT1POINT4;
+            case VALUE_CHANNEL_9POINT1POINT6:
+                return StreamConfiguration.CHANNEL_9POINT1POINT6;
+            case VALUE_CHANNEL_FRONT_BACK:
+            case VALUE_CHANNEL_FRONT_BACK_LOWERCASE:
+                return StreamConfiguration.CHANNEL_FRONT_BACK;
+            default:
+                throw new IllegalArgumentException(
                         channelMaskKey + " invalid: " + channelMaskText);
         }
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
@@ -178,60 +178,62 @@ public class IntentBasedTestSupport {
         String channelMaskText = bundle.getString(channelMaskKey);
         if (channelMaskText == null) {
             return StreamConfiguration.UNSPECIFIED;
-        }
-        switch (channelMaskText) {
-            case VALUE_CHANNEL_MONO:
-                return StreamConfiguration.CHANNEL_MONO;
-            case VALUE_CHANNEL_STEREO:
-                return StreamConfiguration.CHANNEL_STEREO;
-            case VALUE_CHANNEL_2POINT1:
-                return StreamConfiguration.CHANNEL_2POINT1;
-            case VALUE_CHANNEL_TRI:
-                return StreamConfiguration.CHANNEL_TRI;
-            case VALUE_CHANNEL_TRI_BACK:
-                return StreamConfiguration.CHANNEL_TRI_BACK;
-            case VALUE_CHANNEL_3POINT1:
-                return StreamConfiguration.CHANNEL_3POINT1;
-            case VALUE_CHANNEL_2POINT0POINT2:
-                return StreamConfiguration.CHANNEL_2POINT0POINT2;
-            case VALUE_CHANNEL_2POINT1POINT2:
-                return StreamConfiguration.CHANNEL_2POINT1POINT2;
-            case VALUE_CHANNEL_3POINT0POINT2:
-                return StreamConfiguration.CHANNEL_3POINT0POINT2;
-            case VALUE_CHANNEL_3POINT1POINT2:
-                return StreamConfiguration.CHANNEL_3POINT1POINT2;
-            case VALUE_CHANNEL_QUAD:
-                return StreamConfiguration.CHANNEL_QUAD;
-            case VALUE_CHANNEL_QUAD_SIDE:
-                return StreamConfiguration.CHANNEL_QUAD_SIDE;
-            case VALUE_CHANNEL_SURROUND:
-                return StreamConfiguration.CHANNEL_SURROUND;
-            case VALUE_CHANNEL_PENTA:
-                return StreamConfiguration.CHANNEL_PENTA;
-            case VALUE_CHANNEL_5POINT1:
-                return StreamConfiguration.CHANNEL_5POINT1;
-            case VALUE_CHANNEL_5POINT1_SIDE:
-                return StreamConfiguration.CHANNEL_5POINT1_SIDE;
-            case VALUE_CHANNEL_6POINT1:
-                return StreamConfiguration.CHANNEL_6POINT1;
-            case VALUE_CHANNEL_7POINT1:
-                return StreamConfiguration.CHANNEL_7POINT1;
-            case VALUE_CHANNEL_5POINT1POINT2:
-                return StreamConfiguration.CHANNEL_5POINT1POINT2;
-            case VALUE_CHANNEL_5POINT1POINT4:
-                return StreamConfiguration.CHANNEL_5POINT1POINT4;
-            case VALUE_CHANNEL_7POINT1POINT2:
-                return StreamConfiguration.CHANNEL_7POINT1POINT2;
-            case VALUE_CHANNEL_7POINT1POINT4:
-                return StreamConfiguration.CHANNEL_7POINT1POINT4;
-            case VALUE_CHANNEL_9POINT1POINT4:
-                return StreamConfiguration.CHANNEL_9POINT1POINT4;
-            case VALUE_CHANNEL_9POINT1POINT6:
-                return StreamConfiguration.CHANNEL_9POINT1POINT6;
-            case VALUE_CHANNEL_FRONT_BACK:
-                return StreamConfiguration.CHANNEL_FRONT_BACK;
-            default:
-                throw new IllegalArgumentException(
+        } else if (channelMaskText.equals(VALUE_CHANNEL_MONO)) {
+            return StreamConfiguration.CHANNEL_MONO;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_STEREO)) {
+            return StreamConfiguration.CHANNEL_STEREO;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT1)) {
+            return StreamConfiguration.CHANNEL_2POINT1;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_TRI)) {
+            return StreamConfiguration.CHANNEL_TRI;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_TRI_BACK) ||
+                channelMaskText.equals(VALUE_CHANNEL_TRI_BACK.toLowerCase())) {
+            return StreamConfiguration.CHANNEL_TRI_BACK;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT1)) {
+            return StreamConfiguration.CHANNEL_3POINT1;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT0POINT2)) {
+            return StreamConfiguration.CHANNEL_2POINT0POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_2POINT1POINT2)) {
+            return StreamConfiguration.CHANNEL_2POINT1POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT0POINT2)) {
+            return StreamConfiguration.CHANNEL_3POINT0POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_3POINT1POINT2)) {
+            return StreamConfiguration.CHANNEL_3POINT1POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_QUAD)) {
+            return StreamConfiguration.CHANNEL_QUAD;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_QUAD_SIDE) ||
+                channelMaskText.equals(VALUE_CHANNEL_QUAD_SIDE.toLowerCase())) {
+            return StreamConfiguration.CHANNEL_QUAD_SIDE;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_SURROUND)) {
+            return StreamConfiguration.CHANNEL_SURROUND;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_PENTA)) {
+            return StreamConfiguration.CHANNEL_PENTA;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1)) {
+            return StreamConfiguration.CHANNEL_5POINT1;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1_SIDE) ||
+                channelMaskText.equals(VALUE_CHANNEL_5POINT1_SIDE.toLowerCase())) {
+            return StreamConfiguration.CHANNEL_5POINT1_SIDE;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_6POINT1)) {
+            return StreamConfiguration.CHANNEL_6POINT1;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1)) {
+            return StreamConfiguration.CHANNEL_7POINT1;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1POINT2)) {
+            return StreamConfiguration.CHANNEL_5POINT1POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_5POINT1POINT4)) {
+            return StreamConfiguration.CHANNEL_5POINT1POINT4;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1POINT2)) {
+            return StreamConfiguration.CHANNEL_7POINT1POINT2;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_7POINT1POINT4)) {
+            return StreamConfiguration.CHANNEL_7POINT1POINT4;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_9POINT1POINT4)) {
+            return StreamConfiguration.CHANNEL_9POINT1POINT4;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_9POINT1POINT6)) {
+            return StreamConfiguration.CHANNEL_9POINT1POINT6;
+        } else if (channelMaskText.equals(VALUE_CHANNEL_FRONT_BACK) ||
+                channelMaskText.equals(VALUE_CHANNEL_FRONT_BACK.toLowerCase())) {
+            return StreamConfiguration.CHANNEL_FRONT_BACK;
+        } else {
+            throw new IllegalArgumentException(
                         channelMaskKey + " invalid: " + channelMaskText);
         }
     }

--- a/apps/OboeTester/docs/AutomatedTesting.md
+++ b/apps/OboeTester/docs/AutomatedTesting.md
@@ -82,8 +82,10 @@ There are several optional parameters in common for glitch, latency, input, and 
     --ei buffer_bursts      {bursts}     // number of bursts in the buffer, 2 for "double buffered"
     --es in_api             {"unspecified", "opensles", "aaudio"}  // native input API, default is "unspecified"
     --es out_api            {"unspecified", "opensles", "aaudio"}  // native output API, default is "unspecified"
-    --ei in_channels        {samples}    // number of input channels, default is 2
-    --ei out_channels       {samples}    // number of output channels, default is 2
+    --es in_channel_mask    {"mono", "stereo", "2.1", "tri", "triBack", "3.1", "2.0.2", "2.1.2", "3.0.2", "3.1.2", "quad", "quadSide", "surround", "penta", "5.1", "5.1Side", "6.1", "7.1", "5.1.2", "5.1.4", "7.1.2", "7.1.4", "9.1.4", "9.1.6", "frontBack"}
+    --es out_channel_mask    {"mono", "stereo", "2.1", "tri", "triBack", "3.1", "2.0.2", "2.1.2", "3.0.2", "3.1.2", "quad", "quadSide", "surround", "penta", "5.1", "5.1Side", "6.1", "7.1", "5.1.2", "5.1.4", "7.1.2", "7.1.4", "9.1.4", "9.1.6", "frontBack"}
+    --ei in_channels        {samples}    // number of input channels, default is 2. This is ignored if in_channel_mask is set.
+    --ei out_channels       {samples}    // number of output channels, default is 2. This is ignored if out_channel_mask is set.
     --ei sample_rate        {hertz}
     --es in_perf            {"none", "lowlat", "powersave"}  // input performance mode, default is "lowlat"
     --es out_perf           {"none", "lowlat", "powersave"}  // output performance mode, default is "lowlat"


### PR DESCRIPTION
This PR adds instructions for channel mask automated testing.

This PR also makes two changes to the intents:
1. Split KEY_CHANNEL_MASK to KEY_IN_CHANNEL_MASK and KEY_OUT_CHANNEL_MASK. This way input and output channel masks can be requested independently.
2. Change quadside and 5.1side to quadSide and 5.1Side. This allows for a consistent capitalization between channel mask strings.
3. For camelCase strings, check for camelCase or lowercase. For example, both quadSide and quadside will work.