### PR TITLE
OboeTester: associate volume keys with stream type

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -16,12 +16,12 @@
 
 package com.mobileer.oboetester;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.media.AudioAttributes;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Build;
@@ -37,16 +37,9 @@ import android.widget.CheckBox;
 import android.widget.Spinner;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-
-import com.mobileer.audio_device.CommunicationDeviceSpinner;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -587,6 +580,10 @@ abstract class TestAudioActivity extends Activity {
                 if (sampleRate == 0) {
                     sampleRate = streamSampleRate;
                 }
+                // Associate volume keys with this output stream.
+                int actualUsage = streamContext.tester.actualConfiguration.getUsage();
+                int actualContentType = streamContext.tester.actualConfiguration.getContentType();
+                setStreamControlByAttributes(actualUsage, actualContentType);
             }
         }
         for (StreamContext streamContext : mStreamContexts) {
@@ -600,6 +597,21 @@ abstract class TestAudioActivity extends Activity {
         updateEnabledWidgets();
         onStartAllContexts();
         mStreamSniffer.startStreamSniffer();
+    }
+
+    /**
+     * Associate the volume keys with the stream we are playing.
+     * @param usage usage for the stream
+     * @param contentType tupe of the stream
+     */
+    private void setStreamControlByAttributes(int usage, int contentType) {
+        AudioAttributes attributes = new AudioAttributes.Builder().setUsage(usage)
+                .setContentType(contentType).build();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            int volumeControlStream = attributes.getVolumeControlStream();
+            Log.i(TAG, "setVolumeControlStream(" + volumeControlStream + ")");
+            setVolumeControlStream(volumeControlStream);
+        }
     }
 
     /**


### PR DESCRIPTION
This is important when debugging the effect of volume keys on streams with various Usages or ContentTypes.