### PR TITLE
OboeTester: Make font sizes a bit smaller for buttons

### DIFF
--- a/apps/OboeTester/app/src/main/res/layout/merge_audio_common.xml
+++ b/apps/OboeTester/app/src/main/res/layout/merge_audio_common.xml
@@ -35,6 +35,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="openAudio"
             android:text="@string/openAudio" />
 
@@ -45,6 +46,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="startAudio"
             android:text="@string/startAudio" />
 
@@ -55,6 +57,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="pauseAudio"
             android:text="@string/pauseAudio" />
 
@@ -65,6 +68,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="stopAudio"
             android:text="@string/stopAudio" />
 
@@ -75,6 +79,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="releaseAudio"
             android:text="@string/releaseAudio" />
 
@@ -85,6 +90,7 @@
             android:layout_height="wrap_content"
             android:backgroundTint="@xml/button_color_selector"
             android:backgroundTintMode="src_atop"
+            android:textSize="12sp"
             android:onClick="closeAudio"
             android:text="@string/closeAudio" />
 


### PR DESCRIPTION
After PR #1755, on some devices, the word "RELEASE" takes too much space and spans multiple columns. The fix here is to make the font size a bit smaller.

sp is more dynamic compared to using dp