### PR TITLE
OboeTester: fix crash with multiple START calls

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -254,6 +254,8 @@ int ActivityContext::open(jint nativeApi,
         dataBuffer = std::make_unique<float[]>(numSamples);
     }
 
+    configureAfterOpen();
+
     return (result != Result::OK) ? (int)result : streamIndex;
 }
 
@@ -265,8 +267,6 @@ oboe::Result ActivityContext::start() {
         LOGD("%s() - no streams defined", __func__);
         return oboe::Result::ErrorInvalidState; // not open
     }
-
-    configureForStart();
 
     audioStreamGateway.reset();
     result = startStreams();
@@ -381,7 +381,7 @@ void ActivityTestOutput::setChannelEnabled(int channelIndex, bool enabled) {
     }
 }
 
-void ActivityTestOutput::configureForStart() {
+void ActivityTestOutput::configureAfterOpen() {
     manyToMulti = std::make_unique<ManyToMultiConverter>(mChannelCount);
 
     mSinkFloat = std::make_shared<SinkFloat>(mChannelCount);
@@ -485,7 +485,7 @@ void ActivityTestOutput::runBlockingIO() {
 }
 
 // ======================================================================= ActivityTestInput
-void ActivityTestInput::configureForStart() {
+void ActivityTestInput::configureAfterOpen() {
     mInputAnalyzer.reset();
     if (mUseCallback) {
         oboeCallbackProxy.setCallback(&mInputAnalyzer);
@@ -565,7 +565,7 @@ oboe::Result ActivityRecording::startPlayback() {
 }
 
 // ======================================================================= ActivityTapToTone
-void ActivityTapToTone::configureForStart() {
+void ActivityTapToTone::configureAfterOpen() {
     monoToMulti = std::make_unique<MonoToMultiConverter>(mChannelCount);
 
     mSinkFloat = std::make_shared<SinkFloat>(mChannelCount);
@@ -734,7 +734,7 @@ void ActivityTestDisconnect::close(int32_t streamIndex) {
     mSinkFloat.reset();
 }
 
-void ActivityTestDisconnect::configureForStart() {
+void ActivityTestDisconnect::configureAfterOpen() {
     std::shared_ptr<oboe::AudioStream> outputStream = getOutputStream();
     std::shared_ptr<oboe::AudioStream> inputStream = getInputStream();
     if (outputStream) {

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -135,7 +135,7 @@ public:
 
     virtual void close(int32_t streamIndex);
 
-    virtual void configureForStart() {}
+    virtual void configureAfterOpen() {}
 
     oboe::Result start();
 
@@ -326,7 +326,7 @@ public:
     ActivityTestInput() {}
     virtual ~ActivityTestInput() = default;
 
-    void configureForStart() override;
+    void configureAfterOpen() override;
 
     double getPeakLevel(int index) override {
         return mInputAnalyzer.getPeakLevel(index);
@@ -400,7 +400,7 @@ public:
         return getOutputStream()->start();
     }
 
-    void configureForStart() override;
+    void configureAfterOpen() override;
 
     virtual void configureStreamGateway();
 
@@ -451,7 +451,7 @@ public:
     ActivityTapToTone() {}
     virtual ~ActivityTapToTone() = default;
 
-    void configureForStart() override;
+    void configureAfterOpen() override;
 
     virtual void trigger() override {
         sawPingGenerator.trigger();
@@ -645,7 +645,8 @@ public:
 
     void configureBuilder(bool isInput, oboe::AudioStreamBuilder &builder) override;
 
-    void configureForStart() override {
+    void configureAfterOpen() override {
+        // set buffer size
         std::shared_ptr<oboe::AudioStream> outputStream = getOutputStream();
         int32_t capacityInFrames = outputStream->getBufferCapacityInFrames();
         int32_t burstInFrames = outputStream->getFramesPerBurst();
@@ -699,7 +700,7 @@ public:
         return oboe::Result::ErrorNull;
     }
 
-    void configureForStart() override;
+    void configureAfterOpen() override;
 
 private:
     std::unique_ptr<SineOscillator>         sineOscillator;


### PR DESCRIPTION
Do not reallocate objects while callback is running.

Fixes #1802