### PR TITLE
OboeTester: Fix manual glitch activity sharing

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -342,9 +342,6 @@ public class GlitchActivity extends AnalyzerActivity {
     public void onStopAudioTest(View view) {
         stopAudioTest();
         onTestFinished();
-        mStartButton.setEnabled(true);
-        mStopButton.setEnabled(false);
-        mShareButton.setEnabled(false);
         keepScreenOn(false);
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ManualGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ManualGlitchActivity.java
@@ -157,12 +157,6 @@ public class ManualGlitchActivity extends GlitchActivity {
 
     // Only call from UI thread.
     @Override
-    public void onTestFinished() {
-        super.onTestFinished();
-    }
-
-    // Only call from UI thread.
-    @Override
     public void onTestBegan() {
         mWaveformView.clearSampleData();
         mWaveformView.postInvalidate();


### PR DESCRIPTION
`onStopAudioTest()` calls `onTestFinished()` which updates the share UI. However, it reset it right after with `mShareButton.setEnabled(false);`. This change removes the duplicate work.

Fixes #1752