### PR TITLE
DrumThumper: Support stereo

### DIFF
--- a/samples/drumthumper/README.md
+++ b/samples/drumthumper/README.md
@@ -27,7 +27,7 @@ Secondarily, **DrumThumper** demonstrates:
 * How to use the Oboe resampler to resample source audio to the device playback rate, and therefore not incur this overhead at playback time.
 
 To keep things simple, **DrumThumper** specifically does not:
-* Does not support audio samples in other than 16-bit, mono PCM Samples. It does not support Stereo or different PCM formats.
+* Does not support audio samples in other than 16-bit PCM Samples. It does not support different PCM formats.
 * Does not support non-WAV audio data (such as AIFF).
 * Does not support compressed audio data.
 

--- a/samples/drumthumper/README.md
+++ b/samples/drumthumper/README.md
@@ -33,9 +33,7 @@ To keep things simple, **DrumThumper** specifically does not:
 
 **DrumThumper** now supports different sample rates for the source samples.
 
-If one wanted to extend **DrumThumper** to support Stereo samples:
-* The SampleSource class would need to be extended to understand Stereo SampleBuffer objects, it currently assumes Mono.
-* The OneShotSampleSource.mixAudio() method would need to have separate mixing logic for Stereo and Mono SampleSource.
+**DrumThumper** now supports mono and stereo sources.
 
 ## DrumThumper project structure
 ### Kotlin App Layer

--- a/samples/drumthumper/src/main/cpp/DrumPlayerJNI.cpp
+++ b/samples/drumthumper/src/main/cpp/DrumPlayerJNI.cpp
@@ -47,8 +47,6 @@ static SimpleMultiPlayer sDTPlayer;
 JNIEXPORT void JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_setupAudioStreamNative(
         JNIEnv* env, jobject, jint numChannels) {
     __android_log_print(ANDROID_LOG_INFO, TAG, "%s", "init()");
-
-    // we know in this case that the sample buffers are all 1-channel, 41K
     sDTPlayer.setupAudioStream(numChannels);
 }
 

--- a/samples/drumthumper/src/main/cpp/DrumPlayerJNI.cpp
+++ b/samples/drumthumper/src/main/cpp/DrumPlayerJNI.cpp
@@ -72,8 +72,8 @@ JNIEXPORT void JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_teardow
 /**
  * Native (JNI) implementation of DrumPlayer.loadWavAssetNative()
  */
-JNIEXPORT jboolean JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_loadWavAssetNative(
-        JNIEnv* env, jobject, jbyteArray bytearray, jint index, jfloat pan, jint channels) {
+JNIEXPORT void JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_loadWavAssetNative(
+        JNIEnv* env, jobject, jbyteArray bytearray, jint index, jfloat pan) {
     int len = env->GetArrayLength (bytearray);
 
     unsigned char* buf = new unsigned char[len];
@@ -84,7 +84,7 @@ JNIEXPORT jboolean JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_loa
     WavStreamReader reader(&stream);
     reader.parse();
 
-    jboolean isFormatValid = reader.getNumChannels() == channels;
+    reader.getNumChannels();
 
     SampleBuffer* sampleBuffer = new SampleBuffer();
     sampleBuffer->loadSampleData(&reader);
@@ -93,8 +93,6 @@ JNIEXPORT jboolean JNICALL Java_com_plausiblesoftware_drumthumper_DrumPlayer_loa
     sDTPlayer.addSampleSource(source, sampleBuffer);
 
     delete[] buf;
-
-    return isFormatValid;
 }
 
 /**

--- a/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumPlayer.kt
+++ b/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumPlayer.kt
@@ -22,11 +22,10 @@ import java.io.IOException
 class DrumPlayer {
     companion object {
         // Sample attributes
-        val NUM_PLAY_CHANNELS: Int = 2  // The number of channels in the player Stream.
-                                        // Stereo Playback, set to 1 for Mono playback
-                                        // This IS NOT the channel format of the source samples
-                                        // (which must be mono).
-        val NUM_SAMPLE_CHANNELS: Int = 1   // All WAV resource must be mono
+        val NUM_PLAY_CHANNELS: Int = 2      // The number of channels in the player Stream.
+                                            // Stereo Playback, set to 1 for Mono playback
+        val NUM_SAMPLE_CHANNELS: Int = 1    // The number of channels of the WAV files.
+                                            // Mono, set to 2 for Stereo files
 
         // Sample Buffer IDs
         val BASSDRUM: Int = 0

--- a/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumPlayer.kt
+++ b/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumPlayer.kt
@@ -22,10 +22,8 @@ import java.io.IOException
 class DrumPlayer {
     companion object {
         // Sample attributes
-        val NUM_PLAY_CHANNELS: Int = 2      // The number of channels in the player Stream.
-                                            // Stereo Playback, set to 1 for Mono playback
-        val NUM_SAMPLE_CHANNELS: Int = 1    // The number of channels of the WAV files.
-                                            // Mono, set to 2 for Stereo files
+        val NUM_PLAY_CHANNELS: Int = 2  // The number of channels in the player Stream.
+                                        // Stereo Playback, set to 1 for Mono playback
 
         // Sample Buffer IDs
         val BASSDRUM: Int = 0
@@ -64,47 +62,40 @@ class DrumPlayer {
     }
 
     // asset-based samples
-    fun loadWavAssets(assetMgr: AssetManager): Boolean {
-        var allAssetsCorrect = true
-        allAssetsCorrect = loadWavAsset(assetMgr, "KickDrum.wav", BASSDRUM, PAN_BASSDRUM) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "SnareDrum.wav", SNAREDRUM, PAN_SNAREDRUM) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "CrashCymbal.wav", CRASHCYMBAL, PAN_CRASHCYMBAL) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "RideCymbal.wav", RIDECYMBAL, PAN_RIDECYMBAL) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "MidTom.wav", MIDTOM, PAN_MIDTOM) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "LowTom.wav", LOWTOM, PAN_LOWTOM) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "HiHat_Open.wav", HIHATOPEN, PAN_HIHATOPEN) && allAssetsCorrect
-        allAssetsCorrect = loadWavAsset(assetMgr, "HiHat_Closed.wav", HIHATCLOSED, PAN_HIHATCLOSED) && allAssetsCorrect
-
-        return allAssetsCorrect
+    fun loadWavAssets(assetMgr: AssetManager) {
+        loadWavAsset(assetMgr, "KickDrum.wav", BASSDRUM, PAN_BASSDRUM)
+        loadWavAsset(assetMgr, "SnareDrum.wav", SNAREDRUM, PAN_SNAREDRUM)
+        loadWavAsset(assetMgr, "CrashCymbal.wav", CRASHCYMBAL, PAN_CRASHCYMBAL)
+        loadWavAsset(assetMgr, "RideCymbal.wav", RIDECYMBAL, PAN_RIDECYMBAL)
+        loadWavAsset(assetMgr, "MidTom.wav", MIDTOM, PAN_MIDTOM)
+        loadWavAsset(assetMgr, "LowTom.wav", LOWTOM, PAN_LOWTOM)
+        loadWavAsset(assetMgr, "HiHat_Open.wav", HIHATOPEN, PAN_HIHATOPEN)
+        loadWavAsset(assetMgr, "HiHat_Closed.wav", HIHATCLOSED, PAN_HIHATCLOSED)
     }
 
     fun unloadWavAssets() {
         unloadWavAssetsNative()
     }
 
-    private fun loadWavAsset(assetMgr: AssetManager, assetName: String, index: Int, pan: Float) : Boolean {
-        var returnVal = false
+    private fun loadWavAsset(assetMgr: AssetManager, assetName: String, index: Int, pan: Float) {
         try {
             val assetFD = assetMgr.openFd(assetName)
             val dataStream = assetFD.createInputStream()
             val dataLen = assetFD.getLength().toInt()
             val dataBytes = ByteArray(dataLen)
             dataStream.read(dataBytes, 0, dataLen)
-            returnVal = loadWavAssetNative(dataBytes, index, pan, NUM_SAMPLE_CHANNELS)
+            loadWavAssetNative(dataBytes, index, pan)
             assetFD.close()
         } catch (ex: IOException) {
             Log.i(TAG, "IOException$ex")
         }
-
-        return returnVal
     }
 
     private external fun setupAudioStreamNative(numChannels: Int)
     private external fun startAudioStreamNative()
     private external fun teardownAudioStreamNative()
 
-    private external fun loadWavAssetNative(
-            wavBytes: ByteArray, index: Int, pan: Float, channels: Int) : Boolean
+    private external fun loadWavAssetNative(wavBytes: ByteArray, index: Int, pan: Float)
     private external fun unloadWavAssetsNative()
 
     external fun trigger(drumIndex: Int)

--- a/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumThumperActivity.kt
+++ b/samples/drumthumper/src/main/kotlin/com/plausibleaudio/drumthumper/DrumThumperActivity.kt
@@ -168,15 +168,8 @@ class DrumThumperActivity : AppCompatActivity(),
 
         mDrumPlayer.setupAudioStream()
 
-        val allAssetsValid = mDrumPlayer.loadWavAssets(getAssets())
+        mDrumPlayer.loadWavAssets(getAssets())
 
-        if (!allAssetsValid) {
-            // show toast
-            val toast = Toast.makeText(this,
-                    "One or more audio assets has an incorrect format and may not play correctly",
-                    Toast.LENGTH_LONG)
-            toast.show()
-        }
         mDrumPlayer.startAudioStream()
 
         if (mUseDeviceChangeFallback) {

--- a/samples/iolib/src/main/cpp/player/OneShotSampleSource.cpp
+++ b/samples/iolib/src/main/cpp/player/OneShotSampleSource.cpp
@@ -25,14 +25,12 @@ namespace iolib {
 void OneShotSampleSource::mixAudio(float* outBuff, int numChannels, int32_t numFrames) {
     int32_t numSamples = mSampleBuffer->getNumSamples();
     int32_t sampleChannels = mSampleBuffer->getProperties().channelCount;
-    int32_t sampleIndex = mCurSampleIndex;
-    int32_t samplesLeft = numSamples - sampleIndex;
+    int32_t samplesLeft = numSamples - mCurSampleIndex;
     int32_t numWriteFrames = mIsPlaying
                          ? std::min(numFrames, samplesLeft / sampleChannels)
                          : 0;
 
     if (numWriteFrames != 0) {
-        int32_t sampleIndex2 = mCurSampleIndex;
         const float* data  = mSampleBuffer->getSampleData();
         if ((sampleChannels == 1) && (numChannels == 1)) {
             // MONO output from MONO samples

--- a/samples/iolib/src/main/cpp/player/OneShotSampleSource.cpp
+++ b/samples/iolib/src/main/cpp/player/OneShotSampleSource.cpp
@@ -23,31 +23,46 @@
 namespace iolib {
 
 void OneShotSampleSource::mixAudio(float* outBuff, int numChannels, int32_t numFrames) {
-    int32_t numSampleFrames = mSampleBuffer->getNumSampleFrames();
+    int32_t numSamples = mSampleBuffer->getNumSamples();
+    int32_t sampleChannels = mSampleBuffer->getProperties().channelCount;
+    int32_t sampleIndex = mCurSampleIndex;
+    int32_t samplesLeft = numSamples - sampleIndex;
     int32_t numWriteFrames = mIsPlaying
-                         ? std::min(numFrames, numSampleFrames - mCurFrameIndex)
+                         ? std::min(numFrames, samplesLeft / sampleChannels)
                          : 0;
 
     if (numWriteFrames != 0) {
-        // Mix in the samples
-
-        // investigate unrolling these loops...
+        int32_t sampleIndex2 = mCurSampleIndex;
         const float* data  = mSampleBuffer->getSampleData();
-        if (numChannels == 1) {
-            // MONO output
+        if ((sampleChannels == 1) && (numChannels == 1)) {
+            // MONO output from MONO samples
             for (int32_t frameIndex = 0; frameIndex < numWriteFrames; frameIndex++) {
-                outBuff[frameIndex] += data[mCurFrameIndex++] * mGain;
+                outBuff[frameIndex] += data[mCurSampleIndex++] * mGain;
             }
-        } else if (numChannels == 2) {
-            // STEREO output
+        } else if ((sampleChannels == 1) && (numChannels == 2)) {
+            // STEREO output from MONO samples
             int dstSampleIndex = 0;
             for (int32_t frameIndex = 0; frameIndex < numWriteFrames; frameIndex++) {
-                outBuff[dstSampleIndex++] += data[mCurFrameIndex] * mLeftGain;
-                outBuff[dstSampleIndex++] += data[mCurFrameIndex++] * mRightGain;
+                outBuff[dstSampleIndex++] += data[mCurSampleIndex] * mLeftGain;
+                outBuff[dstSampleIndex++] += data[mCurSampleIndex++] * mRightGain;
+            }
+        } else if ((sampleChannels == 2) && (numChannels == 1)) {
+            // MONO output from STEREO samples
+            int dstSampleIndex = 0;
+            for (int32_t frameIndex = 0; frameIndex < numWriteFrames; frameIndex++) {
+                outBuff[dstSampleIndex++] += data[mCurSampleIndex++] * mLeftGain +
+                                             data[mCurSampleIndex++] * mRightGain;
+            }
+        } else if ((sampleChannels == 2) && (numChannels == 2)) {
+            // STEREO output from STEREO samples
+            int dstSampleIndex = 0;
+            for (int32_t frameIndex = 0; frameIndex < numWriteFrames; frameIndex++) {
+                outBuff[dstSampleIndex++] += data[mCurSampleIndex++] * mLeftGain;
+                outBuff[dstSampleIndex++] += data[mCurSampleIndex++] * mRightGain;
             }
         }
 
-        if (mCurFrameIndex >= numSampleFrames) {
+        if (mCurSampleIndex >= numSamples) {
             mIsPlaying = false;
         }
     }

--- a/samples/iolib/src/main/cpp/player/SampleBuffer.cpp
+++ b/samples/iolib/src/main/cpp/player/SampleBuffer.cpp
@@ -26,7 +26,6 @@ using namespace RESAMPLER_OUTER_NAMESPACE::resampler;
 namespace iolib {
 
 void SampleBuffer::loadSampleData(parselib::WavStreamReader* reader) {
-    // Although we read this in, at this time we know a-priori that the data is mono
     mAudioProperties.channelCount = reader->getNumChannels();
     mAudioProperties.sampleRate = reader->getSampleRate();
 

--- a/samples/iolib/src/main/cpp/player/SampleBuffer.h
+++ b/samples/iolib/src/main/cpp/player/SampleBuffer.h
@@ -43,7 +43,7 @@ public:
     virtual AudioProperties getProperties() const { return mAudioProperties; }
 
     float* getSampleData() { return mSampleData; }
-    int32_t getNumSampleFrames() { return mNumSamples; }
+    int32_t getNumSamples() { return mNumSamples; }
 
 protected:
     AudioProperties mAudioProperties;

--- a/samples/iolib/src/main/cpp/player/SampleSource.h
+++ b/samples/iolib/src/main/cpp/player/SampleSource.h
@@ -39,13 +39,13 @@ public:
     static constexpr float PAN_CENTER = 0.0f;
 
     SampleSource(SampleBuffer *sampleBuffer, float pan)
-     : mSampleBuffer(sampleBuffer), mCurFrameIndex(0), mIsPlaying(false), mGain(1.0f) {
+     : mSampleBuffer(sampleBuffer), mCurSampleIndex(0), mIsPlaying(false), mGain(1.0f) {
         setPan(pan);
     }
     virtual ~SampleSource() {}
 
-    void setPlayMode() { mCurFrameIndex = 0; mIsPlaying = true; }
-    void setStopMode() { mIsPlaying = false; mCurFrameIndex = 0; }
+    void setPlayMode() { mCurSampleIndex = 0; mIsPlaying = true; }
+    void setStopMode() { mIsPlaying = false; mCurSampleIndex = 0; }
 
     bool isPlaying() { return mIsPlaying; }
 
@@ -76,7 +76,7 @@ public:
 protected:
     SampleBuffer    *mSampleBuffer;
 
-    int32_t mCurFrameIndex;
+    int32_t mCurSampleIndex;
 
     bool mIsPlaying;
 


### PR DESCRIPTION
#1719 fixed made stereo content not crash but it was not actually being read. It added stereo support to the wav reader but not to the files that used the content.

This PR reads the stereo data in OneShotSampleSource.

Because stereo is now supported, some bandage code that checks the channel count has been removed.

Fixes #1735