### PR TITLE
OboeTester: clear volume ramps on start

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -497,6 +497,15 @@ void ActivityTestOutput::runBlockingIO() {
     }
 }
 
+oboe::Result ActivityTestOutput::startStreams() {
+    mSinkFloat->pullReset();
+    mSinkI16->pullReset();
+    mSinkI24->pullReset();
+    mSinkI32->pullReset();
+    mVolumeRamp->setTarget(mAmplitude);
+    return getOutputStream()->start();
+}
+
 // ======================================================================= ActivityTestInput
 void ActivityTestInput::configureAfterOpen() {
     mInputAnalyzer.reset();

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -410,9 +410,7 @@ public:
 
     void close(int32_t streamIndex) override;
 
-    oboe::Result startStreams() override {
-        return getOutputStream()->start();
-    }
+    oboe::Result startStreams() override;
 
     void configureAfterOpen() override;
 


### PR DESCRIPTION
Fixes #1847 