### PR TITLE
OboeTester: fix overflow in array of PeakDetectors.

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 59
-        versionName "2.3.0"
+        versionCode 60
+        versionName "2.3.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.h
@@ -29,14 +29,12 @@
 #include "MultiChannelRecording.h"
 #include "OboeTesterStreamCallback.h"
 
-constexpr int kMaxInputChannels = 8;
-
 class InputStreamCallbackAnalyzer : public OboeTesterStreamCallback {
 public:
 
     void reset() {
-        for (auto detector : mPeakDetectors) {
-            detector.reset();
+        for (int iChannel = 0; iChannel < mNumChannels; iChannel++) {
+            mPeakDetectors[iChannel].reset();
         }
         OboeTesterStreamCallback::reset();
     }
@@ -44,6 +42,8 @@ public:
     void setup(int32_t maxFramesPerCallback,
                int32_t channelCount,
                oboe::AudioFormat inputFormat) {
+        mNumChannels = channelCount;
+        mPeakDetectors = std::make_unique<PeakDetector[]>(channelCount);
         int32_t bufferSize = maxFramesPerCallback * channelCount;
         mInputConverter = std::make_unique<FormatConverterBox>(bufferSize,
                                                                inputFormat,
@@ -75,11 +75,11 @@ public:
     }
 
 public:
-    PeakDetector            mPeakDetectors[kMaxInputChannels];
+    int32_t mNumChannels = 0;
+    std::unique_ptr<PeakDetector[]> mPeakDetectors;
     MultiChannelRecording  *mRecording = nullptr;
 
 private:
-
     std::unique_ptr<FormatConverterBox> mInputConverter;
     int32_t                 mMinimumFramesBeforeRead = 0;
 };

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -539,8 +539,7 @@ oboe::Result ActivityRecording::startPlayback() {
     builder.setChannelCount(mChannelCount)
             ->setSampleRate(mSampleRate)
             ->setFormat(oboe::AudioFormat::Float)
-            ->setCallback(&mPlayRecordingCallback)
-            ->setAudioApi(oboe::AudioApi::OpenSLES);
+            ->setCallback(&mPlayRecordingCallback);
     oboe::Result result = builder.openStream(&playbackStream);
     if (result != oboe::Result::OK) {
         delete playbackStream;

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -136,6 +136,10 @@
         <item>7</item>
         <item>8</item>
         <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
     </string-array>
 
     <string-array name="glitch_times">


### PR DESCRIPTION
This caused crashes or other undefined behavior
when trying to record more than 8 channels in
the RECORD AND PLAY test.

For b/260169236