### PR TITLE
OboeTester: stop CPU Load sniffer

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
@@ -56,6 +56,7 @@ oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
 
     mSynthWorkload.onCallback(mNumWorkloadVoices);
     if (mNumWorkloadVoices > 0) {
+        // Render into the buffer or discard the synth voices.
         float *buffer = (audioStream->getChannelCount() == 2 && mHearWorkload)
                         ? static_cast<float *>(audioData) : nullptr;
         mSynthWorkload.renderStereo(buffer, numFrames);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
@@ -345,9 +345,13 @@ public class DynamicWorkloadActivity extends TestOutputActivityBase {
     }
 
     public void stopTest(View view) {
+        onStopTest();
+    }
+
+    @Override
+    public void onStopTest() {
         mUpdateThread.stop();
-        stopAudio();
-        closeAudio();
         updateButtons(false);
+        super.onStopTest();
     }
 }


### PR DESCRIPTION
Stop sniffer when onStop() called for Activity.
The sniffer was being left running the background. That was causing the workload to go up and down.

Fixes #1817