### PR TITLE
oboe: remove getMDelayBeforeCloseMillis from header

### DIFF
--- a/src/aaudio/AudioStreamAAudio.h
+++ b/src/aaudio/AudioStreamAAudio.h
@@ -117,11 +117,6 @@ private:
      */
     void launchStopThread();
 
-public:
-    int32_t getMDelayBeforeCloseMillis() const;
-
-    void setDelayBeforeCloseMillis(int32_t mDelayBeforeCloseMillis);
-
 private:
 
     std::atomic<bool>    mCallbackThreadEnabled;


### PR DESCRIPTION
Fixed some misspelled and misplaced declarations.

Fixes #1761