### PR TITLE
OboeTester: Log whether an added device is a sink or source in TestPlugLatencyActivity

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestPlugLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestPlugLatencyActivity.java
@@ -202,6 +202,11 @@ public class TestPlugLatencyActivity extends TestAudioActivity {
         sb.append("\nType: ");
         sb.append(AudioDeviceInfoConverter.typeToString(adi.getType()));
 
+        sb.append("\nIsSource: ");
+        sb.append(String.valueOf(adi.isSource()));
+        sb.append(", IsSink: ");
+        sb.append(String.valueOf(adi.isSink()));
+
         return sb.toString();
     }
 


### PR DESCRIPTION
I tested with a 3.5mm headset and this now shows one sink and one source