### PR TITLE
OboeTester: Use AppCompatSpinner and AppCompatTextView

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.core:core-ktx:1.9.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceSpinner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceSpinner.java
@@ -22,13 +22,14 @@ import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.util.AttributeSet;
-import android.widget.Spinner;
+
+import androidx.appcompat.widget.AppCompatSpinner;
 
 import com.mobileer.oboetester.R;
 
 import java.util.List;
 
-public class AudioDeviceSpinner extends Spinner {
+public class AudioDeviceSpinner extends AppCompatSpinner {
 
     private static final int AUTO_SELECT_DEVICE_ID = 0;
     private static final String TAG = AudioDeviceSpinner.class.getName();
@@ -63,14 +64,8 @@ public class AudioDeviceSpinner extends Spinner {
     }
 
     public AudioDeviceSpinner(Context context, AttributeSet attrs, int defStyleAttr,
-                              int defStyleRes, int mode){
-        super(context, attrs, defStyleAttr, defStyleRes, mode);
-        setup(context);
-    }
-
-    public AudioDeviceSpinner(Context context, AttributeSet attrs, int defStyleAttr,
-                              int defStyleRes, int mode, Theme popupTheme){
-        super(context, attrs, defStyleAttr, defStyleRes, mode, popupTheme);
+                              int mode, Theme popupTheme){
+        super(context, attrs, defStyleAttr, mode, popupTheme);
         setup(context);
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/CommunicationDeviceSpinner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/CommunicationDeviceSpinner.java
@@ -22,13 +22,14 @@ import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.util.AttributeSet;
-import android.widget.Spinner;
+
+import androidx.appcompat.widget.AppCompatSpinner;
 
 import com.mobileer.oboetester.R;
 
 import java.util.List;
 
-public class CommunicationDeviceSpinner extends Spinner {
+public class CommunicationDeviceSpinner extends AppCompatSpinner {
     private static final int CLEAR_DEVICE_ID = 0;
     private static final String TAG = CommunicationDeviceSpinner.class.getName();
     private AudioDeviceAdapter mDeviceAdapter;
@@ -62,14 +63,8 @@ public class CommunicationDeviceSpinner extends Spinner {
     }
 
     public CommunicationDeviceSpinner(Context context, AttributeSet attrs, int defStyleAttr,
-                                      int defStyleRes, int mode){
-        super(context, attrs, defStyleAttr, defStyleRes, mode);
-        setup(context);
-    }
-
-    public CommunicationDeviceSpinner(Context context, AttributeSet attrs, int defStyleAttr,
-                                      int defStyleRes, int mode, Theme popupTheme){
-        super(context, attrs, defStyleAttr, defStyleRes, mode, popupTheme);
+                                      int mode, Theme popupTheme){
+        super(context, attrs, defStyleAttr, mode, popupTheme);
         setup(context);
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FastButton.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FastButton.java
@@ -19,14 +19,15 @@ package com.mobileer.oboetester;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.widget.TextView;
+
+import androidx.appcompat.widget.AppCompatTextView;
 
 import java.util.ArrayList;
 
 /**
  * Button-like View that responds quickly to touch events.
  */
-public class FastButton extends TextView {
+public class FastButton extends AppCompatTextView {
 
     public FastButton(Context context) {
         super(context);


### PR DESCRIPTION
When making custom spinners and text views, we should use [AppCompatSpinner](https://developer.android.com/reference/kotlin/androidx/appcompat/widget/AppCompatSpinner) and [AppCompatTextView](https://developer.android.com/reference/kotlin/androidx/appcompat/widget/AppCompatTextView).

See the links to the new files. These bring new features to old versions of Android.