### PR TITLE
OpenSL ES: Check zero buffer depth and enqueue before setRecordState for input streams

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -264,12 +264,16 @@ Result AudioInputStreamOpenSLES::requestStart() {
     setDataCallbackEnabled(true);
 
     setState(StreamState::Starting);
-    Result result = setRecordState_l(SL_RECORDSTATE_RECORDING);
-    if (result == Result::OK) {
-        setState(StreamState::Started);
+
+    if (getBufferDepth(mSimpleBufferQueueInterface) == 0) {
         // Enqueue the first buffer to start the streaming.
         // This does not call the callback function.
         enqueueCallbackBuffer(mSimpleBufferQueueInterface);
+    }
+
+    Result result = setRecordState_l(SL_RECORDSTATE_RECORDING);
+    if (result == Result::OK) {
+        setState(StreamState::Started);
     } else {
         setState(initialState);
     }


### PR DESCRIPTION
This PR does 2 things:
1. Check buffer depth before enqueuing for input streams. This is the input equivalent of #625.
2. Queue an callback buffer before setting record state to recording. This is the input equivalent of #1570.

Fixes #1431