### PR TITLE
OboeTester: add Input to Routing Stress test

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
+++ b/apps/OboeTester/app/src/main/cpp/TestRoutingCrash.h
@@ -29,16 +29,16 @@
 class TestRoutingCrash {
 public:
 
-    int32_t start();
+    int32_t start(bool useInput);
     int32_t stop();
 
     int32_t getSleepTimeMicros() {
-        return (int32_t) (sleepTimeNanos.load() / 1000);
+        return (int32_t) (averageSleepTimeMicros.load());
     }
 
 protected:
 
-    std::atomic<int64_t> sleepTimeNanos{0};
+    std::atomic<double> averageSleepTimeMicros{0};
 
 private:
 
@@ -52,10 +52,10 @@ private:
                 int32_t numFrames) override;
     private:
         TestRoutingCrash *mParent;
-        int64_t mLastCallbackTime = 0;
         // For sine generator.
         float mPhase = 0.0f;
-        float mPhaseIncrement = 2.0f * (float) M_PI * 440.0f / 48000.0f;
+        static constexpr float kPhaseIncrement = 2.0f * (float) M_PI * 440.0f / 48000.0f;
+        float mInputSum = 0.0f; // For saving input data sum to prevent over-optimization.
     };
 
     std::shared_ptr<oboe::AudioStream> mStream;

--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -106,7 +106,7 @@ public:
             incrementOutputPhase();
             output = (sinOut * mOutputAmplitude)
                      + (mWhiteNoise.nextRandomDouble() * getNoiseAmplitude());
-            // ALOGD("sin(%f) = %f, %f\n", mOutputPhase, sinOut,  mPhaseIncrement);
+            // ALOGD("sin(%f) = %f, %f\n", mOutputPhase, sinOut,  kPhaseIncrement);
         }
         for (int i = 0; i < channelCount; i++) {
             frameData[i] = (i == mOutputChannel) ? output : 0.0f;

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -809,8 +809,9 @@ static TestRoutingCrash sRoutingCrash;
 
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_TestRouteDuringCallbackActivity_startStream(
-        JNIEnv *env, jobject instance) {
-    return sRoutingCrash.start();
+        JNIEnv *env, jobject instance,
+        jboolean useInput) {
+    return sRoutingCrash.start(useInput);
 }
 
 JNIEXPORT jint JNICALL

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
@@ -30,7 +30,7 @@ public class ExtraTestsActivity extends BaseOboeTesterActivity {
     }
 
     public void onLaunchRouteDuringCallbackTest(View view) {
-        launchTestActivity(TestRouteDuringCallbackActivity.class);
+        launchTestThatDoesRecording(TestRouteDuringCallbackActivity.class);
     }
 
 }

--- a/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
@@ -19,15 +19,48 @@
             android:gravity="bottom"
             android:text="@string/routing_crash_intro" />
 
-        <Button
-            android:id="@+id/buttonRoutingCrash"
+        <RadioGroup
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkedButton="@+id/direction_output"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/direction_output"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Output" />
+
+            <RadioButton
+                android:id="@+id/direction_input"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Input" />
+        </RadioGroup>
+
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_columnWeight="1"
-            android:layout_gravity="fill"
-            android:backgroundTint="@color/button_tint"
-            android:onClick="onTestRoutingCrash"
-            android:text="Run test" />
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_start_test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="@color/button_tint"
+                android:onClick="onStartRoutingTest"
+                android:text="Start Test" />
+            <Button
+                android:id="@+id/button_stop_test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="@color/button_tint"
+                android:onClick="onStopRoutingTest"
+                android:text="Stop Test" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/text_callback_status"

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -217,9 +217,11 @@
     <string name="analyze">Analyze</string>
 
     <string name="routing_crash_intro">
-    Try to cause a crash by changing the\n
-    VoiceCommunication routing while playing\n
-    audio with a long duration callback.\n
+        May cause a crash by changing the\n
+        VoiceCommunication routing while playing\n
+        audio with a long duration callback.\n
+        More likely to crash with Bluetooth\n
+        headsets. Issue #1763
     </string>
 
     <string-array name="conversion_qualities">


### PR DESCRIPTION
Show loopcount on screen.

Simplify sleep calculation to simulate a workload proportional to the numFrames.

Add more comments and improve instructions.