### PR TITLE
resampler fix glitch in some configurations

### DIFF
--- a/src/flowgraph/resampler/MultiChannelResampler.cpp
+++ b/src/flowgraph/resampler/MultiChannelResampler.cpp
@@ -40,7 +40,7 @@ MultiChannelResampler::MultiChannelResampler(const MultiChannelResampler::Builde
     ratio.reduce();
     mNumerator = ratio.getNumerator();
     mDenominator = ratio.getDenominator();
-    mIntegerPhase = mDenominator;
+    mIntegerPhase = mDenominator; // so we start with a write needed
 }
 
 // static factory method

--- a/src/flowgraph/resampler/SincResampler.cpp
+++ b/src/flowgraph/resampler/SincResampler.cpp
@@ -42,27 +42,27 @@ void SincResampler::readFrame(float *frame) {
 
     // Determine indices into coefficients table.
     double tablePhase = getIntegerPhase() * mPhaseScaler;
-    int index1 = static_cast<int>(floor(tablePhase));
-    int index2 = index1 + 1; // OK because using a guard row.
-    assert (index2 < mNumRows);
-    float *coefficients1 = &mCoefficients[static_cast<size_t>(index1)
-            * static_cast<size_t>(getNumTaps())];
-    float *coefficients2 = &mCoefficients[static_cast<size_t>(index2)
-            * static_cast<size_t>(getNumTaps())];
+    int indexLow = static_cast<int>(floor(tablePhase));
+    int indexHigh = indexLow + 1; // OK because using a guard row.
+    assert (indexHigh < mNumRows);
+    float *coefficientsLow = &mCoefficients[static_cast<size_t>(indexLow)
+                                            * static_cast<size_t>(getNumTaps())];
+    float *coefficientsHigh = &mCoefficients[static_cast<size_t>(indexHigh)
+                                             * static_cast<size_t>(getNumTaps())];
 
     float *xFrame = &mX[static_cast<size_t>(mCursor) * static_cast<size_t>(getChannelCount())];
-    for (int i = 0; i < mNumTaps; i++) {
-        float coefficient1 = *coefficients1++;
-        float coefficient2 = *coefficients2++;
+    for (int tap = 0; tap < mNumTaps; tap++) {
+        float coefficientLow = *coefficientsLow++;
+        float coefficientHigh = *coefficientsHigh++;
         for (int channel = 0; channel < getChannelCount(); channel++) {
             float sample = *xFrame++;
-            mSingleFrame[channel]  += sample * coefficient1;
-            mSingleFrame2[channel] += sample * coefficient2;
+            mSingleFrame[channel] += sample * coefficientLow;
+            mSingleFrame2[channel] += sample * coefficientHigh;
         }
     }
 
     // Interpolate and copy to output.
-    float fraction = tablePhase - index1;
+    float fraction = tablePhase - indexLow;
     for (int channel = 0; channel < getChannelCount(); channel++) {
         float low = mSingleFrame[channel];
         float high = mSingleFrame2[channel];

--- a/src/flowgraph/resampler/SincResamplerStereo.cpp
+++ b/src/flowgraph/resampler/SincResamplerStereo.cpp
@@ -57,9 +57,7 @@ void SincResamplerStereo::readFrame(float *frame) {
     float *coefficients1 = &mCoefficients[static_cast<size_t>(index1)
             * static_cast<size_t>(getNumTaps())];
     int index2 = (index1 + 1);
-    if (index2 >= mNumRows) { // no guard row needed because we wrap the indices
-        index2 = 0;
-    }
+    assert (index2 < mNumRows);
     float *coefficients2 = &mCoefficients[static_cast<size_t>(index2)
             * static_cast<size_t>(getNumTaps())];
     float *xFrame = &mX[static_cast<size_t>(mCursor) * static_cast<size_t>(getChannelCount())];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
 		testOboe
 		testAAudio.cpp
 		testFlowgraph.cpp
+		testResampler.cpp
 		testReturnStop.cpp
 		testStreamClosedMethods.cpp
 		testStreamFramesProcessed.cpp

--- a/tests/testFlowgraph.cpp
+++ b/tests/testFlowgraph.cpp
@@ -18,9 +18,8 @@
  * Test FlowGraph
  */
 
+#include "math.h"
 #include "stdio.h"
-
-#include <iostream>
 
 #include <gtest/gtest.h>
 #include <oboe/Oboe.h>
@@ -29,7 +28,6 @@
 #include "flowgraph/MonoToMultiConverter.h"
 #include "flowgraph/SourceFloat.h"
 #include "flowgraph/RampLinear.h"
-#include "flowgraph/SampleRateConverter.h"
 #include "flowgraph/SinkFloat.h"
 #include "flowgraph/SinkI16.h"
 #include "flowgraph/SinkI24.h"

--- a/tests/testResampler.cpp
+++ b/tests/testResampler.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test FlowGraph
+ */
+
+#include "math.h"
+#include "stdio.h"
+
+#include <gtest/gtest.h>
+#include <oboe/Oboe.h>
+
+#include "flowgraph/resampler/MultiChannelResampler.h"
+
+using namespace oboe::resampler;
+
+// Measure zero crossings.
+static int32_t countZeroCrossingsWithHysteresis(float *input, int32_t numSamples) {
+    const float kHysteresisLevel = 0.25f;
+    int zeroCrossingCount = 0;
+    bool armed = false;
+    for (int i = 0; i < numSamples; i++) {
+        if (!armed && input[i] >= kHysteresisLevel) {
+            zeroCrossingCount++;
+            armed = true;
+        } else if (armed && input[i] <= -kHysteresisLevel) {
+            zeroCrossingCount++;
+            armed = false;
+        }
+    }
+    return zeroCrossingCount;
+}
+
+static constexpr int kChannelCount = 1;
+
+/**
+ * Convert a sine wave and then look for glitches.
+ * Glitches have a high value in the second derivative.
+ */
+static void checkResampler(int32_t sourceRate, int32_t sinkRate,
+        MultiChannelResampler::Quality quality) {
+    const int kNumOutputSamples = 10000;
+    const double kSinFrequency = 440.0;
+
+    int numInputSamples = kNumOutputSamples * sourceRate / sinkRate;
+
+    std::unique_ptr<float[]>  inputBuffer = std::make_unique<float[]>(numInputSamples);
+    std::unique_ptr<float[]>  outputBuffer = std::make_unique<float[]>(kNumOutputSamples);
+
+    // Generate a sine wave for input.
+    const double kPhaseIncrement = kSinFrequency * 2.0 / sourceRate;
+    double phase = 0.0;
+    for (int i = 0; i < numInputSamples; i++) {
+        inputBuffer[i] = sin(phase * M_PI);
+        phase += kPhaseIncrement;
+        if (phase > 1.0) phase -= 2.0;
+    }
+    int sourceZeroCrossingCount = countZeroCrossingsWithHysteresis(inputBuffer.get(), numInputSamples);
+
+    // Use a MultiChannelResampler to convert from the sourceRate to the sinkRate.
+    std::unique_ptr<MultiChannelResampler>  mcResampler;
+    mcResampler.reset(MultiChannelResampler::make(kChannelCount,
+                                                 sourceRate,
+                                                 sinkRate,
+                                                 quality));
+    int inputFramesLeft = numInputSamples;
+    int numRead = 0;
+    float *input = inputBuffer.get(); // for iteration
+    float *output = outputBuffer.get();
+    while (inputFramesLeft > 0) {
+        if(mcResampler->isWriteNeeded()) {
+            mcResampler->writeNextFrame(input);
+            input++;
+            inputFramesLeft--;
+        } else {
+            mcResampler->readNextFrame(output);
+            output++;
+            numRead++;
+        }
+    }
+
+    ASSERT_LE(numRead, kNumOutputSamples);
+    EXPECT_GT(numRead, kNumOutputSamples - 16);
+
+    int sinkZeroCrossingCount = countZeroCrossingsWithHysteresis(outputBuffer.get(), numRead);
+    EXPECT_LE(abs(sourceZeroCrossingCount - sinkZeroCrossingCount), 2);
+
+    // Detect glitches by looking for spikes in the second derivative.
+    output = outputBuffer.get();
+    float previousValue = output[0];
+    float previousSlope = output[1] - output[0];
+    for (int i = 0; i < numRead; i++) {
+        float slope = output[i] - previousValue;
+        float slopeDelta = fabs(slope - previousSlope);
+        // Skip a few samples because there are often some steep slope changes at the beginning.
+        if (i > 10) {
+            EXPECT_LT(slopeDelta, 0.1);
+        }
+        previousValue = output[i];
+        previousSlope = slope;
+    }
+
+#if 1
+    // Save to disk for inspection.
+    FILE *fp = fopen( "/sdcard/Download/src_float_out.raw" , "wb" );
+    fwrite(outputBuffer.get(), sizeof(float), numRead, fp );
+    fclose(fp);
+#endif
+}
+
+TEST(test_resampler, resampler_8000_48000_best) {
+    checkResampler(8000, 48000, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_11025_24000_best) {
+    checkResampler(11025, 24000, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_11025_48000_fastest) {
+    checkResampler(11025, 48000, MultiChannelResampler::Quality::Fastest);
+}
+TEST(test_resampler, resampler_11025_48000_low) {
+    checkResampler(11025, 48000, MultiChannelResampler::Quality::Low);
+}
+TEST(test_resampler, resampler_11025_48000_medium) {
+    checkResampler(11025, 48000, MultiChannelResampler::Quality::Medium);
+}
+TEST(test_resampler, resampler_11025_48000_high) {
+    checkResampler(11025, 48000, MultiChannelResampler::Quality::High);
+}
+
+TEST(test_resampler, resampler_11025_48000_best) {
+    checkResampler(11025, 48000, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_11025_44100_best) {
+    checkResampler(11025, 44100, MultiChannelResampler::Quality::Best);
+}
+TEST(test_resampler, resampler_11025_88200_best) {
+    checkResampler(11025, 88200, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_16000_48000_best) {
+    checkResampler(16000, 48000, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_44100_48000_low) {
+    checkResampler(44100, 48000, MultiChannelResampler::Quality::Low);
+}
+TEST(test_resampler, resampler_44100_48000_best) {
+    checkResampler(44100, 48000, MultiChannelResampler::Quality::Best);
+}
+
+// Look for glitches when downsampling.
+TEST(test_resampler, resampler_48000_11025_best) {
+    checkResampler(48000, 11025, MultiChannelResampler::Quality::Best);
+}
+TEST(test_resampler, resampler_48000_44100_best) {
+    checkResampler(48000, 11025, MultiChannelResampler::Quality::Best);
+}
+
+TEST(test_resampler, resampler_44100_11025_best) {
+    checkResampler(48000, 11025, MultiChannelResampler::Quality::Best);
+}


### PR DESCRIPTION
Converting from 11025 to 48000 with Best quality had a strong glitch. Added guard row to Coefficients table for interpolation.

Fixes #1622