### PR TITLE
oboetester: try to repro routing crash

### DIFF
--- a/apps/OboeTester/app/CMakeLists.txt
+++ b/apps/OboeTester/app/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 link_directories(${CMAKE_CURRENT_LIST_DIR}/..)
 
-# Increment this number when adding files to OboeTester => 101
+# Increment this number when adding files to OboeTester => 102
 # The change in this file will help Android Studio resync
 # and generate new build files that reference the new code.
 file(GLOB_RECURSE app_native_sources src/main/cpp/*)

--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 67
-        versionName "2.3.8"
+        versionCode 68
+        versionName "2.4.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -108,6 +108,10 @@
             android:name=".TestErrorCallbackActivity"
             android:label="@string/title_error_callback"
             android:exported="true" />
+        <activity
+            android:name=".TestRouteDuringCallbackActivity"
+            android:label="@string/title_route_during_callback"
+            android:exported="true" />
 
         <service
             android:name=".MidiTapTester"

--- a/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <aaudio/AAudioExtensions.h>
+
+#include "common/OboeDebug.h"
+#include "common/AudioClock.h"
+#include "TestRoutingCrash.h"
+
+using namespace oboe;
+
+int32_t TestRoutingCrash::start() {
+
+    mDataCallback = std::make_shared<MyDataCallback>(this);
+
+    // Disable MMAP because we are trying to crash a Legacy Stream.
+    bool wasMMapEnabled = AAudioExtensions::getInstance().isMMapEnabled();
+    AAudioExtensions::getInstance().setMMapEnabled(false);
+
+    AudioStreamBuilder builder;
+    oboe::Result result = builder.setPerformanceMode(oboe::PerformanceMode::LowLatency)
+            ->setFormat(oboe::AudioFormat::Float)
+            ->setChannelCount(kChannelCount)
+            ->setBufferCapacityInFrames(32000)
+            ->setDataCallback(mDataCallback)
+            ->setUsage(oboe::Usage::VoiceCommunication) // so we can reroute it
+            ->openStream(mStream);
+    if (result != oboe::Result::OK) {
+        return (int32_t) result;
+    }
+
+    mStream->setBufferSizeInFrames(mStream->getBufferCapacityInFrames());
+
+    AAudioExtensions::getInstance().setMMapEnabled(wasMMapEnabled);
+    return (int32_t) mStream->requestStart();
+}
+
+int32_t TestRoutingCrash::stop() {
+    oboe::Result result1 =  mStream->requestStop();
+    oboe::Result result2 =   mStream->close();
+    return (int32_t)((result1 != oboe::Result::OK) ? result1 : result2);
+}
+
+DataCallbackResult TestRoutingCrash::MyDataCallback::onAudioReady(
+        AudioStream *audioStream,
+        void *audioData,
+        int32_t numFrames) {
+    float *output = (float *) audioData;
+
+    // Sleep so that we spend most of our time in the callback without underflowing.
+    // Otherwise the window for the crash is very narrow.
+    int64_t now = AudioClock::getNanoseconds();
+    int64_t elapsed = now - mLastCallbackTime;
+    double bufferTimeNanos = 1.0e9 * numFrames / (double) audioStream->getSampleRate();
+    int64_t targetDuration = (int64_t) (bufferTimeNanos * 0.7);
+    mParent->sleepTimeNanos = targetDuration - elapsed;
+    AudioClock::sleepForNanos(mParent->sleepTimeNanos);
+
+    // Try to trigger a restoreTrack_l() in AudioFlinger.
+    audioStream->getTimestamp(CLOCK_MONOTONIC);
+
+    // Fill mono buffer with a sine wave.
+    // If the routing occurred then the buffer may be dead and
+    // we may be writing into unallocated memory.
+    int numSamples = numFrames * kChannelCount;
+    for (int i = 0; i < numSamples; i++) {
+        *output++ = sinf(mPhase) * 0.2f;
+        mPhase += mPhaseIncrement;
+        // Wrap the phase around the circular.
+        if (mPhase >= M_PI) mPhase -= 2 * M_PI;
+    }
+
+    mLastCallbackTime = AudioClock::getNanoseconds();
+
+    return oboe::DataCallbackResult::Continue;
+}

--- a/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
+++ b/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
+++ b/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOETESTER_TEST_ROUTING_CRASH_H
+#define OBOETESTER_TEST_ROUTING_CRASH_H
+
+#include "oboe/Oboe.h"
+#include <thread>
+
+/**
+ * Try to cause a crash by changing routing during a data callback.
+ * We use Use::VoiceCommunication for the stream and
+ * setSpeakerPhoneOn(b) to force a routing change.
+ * This works best when connected to a BT headset.
+ */
+class TestRoutingCrash {
+public:
+
+    int32_t start();
+    int32_t stop();
+
+    int32_t getSleepTimeMicros() {
+        return (int32_t) (sleepTimeNanos.load() / 1000);
+    }
+
+protected:
+
+    std::atomic<int64_t> sleepTimeNanos{0};
+
+private:
+
+    class MyDataCallback : public oboe::AudioStreamDataCallback {    public:
+
+        MyDataCallback(TestRoutingCrash *parent): mParent(parent) {}
+
+        oboe::DataCallbackResult onAudioReady(
+                oboe::AudioStream *audioStream,
+                void *audioData,
+                int32_t numFrames) override;
+    private:
+        TestRoutingCrash *mParent;
+        int64_t mLastCallbackTime = 0;
+        // For sine generator.
+        float mPhase = 0.0f;
+        float mPhaseIncrement = 2.0f * (float) M_PI * 440.0f / 48000.0f;
+    };
+
+    std::shared_ptr<oboe::AudioStream> mStream;
+    std::shared_ptr<MyDataCallback> mDataCallback;
+
+    static constexpr int kChannelCount = 1;
+};
+
+#endif //OBOETESTER_TEST_ROUTING_CRASH_H

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -27,6 +27,7 @@
 
 #include "NativeAudioContext.h"
 #include "TestErrorCallback.h"
+#include "TestRoutingCrash.h"
 
 NativeAudioContext engine;
 
@@ -785,18 +786,38 @@ Java_com_mobileer_oboetester_TestAudioActivity_setDefaultAudioValues(JNIEnv *env
     oboe::DefaultStreamValues::FramesPerBurst = audio_manager_frames_per_burst;
 }
 
-static TestErrorCallback sTester;
+static TestErrorCallback sErrorCallbackTester;
 
 JNIEXPORT void JNICALL
 Java_com_mobileer_oboetester_TestErrorCallbackActivity_testDeleteCrash(
         JNIEnv *env, jobject instance) {
-    sTester.test();
+    sErrorCallbackTester.test();
 }
 
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_TestErrorCallbackActivity_getCallbackMagic(
         JNIEnv *env, jobject instance) {
-    return sTester.getCallbackMagic();
+    return sErrorCallbackTester.getCallbackMagic();
+}
+
+static TestRoutingCrash sRoutingCrash;
+
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRouteDuringCallbackActivity_startStream(
+        JNIEnv *env, jobject instance) {
+    return sRoutingCrash.start();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRouteDuringCallbackActivity_stopStream(
+        JNIEnv *env, jobject instance) {
+    return sRoutingCrash.stop();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRouteDuringCallbackActivity_getSleepTimeMicros(
+        JNIEnv *env, jobject instance) {
+    return sRoutingCrash.getSleepTimeMicros();
 }
 
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
@@ -29,4 +29,8 @@ public class ExtraTestsActivity extends BaseOboeTesterActivity {
         launchTestActivity(TestErrorCallbackActivity.class);
     }
 
+    public void onLaunchRouteDuringCallbackTest(View view) {
+        launchTestActivity(TestRouteDuringCallbackActivity.class);
+    }
+
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRouteDuringCallbackActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRouteDuringCallbackActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRouteDuringCallbackActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRouteDuringCallbackActivity.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.oboetester;
+
+import static com.mobileer.oboetester.TestAudioActivity.TAG;
+
+import android.app.Activity;
+import android.content.Context;
+import android.media.AudioManager;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+
+import java.util.Random;
+
+/**
+ * Try to crash in the native AAudio code by causing a routing change
+ * while playing audio. The buffer may get deleted while we are writing to it!
+ * See b/274815060
+ */
+public class TestRouteDuringCallbackActivity extends Activity {
+
+    private TextView mStatusView;
+    private MyStreamSniffer mStreamSniffer;
+    private AudioManager mAudioManager;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_routing_crash);
+        mStatusView = (TextView) findViewById(R.id.text_callback_status);
+        mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+    }
+
+    public void onTestRoutingCrash(View view) {
+        stopSniffer();
+        mStreamSniffer = new MyStreamSniffer();
+        mStreamSniffer.start();
+    }
+
+    // Change routing while the stream is playing.
+    // Keep trying until we crash.
+    protected class MyStreamSniffer extends Thread {
+        boolean enabled = true;
+        int routingOption = 0;
+        StringBuffer statusBuffer = new StringBuffer();
+
+        @Override
+        public void run() {
+            routingOption = 0;
+            changeRoute(routingOption);
+            int result;
+            Random random = new Random();
+            while (enabled) {
+                if (routingOption == 0) {
+                    statusBuffer = new StringBuffer();
+                }
+                try {
+                    sleep(100);
+                    result = startStream();
+                    sleep(100);
+                    log("-------\nstartStream() returned " + result);
+                    int sleepTimeMillis = 500 + random.nextInt(500);
+                    sleep(sleepTimeMillis);
+                    routingOption = (routingOption == 0) ? 1 : 0;
+                    log("changeRoute " + routingOption);
+                    changeRoute(routingOption);
+                    sleep(50);
+                } catch (InterruptedException e) {
+                } finally {
+                    result = stopStream();
+                    log("stopStream() returned " + result);
+                }
+            }
+            changeRoute(0);
+        }
+
+        // Log to screen and logcat.
+        private void log(String text) {
+            Log.e(TAG, "RoutingCrash: " + text);
+            statusBuffer.append(text + ", sleep " + getSleepTimeMicros() + " us\n");
+            showStatus(statusBuffer.toString());
+        }
+
+        // Stop the test thread.
+        void finish() {
+            enabled = false;
+            interrupt();
+            try {
+                join(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    protected void showStatus(final String message) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mStatusView.setText(message);
+            }
+        });
+    }
+
+    private void changeRoute(int option) {
+        mAudioManager.setSpeakerphoneOn(option > 0);
+    }
+
+    private native int startStream();
+    private native int getSleepTimeMicros();
+    private native int stopStream();
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        stopSniffer();
+    }
+
+    private void stopSniffer() {
+        if (mStreamSniffer != null) {
+            mStreamSniffer.finish();
+            mStreamSniffer = null;
+        }
+    }
+}

--- a/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
@@ -51,5 +51,15 @@
         android:backgroundTint="@color/button_tint"
         android:onClick="onLaunchErrorCallbackTest"
         android:text="Error Callback" />
+
+        <Button
+            android:id="@+id/buttonRouteDuringCallback"
+            android:layout_gravity="fill"
+            android:layout_width="0dp"
+            android:layout_columnWeight="1"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/button_tint"
+            android:onClick="onLaunchRouteDuringCallbackTest"
+            android:text="Routing Stress" />
 </GridLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
@@ -17,11 +17,7 @@
             android:layout_height="wrap_content"
             android:fontFamily="monospace"
             android:gravity="bottom"
-            android:text="
-Try to cause a crash by changing the\n
-VoiceCommunication routing while playing\n
-audio with a long duration callback.\n
-            " />
+            android:text="@string/routing_crash_intro" />
 
         <Button
             android:id="@+id/buttonRoutingCrash"

--- a/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TestRouteDuringCallbackActivity">
+
+    <LinearLayout
+        android:id="@+id/buttonGrid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="monospace"
+            android:gravity="bottom"
+            android:text="
+Try to cause a crash by changing the\n
+VoiceCommunication routing while playing\n
+audio with a long duration callback.\n
+            " />
+
+        <Button
+            android:id="@+id/buttonRoutingCrash"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_gravity="fill"
+            android:backgroundTint="@color/button_tint"
+            android:onClick="onTestRoutingCrash"
+            android:text="Run test" />
+
+        <TextView
+            android:id="@+id/text_callback_status"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fontFamily="monospace"
+            android:gravity="bottom"
+            android:lines="10"
+            android:text="@string/init_status" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <string name="title_external_tap">External Tap To Tone</string>
     <string name="title_plug_latency">Plug Latency Test</string>
     <string name="title_error_callback">Error Callback Test</string>
+    <string name="title_route_during_callback">Route Callback Test</string>
     <string name="analyze">Analyze</string>
 
     <string-array name="conversion_qualities">

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -215,6 +215,12 @@
     <string name="title_route_during_callback">Route Callback Test</string>
     <string name="analyze">Analyze</string>
 
+    <string name="routing_crash_intro">
+    Try to cause a crash by changing the\n
+    VoiceCommunication routing while playing\n
+    audio with a long duration callback.\n
+    </string>
+
     <string-array name="conversion_qualities">
         <item>None</item>
         <item>Fastest</item>


### PR DESCRIPTION
This test tries to trigger a routing change
while long duration callbacks are playing.
This can cause the callback to write into a dead buffer and cause a SIGSEGV.

See b/274815060