### PR TITLE
OboeTester: Shorten Release string

### DIFF
--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="pauseAudio">Pause</string>
     <string name="flushAudio">Flush</string>
     <string name="stopAudio">Stop</string>
-    <string name="releaseAudio">Release</string>
+    <string name="releaseAudio">Rlse</string>
     <string name="closeAudio">Close</string>
     <string name="recordAudio">Record</string>
     <string name="playAudio">Play</string>


### PR DESCRIPTION
For smaller screens, the release button is taking multiple lines.