### PR TITLE
OboeTester: check for (result != 0)

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
@@ -29,7 +29,7 @@ abstract class OboeAudioStream extends AudioStreamBase {
     @Override
     public void stopPlayback() throws IOException {
         int result = stopPlaybackNative();
-        if (result < 0) {
+        if (result != 0) {
             throw new IOException("Stop Playback failed! result = " + result);
         }
     }
@@ -39,7 +39,7 @@ abstract class OboeAudioStream extends AudioStreamBase {
     @Override
     public void startPlayback() throws IOException {
         int result = startPlaybackNative();
-        if (result < 0) {
+        if (result != 0) {
             throw new IOException("Start Playback failed! result = " + result);
         }
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -587,7 +587,7 @@ abstract class TestAudioActivity extends Activity {
     public void startAudio() throws IOException {
         Log.i(TAG, "startAudio() called =========================");
         int result = startNative();
-        if (result < 0) {
+        if (result != 0) {
             showErrorToast("Start failed with " + result);
             throw new IOException("startNative returned " + result);
         } else {
@@ -608,7 +608,7 @@ abstract class TestAudioActivity extends Activity {
 
     public void pauseAudio() {
         int result = pauseNative();
-        if (result < 0) {
+        if (result != 0) {
             toastPauseError(result);
         } else {
             mAudioState = AUDIO_STATE_PAUSED;
@@ -618,7 +618,7 @@ abstract class TestAudioActivity extends Activity {
 
     public void stopAudio() {
         int result = stopNative();
-        if (result < 0) {
+        if (result != 0) {
             showErrorToast("Stop failed with " + result);
         } else {
             mAudioState = AUDIO_STATE_STOPPED;


### PR DESCRIPTION
In case AAudio returns a positive error by mistake.

Fixes #1706