### PR TITLE
OboeTester: fix crash if open failed

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -254,9 +254,12 @@ int ActivityContext::open(jint nativeApi,
         dataBuffer = std::make_unique<float[]>(numSamples);
     }
 
-    configureAfterOpen();
-
-    return (result != Result::OK) ? (int)result : streamIndex;
+    if (result != Result::OK) {
+        return (int) result;
+    } else {
+        configureAfterOpen();
+        return streamIndex;
+    }
 }
 
 oboe::Result ActivityContext::start() {


### PR DESCRIPTION
Skip configureAfterOpen() is open failed.

Fixes #1809