### PR TITLE
OboeTester: Fix Device Report crash before Android S

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
@@ -126,7 +126,10 @@ public class AudioQueryTools {
     }
 
     public static String getMediaPerformanceClass() {
-        int mpc = Build.VERSION.MEDIA_PERFORMANCE_CLASS;
+        int mpc = 0;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            mpc = Build.VERSION.MEDIA_PERFORMANCE_CLASS;
+        }
         String text = (mpc == 0) ? "not declared" : convertSdkToShortName(mpc);
         return formatKeyValueLine("Media Perf Class",
                 mpc + " (" + text + ")");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
@@ -126,10 +126,10 @@ public class AudioQueryTools {
     }
 
     public static String getMediaPerformanceClass() {
-        int mpc = 0;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            mpc = Build.VERSION.MEDIA_PERFORMANCE_CLASS;
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) {
+            return formatKeyValueLine("Media Perf Class", "not supported");
         }
+        int mpc = Build.VERSION.MEDIA_PERFORMANCE_CLASS;
         String text = (mpc == 0) ? "not declared" : convertSdkToShortName(mpc);
         return formatKeyValueLine("Media Perf Class",
                 mpc + " (" + text + ")");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -106,9 +106,7 @@ public class DeviceReportActivity extends Activity {
         report.append("Device: ").append(Build.MANUFACTURER).append(", ").append(Build.MODEL)
                 .append(", ").append(Build.PRODUCT).append("\n");
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            report.append(AudioQueryTools.getMediaPerformanceClass());
-        }
+        report.append(reportExtraDeviceInfo());
 
         for (AudioDeviceInfo deviceInfo : devices) {
             report.append("\n==== Device =================== " + deviceInfo.getId() + "\n");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -106,7 +106,9 @@ public class DeviceReportActivity extends Activity {
         report.append("Device: ").append(Build.MANUFACTURER).append(", ").append(Build.MODEL)
                 .append(", ").append(Build.PRODUCT).append("\n");
 
-        report.append(reportExtraDeviceInfo());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            report.append(AudioQueryTools.getMediaPerformanceClass());
+        }
 
         for (AudioDeviceInfo deviceInfo : devices) {
             report.append("\n==== Device =================== " + deviceInfo.getId() + "\n");


### PR DESCRIPTION
Build.VERSION.MEDIA_PERFORMANCE_CLASS is not defined before Android S.

Fixes #1738