### PR TITLE
Match setChannelConversionAllowed comment to code

### DIFF
--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -460,7 +460,7 @@ public:
      * On some devices, mono streams might be broken, so a stereo stream might be opened
      * and converted to mono.
      *
-     * Default is true.
+     * Default is false.
      */
     AudioStreamBuilder *setChannelConversionAllowed(bool allowed) {
         mChannelConversionAllowed = allowed;


### PR DESCRIPTION
setFormatConversionAllowed was changed to match code in https://github.com/google/oboe/commit/1fd49e2f1d0980995b61cb33f5ef0cbe0eae6963. We should do the same for setChannelConversionAllowed

Fixes #712