### PR TITLE
OboeTester: fix hang msec menu when no callbacks

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.cpp
+++ b/apps/OboeTester/app/src/main/cpp/AudioStreamGateway.cpp
@@ -28,6 +28,7 @@ oboe::DataCallbackResult AudioStreamGateway::onAudioReady(
         void *audioData,
         int numFrames) {
 
+    maybeHang(getNanoseconds());
     printScheduler();
 
     if (mAudioSink != nullptr) {

--- a/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.cpp
+++ b/apps/OboeTester/app/src/main/cpp/InputStreamCallbackAnalyzer.cpp
@@ -34,6 +34,7 @@ oboe::DataCallbackResult InputStreamCallbackAnalyzer::onAudioReady(
         int numFrames) {
     int32_t channelCount = audioStream->getChannelCount();
 
+    maybeHang(getNanoseconds());
     printScheduler();
     mInputConverter->convertToInternalOutput(numFrames * channelCount, audioData);
     float *floatData = (float *) mInputConverter->getOutputBuffer();

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
@@ -26,8 +26,6 @@ oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
     oboe::DataCallbackResult callbackResult = oboe::DataCallbackResult::Stop;
     int64_t startTimeNanos = getNanoseconds();
 
-    maybeHang(startTimeNanos);
-
     if (mCpuAffinityMask != mPreviousMask) {
         uint32_t mask = mCpuAffinityMask;
         applyCpuAffinityMask(mask);


### PR DESCRIPTION
It was ignoring the menu setting when not using callbacks.

See #1829