### PR TITLE
OboeTester: check for callback size in InputAnalyzer

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -347,7 +347,7 @@ protected:
 
     oboe::Result startStreams() override {
         mInputAnalyzer.reset();
-        mInputAnalyzer.setup(getInputStream()->getFramesPerBurst(),
+        mInputAnalyzer.setup(std::max(getInputStream()->getFramesPerBurst(), callbackSize),
                              getInputStream()->getChannelCount(),
                              getInputStream()->getFormat());
         return getInputStream()->requestStart();


### PR DESCRIPTION
InputAnalyzer creates a buffer based on the burst size for callbacks.

This did not account for the fact that the user can manually override the callback size.

Fixes b/278942008