### PR TITLE
remove unecessary streamContext.tester assignement

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -381,7 +381,6 @@ abstract class TestAudioActivity extends Activity {
         if (streamContext.configurationView != null) {
             streamContext.configurationView.setOutput(false);
         }
-        streamContext.tester = AudioInputTester.getInstance();
         mStreamContexts.add(streamContext);
         return streamContext;
     }


### PR DESCRIPTION
`streamContext.tester = AudioInputTester.getInstance();` is already executed at the start of the function