### PR TITLE
OboeTester: Data Paths cleanup, remove earpiece

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
@@ -54,11 +54,11 @@ public class AudioDeviceInfoConverter {
 
         sb.append("\nChannel masks: ");
         int[] channelMasks = adi.getChannelMasks();
-        sb.append(intArrayToString(channelMasks));
+        sb.append(intArrayToStringHex(channelMasks));
 
         sb.append("\nChannel index masks: ");
         int[] channelIndexMasks = adi.getChannelIndexMasks();
-        sb.append(intArrayToString(channelIndexMasks));
+        sb.append(intArrayToStringHex(channelIndexMasks));
 
         sb.append("\nEncodings: ");
         int[] encodings = adi.getEncodings();
@@ -111,6 +111,21 @@ public class AudioDeviceInfoConverter {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < integerArray.length; i++){
             sb.append(integerArray[i]);
+            if (i != integerArray.length -1) sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts an integer array into a hexadecimal string where each int is separated by a space
+     *
+     * @param integerArray the integer array to convert to a string
+     * @return string containing all the integer values separated by spaces
+     */
+    private static String intArrayToStringHex(int[] integerArray){
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < integerArray.length; i++){
+            sb.append(String.format("0x%02X", integerArray[i]));
             if (i != integerArray.length -1) sb.append(" ");
         }
         return sb.toString();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/audio_device/AudioDeviceInfoConverter.java
@@ -111,7 +111,7 @@ public class AudioDeviceInfoConverter {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < integerArray.length; i++){
             sb.append(integerArray[i]);
-            if (i != integerArray.length -1) sb.append(" ");
+            if (i != integerArray.length - 1) sb.append(" ");
         }
         return sb.toString();
     }
@@ -126,7 +126,7 @@ public class AudioDeviceInfoConverter {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < integerArray.length; i++){
             sb.append(String.format("0x%02X", integerArray[i]));
-            if (i != integerArray.length -1) sb.append(" ");
+            if (i != integerArray.length - 1) sb.append(" ");
         }
         return sb.toString();
     }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
@@ -71,7 +71,11 @@ abstract class OboeAudioStream extends AudioStreamBase {
         );
         if (result < 0) {
             streamIndex = INVALID_STREAM_INDEX;
-            throw new IOException("Open failed! result = " + result);
+            String message = "Open "
+                    + (isInput() ? "Input" : "Output")
+                    + " failed! result = " + result + ", "
+                    + StreamConfiguration.convertErrorToText(result);
+            throw new IOException(message);
         } else {
             streamIndex = result;
         }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -70,10 +70,12 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     private final static double MAX_ALLOWED_JITTER = 2.0 * PHASE_PER_BIN;
     private final static String MAGNITUDE_FORMAT = "%7.5f";
 
-    public static final int JAVA_CHANNEL_IN_LEFT = 1 << 2;
-    public static final int JAVA_CHANNEL_IN_RIGHT = 1 << 3;
-    public static final int JAVA_CHANNEL_IN_FRONT = 1 << 4;
-    public static final int JAVA_CHANNEL_IN_BACK = 1 << 5;
+    // These define the values returned by the Java API deviceInfo.getChannelMasks().
+    public static final int JAVA_CHANNEL_IN_LEFT = 1 << 2;  // AudioFormat.CHANNEL_IN_LEFT
+    public static final int JAVA_CHANNEL_IN_RIGHT = 1 << 3; // AudioFormat.CHANNEL_IN_RIGHT
+    public static final int JAVA_CHANNEL_IN_FRONT = 1 << 4; // AudioFormat.CHANNEL_IN_FRONT
+    public static final int JAVA_CHANNEL_IN_BACK = 1 << 5;  // AudioFormat.CHANNEL_IN_BACK
+
     public static final int JAVA_CHANNEL_IN_BACK_LEFT = 1 << 16;
     public static final int JAVA_CHANNEL_IN_BACK_RIGHT = 1 << 17;
     public static final int JAVA_CHANNEL_IN_CENTER = 1 << 18;
@@ -117,8 +119,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     private CheckBox mCheckBoxOutputDevices;
 
     private static final int[] INPUT_PRESETS = {
-            // VOICE_RECOGNITION gets tested in testInputs()
-            // StreamConfiguration.INPUT_PRESET_VOICE_RECOGNITION,
             StreamConfiguration.INPUT_PRESET_GENERIC,
             StreamConfiguration.INPUT_PRESET_CAMCORDER,
             StreamConfiguration.INPUT_PRESET_UNPROCESSED,
@@ -463,15 +463,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         for (int inputPreset : INPUT_PRESETS) {
             testPresetCombo(inputPreset);
         }
-// TODO Resolve issue with echo cancellation killing the signal.
-//        testPresetCombo(StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION,
-//                1, 0, 2, 0);
-//        testPresetCombo(StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION,
-//                1, 0, 2, 1);
-//        testPresetCombo(StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION,
-//                2, 0, 2, 0);
-//        testPresetCombo(StreamConfiguration.INPUT_PRESET_VOICE_COMMUNICATION,
-//                2, 0, 2, 1);
     }
 
     void testInputDeviceCombo(int deviceId,
@@ -525,7 +516,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         int numTested = 0;
         for (AudioDeviceInfo deviceInfo : devices) {
             log("----\n"
-                    + AudioDeviceInfoConverter.toString(deviceInfo) + "\n");
+                    + AudioDeviceInfoConverter.toString(deviceInfo));
             if (!deviceInfo.isSource()) continue; // FIXME log as error?!
             int deviceType = deviceInfo.getType();
             if (deviceType == AudioDeviceInfo.TYPE_BUILTIN_MIC) {
@@ -701,7 +692,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             if (!deviceInfo.isSink()) continue;
             int deviceType = deviceInfo.getType();
             if (deviceType == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
-                || deviceType == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
                 || deviceType == TYPE_BUILTIN_SPEAKER_SAFE) {
                 int id = deviceInfo.getId();
                 int[] channelCounts = deviceInfo.getChannelCounts();
@@ -734,7 +724,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                     }
                 }
             } else {
-                log("Device skipped. Not BuiltIn Speaker.");
+                log("Device skipped because DeviceType not testable.");
             }
         }
         if (numTested == 0) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -76,6 +76,8 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     public static final int JAVA_CHANNEL_IN_FRONT = 1 << 4; // AudioFormat.CHANNEL_IN_FRONT
     public static final int JAVA_CHANNEL_IN_BACK = 1 << 5;  // AudioFormat.CHANNEL_IN_BACK
 
+    // These do not have corresponding Java definitions.
+    // They match definitions in system/media/audio/include/system/audio-hal-enums.h
     public static final int JAVA_CHANNEL_IN_BACK_LEFT = 1 << 16;
     public static final int JAVA_CHANNEL_IN_BACK_RIGHT = 1 << 17;
     public static final int JAVA_CHANNEL_IN_CENTER = 1 << 18;
@@ -724,7 +726,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                     }
                 }
             } else {
-                log("Device skipped because DeviceType not testable.");
+                log("Device skipped because DeviceType is not testable.");
             }
         }
         if (numTested == 0) {


### PR DESCRIPTION
Remove earpiece tests because they are flakey.
Show more info when open fails.
Display channel masks in hex format.

Fixes #1866