### PR TITLE
Coerce positive error from open() to negative code

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 65
-        versionName "2.3.6"
+        versionCode 66
+        versionName "2.3.7"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/include/oboe/Version.h
+++ b/include/oboe/Version.h
@@ -37,7 +37,7 @@
 #define OBOE_VERSION_MINOR 7
 
 // Type: 16-bit unsigned int. Min value: 0 Max value: 65535. See below for description.
-#define OBOE_VERSION_PATCH 1
+#define OBOE_VERSION_PATCH 2
 
 #define OBOE_STRINGIFY(x) #x
 #define OBOE_TOSTRING(x) OBOE_STRINGIFY(x)

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -332,17 +332,17 @@ Result AudioStreamAAudio::open() {
 
 error2:
     mLibLoader->builder_delete(aaudioBuilder);
-    LOGD("AudioStreamAAudio.open: AAudioStream_Open() returned %s = %d",
-         mLibLoader->convertResultToText(static_cast<aaudio_result_t>(result)),
-         static_cast<int>(result));
     if (static_cast<int>(result) > 0) {
         // Possibly due to b/267531411
+        LOGW("AudioStreamAAudio.open: AAudioStream_Open() returned positive error = %d",
+             static_cast<int>(result));
         if (OboeGlobals::areWorkaroundsEnabled()) {
             result = Result::ErrorInternal; // Coerce to negative error.
-        } else {
-            LOGW("AudioStreamAAudio.open: AAudioStream_Open() returned positive error = %d",
-                 static_cast<int>(result));
         }
+    } else {
+        LOGD("AudioStreamAAudio.open: AAudioStream_Open() returned %s = %d",
+             mLibLoader->convertResultToText(static_cast<aaudio_result_t>(result)),
+             static_cast<int>(result));
     }
     return result;
 }

--- a/src/aaudio/AudioStreamAAudio.cpp
+++ b/src/aaudio/AudioStreamAAudio.cpp
@@ -332,8 +332,18 @@ Result AudioStreamAAudio::open() {
 
 error2:
     mLibLoader->builder_delete(aaudioBuilder);
-    LOGD("AudioStreamAAudio.open: AAudioStream_Open() returned %s",
-         mLibLoader->convertResultToText(static_cast<aaudio_result_t>(result)));
+    LOGD("AudioStreamAAudio.open: AAudioStream_Open() returned %s = %d",
+         mLibLoader->convertResultToText(static_cast<aaudio_result_t>(result)),
+         static_cast<int>(result));
+    if (static_cast<int>(result) > 0) {
+        // Possibly due to b/267531411
+        if (OboeGlobals::areWorkaroundsEnabled()) {
+            result = Result::ErrorInternal; // Coerce to negative error.
+        } else {
+            LOGW("AudioStreamAAudio.open: AAudioStream_Open() returned positive error = %d",
+                 static_cast<int>(result));
+        }
+    }
     return result;
 }
 


### PR DESCRIPTION
AAudio could sometimes return a positive number (1) as an error code. That was confusing to apps like OboeTester, which often look for (result < 0).

The fix is to coerce these bogus error codes to ErrorInternal.

Bump Oboe to 1.7.2 and OboeTester to 2.3.7.