### PR TITLE
OboeTester: Run and Cancel buttons for auto tests

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -190,6 +191,11 @@ public class TestDisconnectActivity extends TestAudioActivity {
                 + ", " + config.getSampleRate();
     }
 
+    private void log(Exception e) {
+        Log.e(TestAudioActivity.TAG, "Caught ", e);
+        mAutomatedTestRunner.log("Caught " + e);
+    }
+
     private void log(String text) {
         mAutomatedTestRunner.log(text);
     }
@@ -259,7 +265,7 @@ public class TestDisconnectActivity extends TestAudioActivity {
                     : mAudioOutTester.getCurrentAudioStream();
         } catch (IOException e) {
             openFailed = true;
-            log(e.getMessage());
+            log(e);
         }
 
         // The test is only worth running if we got the configuration we requested.
@@ -285,7 +291,7 @@ public class TestDisconnectActivity extends TestAudioActivity {
             } catch (IOException e) {
                 e.printStackTrace();
                 valid = false;
-                log(e.getMessage());
+                log(e);
             }
         }
 
@@ -404,10 +410,12 @@ public class TestDisconnectActivity extends TestAudioActivity {
             testConfiguration(StreamConfiguration.PERFORMANCE_MODE_NONE,
                     StreamConfiguration.SHARING_MODE_SHARED);
         } catch (InterruptedException e) {
-            log(e.getMessage());
-            showErrorToast(e.getMessage());
+            log("Test CANCELLED - INVALID!");
+        } catch (Exception e) {
+            log(e);
+            showErrorToast("Caught " + e);
         } finally {
-            setInstructionsText("Test completed.");
+            setInstructionsText("Test finished.");
             updateFailSkipButton(false);
         }
     }

--- a/apps/OboeTester/app/src/main/res/layout/auto_test_runner.xml
+++ b/apps/OboeTester/app/src/main/res/layout/auto_test_runner.xml
@@ -15,14 +15,14 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="@string/startAudio" />
+            android:text="@string/runTest" />
 
         <Button
             android:id="@+id/button_stop"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="@string/stopAudio" />
+            android:text="@string/cancelTest" />
 
         <Button
             android:id="@+id/button_share"

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="measure">Measure</string>
     <string name="cancel">Cancel</string>
     <string name="clear">Clear</string>
+    <string name="runTest">Run</string>
+    <string name="cancelTest">Cancel</string>
 
     <string name="GetParam">Get Param</string>
     <string name="device_name">Device Name</string>


### PR DESCRIPTION
The Stop button was inviting users to stop the test prematurely. Run and Cancel buttons better reflect their action.

Also stop showing "Error: null" when the test is cancelled. Improve Exception logging.

Bug: b/268224770 internal Android