### PR TITLE
OboeTester: TEST DISCONNECT checks for mic on headset

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -42,8 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 
 /**
- * Guide the user through a series of tests plugging in and unplugging a headset.
- * Print a summary at the end of any failures.
+ * Print a report of all the available audio devices.
  */
 public class DeviceReportActivity extends Activity {
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
@@ -30,6 +30,25 @@
         android:textStyle="bold"
         />
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/checkbox_disco_outputs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="Outputs" />
+
+        <CheckBox
+            android:id="@+id/checkbox_disco_inputs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="Inputs" />
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -246,7 +246,7 @@
     <string name="failTest">Fail</string>
     <string name="skipTest">Skip</string>
     <string name="test_datapath_instructions">Disconnect all headsets.\nIn quiet room, volume up, [START]</string>
-    <string name="test_disconnect_instructions">Disconnect all headsets.\nPress [START]</string>
+    <string name="test_disconnect_instructions">Disconnect all headsets.\nPress [RUN]</string>
 
     <string name="analyze">Analyze</string>
 


### PR DESCRIPTION
Some peripherals have no mic so the INPUT test fails. Now there will be a message explaining why.

Also add checkboxes for disabling INPUT or OUTPUT tests.

Avoid asking user to plug in a headset when it is already plugged in.

Fixes #1045