### PR TITLE
OboeTester: fix crash in Tap-to-tone

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -511,7 +511,9 @@ oboe::Result ActivityTestOutput::startStreams() {
     mSinkI16->pullReset();
     mSinkI24->pullReset();
     mSinkI32->pullReset();
-    mVolumeRamp->setTarget(mAmplitude);
+    if (mVolumeRamp != nullptr) {
+        mVolumeRamp->setTarget(mAmplitude);
+    }
     return getOutputStream()->start();
 }
 


### PR DESCRIPTION
A change to the Volume ramp caused a regression.

Fixes #1857