### PR TITLE
oboe: clip waitForAvailableFrames

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 64
-        versionName "2.3.5"
+        versionCode 65
+        versionName "2.3.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -435,7 +435,12 @@ public:
      * This can be used with an EXCLUSIVE MMAP input stream to avoid reading data too close to
      * the DSP write position, which may cause glitches.
      *
-     * @param numFrames minimum frames available
+     * Starting with Oboe 1.7.1, the numFrames will be clipped internally against the
+     * BufferCapacity minus BurstSize. This is to prevent trying to wait for more frames
+     * than could possibly be available. In this case, the return value may be less than numFrames.
+     * Note that there may still be glitching if numFrames is too high.
+     *
+     * @param numFrames requested minimum frames available
      * @param timeoutNanoseconds
      * @return number of frames available, ErrorTimeout
      */

--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 7
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 0
+#define OBOE_VERSION_PATCH 1
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -166,6 +166,12 @@ ResultWithValue<int32_t> AudioStream::waitForAvailableFrames(int32_t numFrames,
     if (numFrames == 0) return Result::OK;
     if (numFrames < 0) return Result::ErrorOutOfRange;
 
+    // Make sure we don't try to wait for more frames than the buffer can hold.
+    // Subtract framesPerBurst because this is often called from a callback
+    // and we don't want to be sleeping if the buffer is close to overflowing.
+    const int32_t maxAvailableFrames = getBufferCapacityInFrames() - getFramesPerBurst();
+    numFrames = std::min(numFrames, maxAvailableFrames);
+
     int64_t framesAvailable = 0;
     int64_t burstInNanos = getFramesPerBurst() * kNanosPerSecond / getSampleRate();
     bool ready = false;

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -171,6 +171,8 @@ ResultWithValue<int32_t> AudioStream::waitForAvailableFrames(int32_t numFrames,
     // and we don't want to be sleeping if the buffer is close to overflowing.
     const int32_t maxAvailableFrames = getBufferCapacityInFrames() - getFramesPerBurst();
     numFrames = std::min(numFrames, maxAvailableFrames);
+    // The capacity should never be less than one burst. But clip to zero just in case.
+    numFrames = std::max(0, numFrames);
 
     int64_t framesAvailable = 0;
     int64_t burstInNanos = getFramesPerBurst() * kNanosPerSecond / getSampleRate();


### PR DESCRIPTION
Clip against BufferCapacity minus BurstSize.

Also bump Oboe to 1.7.1 and OboeTester to  2.3.6.

Fixes #1701