### PR TITLE
tests: upgrade gradle to 7.6

### DIFF
--- a/tests/UnitTestRunner/build.gradle
+++ b/tests/UnitTestRunner/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.6'
     }
 }
 

--- a/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/UnitTestRunner/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip


### PR DESCRIPTION
Fix for error: Unsupported class file major version 63

Fixes #1815