### PR TITLE
Add assert() in FormatConverterBox

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/FormatConverterBox.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FormatConverterBox.cpp
@@ -16,14 +16,15 @@
 
 #include "FormatConverterBox.h"
 
-FormatConverterBox::FormatConverterBox(int32_t numSamples,
+FormatConverterBox::FormatConverterBox(int32_t maxSamples,
                                        oboe::AudioFormat inputFormat,
                                        oboe::AudioFormat outputFormat) {
     mInputFormat = inputFormat;
     mOutputFormat = outputFormat;
 
-    mInputBuffer = std::make_unique<uint8_t[]>(numSamples * sizeof(int32_t));
-    mOutputBuffer = std::make_unique<uint8_t[]>(numSamples * sizeof(int32_t));
+    mMaxSamples = maxSamples;
+    mInputBuffer = std::make_unique<uint8_t[]>(maxSamples * sizeof(int32_t));
+    mOutputBuffer = std::make_unique<uint8_t[]>(maxSamples * sizeof(int32_t));
 
     mSource.reset();
     switch (mInputFormat) {
@@ -70,14 +71,17 @@ FormatConverterBox::FormatConverterBox(int32_t numSamples,
 }
 
 int32_t FormatConverterBox::convertInternalBuffers(int32_t numSamples) {
+    assert(numSamples <= mMaxSamples);
     return convert(getOutputBuffer(), numSamples, getInputBuffer());
 }
 
 int32_t FormatConverterBox::convertToInternalOutput(int32_t numSamples, const void *inputBuffer) {
+    assert(numSamples <= mMaxSamples);
     return convert(getOutputBuffer(), numSamples, inputBuffer);
 }
 
 int32_t FormatConverterBox::convertFromInternalInput(void *outputBuffer, int32_t numSamples) {
+    assert(numSamples <= mMaxSamples);
     return convert(outputBuffer, numSamples, getInputBuffer());
 }
 

--- a/apps/OboeTester/app/src/main/cpp/FormatConverterBox.h
+++ b/apps/OboeTester/app/src/main/cpp/FormatConverterBox.h
@@ -38,7 +38,7 @@
 
 class FormatConverterBox {
 public:
-    FormatConverterBox(int32_t numSamples,
+    FormatConverterBox(int32_t maxSamples,
                        oboe::AudioFormat inputFormat,
                        oboe::AudioFormat outputFormat);
 
@@ -90,6 +90,7 @@ private:
     oboe::AudioFormat mInputFormat{oboe::AudioFormat::Invalid};
     oboe::AudioFormat mOutputFormat{oboe::AudioFormat::Invalid};
 
+    int32_t mMaxSamples = 0;
     std::unique_ptr<uint8_t[]> mInputBuffer;
     std::unique_ptr<uint8_t[]> mOutputBuffer;
 


### PR DESCRIPTION
Catch conversions larger than allocated buffer size.