### PR TITLE
OboeTester: add out_usage to automated testing

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 71
-        versionName "2.5.0"
+        versionCode 72
+        versionName "2.5.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -20,10 +20,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- This is needed for sharing test results. -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="false"

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
@@ -161,11 +161,4 @@ public class AnalyzerActivity extends TestInputActivity {
         }
     }
 
-    private void writeTestInBackground(final String resultString) {
-        new Thread() {
-            public void run() {
-                writeTestResult(resultString);
-            }
-        }.start();
-    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalFileWriter.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalFileWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.oboetester;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+public class ExternalFileWriter {
+    private static final String TAG = "OboeTester";
+    private Context mContext;
+
+    public ExternalFileWriter(Context context) {
+        mContext = context;
+    }
+
+    public File writeStringToExternalFile(String result, String fileName) throws IOException {
+        File[] dirs = mContext.getExternalFilesDirs(null);
+        File resultFile = new File(dirs[0], fileName);
+        Log.d(TAG, "EXTFILE = " + resultFile.getAbsolutePath());
+        Writer writer = null;
+        try {
+            writer = new OutputStreamWriter(new FileOutputStream(resultFile));
+            writer.write(result);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return resultFile;
+    }
+}

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalFileWriter.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExternalFileWriter.java
@@ -34,8 +34,8 @@ public class ExternalFileWriter {
     }
 
     public File writeStringToExternalFile(String result, String fileName) throws IOException {
-        File[] dirs = mContext.getExternalFilesDirs(null);
-        File resultFile = new File(dirs[0], fileName);
+        File dir = mContext.getExternalFilesDir(null);
+        File resultFile = new File(dir, fileName);
         Log.d(TAG, "EXTFILE = " + resultFile.getAbsolutePath());
         Writer writer = null;
         try {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
@@ -46,6 +46,13 @@ public class IntentBasedTestSupport {
     public static final int VALUE_DEFAULT_SAMPLE_RATE = 48000;
     public static final String VALUE_UNSPECIFIED = "unspecified";
 
+    public static final String KEY_OUT_USAGE = "out_usage";
+    public static final String VALUE_USAGE_MEDIA = "media";
+    public static final String VALUE_USAGE_VOICE_COMMUNICATION = "voice_communication";
+    public static final String VALUE_USAGE_ALARM = "alarm";
+    public static final String VALUE_USAGE_NOTIFICATION = "notification";
+    public static final String VALUE_USAGE_GAME = "game";
+
     public static final String KEY_IN_API = "in_api";
     public static final String KEY_OUT_API = "out_api";
     public static final String VALUE_API_AAUDIO = "aaudio";
@@ -136,6 +143,21 @@ public class IntentBasedTestSupport {
             return StreamConfiguration.SHARING_MODE_SHARED;
         } else {
             return StreamConfiguration.SHARING_MODE_EXCLUSIVE;
+        }
+    }
+    public static int getUsageFromText(String text) {
+        if (VALUE_USAGE_GAME.equals(text)) {
+            return StreamConfiguration.USAGE_GAME;
+        } else if (VALUE_USAGE_VOICE_COMMUNICATION.equals(text)) {
+            return StreamConfiguration.USAGE_VOICE_COMMUNICATION;
+        } else if (VALUE_USAGE_MEDIA.equals(text)) {
+            return StreamConfiguration.USAGE_MEDIA;
+        } else if (VALUE_USAGE_ALARM.equals(text)) {
+            return StreamConfiguration.USAGE_ALARM;
+        } else if (VALUE_USAGE_NOTIFICATION.equals(text)) {
+            return StreamConfiguration.USAGE_NOTIFICATION;
+        } else {
+            return StreamConfiguration.UNSPECIFIED;
         }
     }
 
@@ -277,6 +299,11 @@ public class IntentBasedTestSupport {
         text = bundle.getString(KEY_OUT_SHARING, VALUE_SHARING_EXCLUSIVE);
         int sharingMode = getSharingFromText(text);
         requestedOutConfig.setSharingMode(sharingMode);
+
+        text = bundle.getString(KEY_OUT_USAGE, VALUE_USAGE_MEDIA);
+        int usage = getUsageFromText(text);
+        requestedOutConfig.setUsage(usage);
+
 
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/RoundTripLatencyActivity.java
@@ -21,11 +21,13 @@ import static com.mobileer.oboetester.IntentBasedTestSupport.configureStreamsFro
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
 
@@ -209,7 +211,10 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
                     } else {
                         message = getResultString();
                     }
-                    onAnalyzerDone();
+                    File resultFile = onAnalyzerDone();
+                    if (resultFile != null) {
+                        message = "result.file = " + resultFile.getAbsolutePath() + "\n" + message;
+                    }
                 } else {
                     message = getProgressText();
                     message += "please wait... " + counter + "\n";
@@ -255,15 +260,17 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         return message;
     }
 
-    private void onAnalyzerDone() {
+    private File onAnalyzerDone() {
+        File resultFile = null;
         if (mTestRunningByIntent) {
             String report = getCommonTestReport();
             report += getResultString();
-            maybeWriteTestResult(report);
+            resultFile = maybeWriteTestResult(report);
         }
         mTestRunningByIntent = false;
         mHasRecording = true;
         stopAudioTest();
+        return resultFile;
     }
 
     @NonNull
@@ -351,6 +358,7 @@ public class RoundTripLatencyActivity extends AnalyzerActivity {
         mBufferSizeView.setFaderNormalizedProgress(0.0); // for lowest latency
 
         mCommunicationDeviceView = (CommunicationDeviceView) findViewById(R.id.comm_device_view);
+
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfiguration.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfiguration.java
@@ -588,7 +588,7 @@ public class StreamConfiguration {
             message.append(String.format(Locale.getDefault(), "%s.preset = %s\n", prefix,
                     convertInputPresetToText(mInputPreset).toLowerCase(Locale.getDefault())));
         } else {
-            message.append(String.format(Locale.getDefault(), "%s.preset = %s\n", prefix,
+            message.append(String.format(Locale.getDefault(), "%s.usage = %s\n", prefix,
                     convertUsageToText(mUsage).toLowerCase(Locale.getDefault())));
             message.append(String.format(Locale.getDefault(), "%s.contentType = %s\n", prefix,
                     convertContentTypeToText(mContentType).toLowerCase(Locale.getDefault())));


### PR DESCRIPTION
Also change where the results files is stores.
No longer requires permissions but the path name is longer!

See apps/OboeTester/docs/AutomatedTesting.md