### PR TITLE
OboeTester: fix buffer size radio button

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BufferSizeView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BufferSizeView.java
@@ -23,6 +23,7 @@ import android.view.LayoutInflater;
 
 import android.view.View;
 import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.LinearLayout;
@@ -36,6 +37,7 @@ public class BufferSizeView extends LinearLayout {
     private TextView mTextLabel;
     private SeekBar mFader;
     private ExponentialTaper mTaper;
+    private RadioGroup mBufferSizeGroup;
     private RadioButton mBufferSizeRadio1;
     private RadioButton mBufferSizeRadio2;
     private RadioButton mBufferSizeRadio3;
@@ -97,6 +99,8 @@ public class BufferSizeView extends LinearLayout {
         mTaper = new ExponentialTaper(0.0, 1.0, 10.0);
         mFader.setProgress(0);
 
+        mBufferSizeGroup = (RadioGroup) findViewById(R.id.bufferSizeGroup);
+
         mBufferSizeRadio1 = (RadioButton) findViewById(R.id.bufferSize1);
         mBufferSizeRadio1.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -118,13 +122,18 @@ public class BufferSizeView extends LinearLayout {
                 onSizeRadioButtonClicked(view, 3);
             }
         });
+
         mNumBursts = DEFAULT_NUM_BURSTS;
         updateRadioButtons();
         updateBufferSize();
     }
 
     public void updateRadioButtons() {
-        if (mBufferSizeRadio3 != null) {
+        if (mNumBursts == USE_FADER && mBufferSizeGroup != null) {
+            // Clear all the radio buttons using the group.
+            // If you clear a checked button directly then it stops working.
+            mBufferSizeGroup.clearCheck();
+        } else if (mBufferSizeRadio3 != null) {
             mBufferSizeRadio1.setChecked(mNumBursts == 1);
             mBufferSizeRadio2.setChecked(mNumBursts == 2);
             mBufferSizeRadio3.setChecked(mNumBursts == 3);

--- a/apps/OboeTester/app/src/main/res/layout/buffer_size_view.xml
+++ b/apps/OboeTester/app/src/main/res/layout/buffer_size_view.xml
@@ -17,6 +17,7 @@
         android:layout_height="match_parent">
 
     <RadioGroup
+        android:id="@+id/bufferSizeGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal">


### PR DESCRIPTION
If you uncheck all the individual radio buttons
then they stop working properly.
So you have to uncheck the RadioGroup.

Internal bug: b/280421942