### PR TITLE
MegaDrone/SoundBoard:Remove stablized callback from READMEs

### DIFF
--- a/samples/MegaDrone/README.md
+++ b/samples/MegaDrone/README.md
@@ -12,8 +12,6 @@ This sample demonstrates how to obtain the lowest latency and optimal computatio
 4) Setting the buffer size to 2 bursts
 5) Using the `-Ofast` compiler optimization flag, even when building the `Debug` variant
 6) Using [`getExclusiveCores`](https://developer.android.com/reference/android/os/Process#getExclusiveCores()) (API 24+) and thread affinity to bind the audio thread to the best available CPU core(s)
-7) Using a `StabilizedCallback` which aims to spend a fixed percentage of the callback time to avoid CPU frequency scaling ([video explanation](https://www.youtube.com/watch?v=C0BPXZIvG-Q&feature=youtu.be&t=1158))
-
 
 This code was presented at [AES Milan](http://www.aes.org/events/144/) and [Droidcon Berlin](https://www.de.droidcon.com/) as part of a talk on Oboe.
 

--- a/samples/SoundBoard/README.md
+++ b/samples/SoundBoard/README.md
@@ -9,7 +9,6 @@ This sample demonstrates how to obtain the lowest latency and optimal computatio
 3) Setting sharing mode to Exclusive
 4) Setting the buffer size to 2 bursts
 5) Using the `-Ofast` compiler optimization flag, even when building the `Debug` variant
-7) Using a `StabilizedCallback` which aims to spend a fixed percentage of the callback time to avoid CPU frequency scaling ([video explanation](https://www.youtube.com/watch?v=C0BPXZIvG-Q&feature=youtu.be&t=1158))
 
 The [following article explaining how to debug CPU performance problems](https://medium.com/@donturner/debugging-audio-glitches-on-android-ed10782f9c64) may also be useful when looking at this code.
 


### PR DESCRIPTION
MegaDrone and SoundBoard apps aren't actually using StabilizedCallbacks anymore. We should remove this reference for now instead of readding StabilizedCallbacks as the class isn't that stable. See issue #1298. Arguably, they should use a [LatencyTuner](https://github.com/google/oboe/blob/main/src/common/LatencyTuner.cpp).

Fixes #1748 