### PR TITLE
OboeTester: Stop using get_nprocs()

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
@@ -223,7 +223,7 @@ public:
     int applyCpuAffinityMask(uint32_t mask) {
         cpu_set_t cpu_set;
         CPU_ZERO(&cpu_set);
-        int cpuCount = get_nprocs();
+        int cpuCount = sysconf(_SC_NPROCESSORS_CONF);
         for (int cpuIndex = 0; cpuIndex < cpuCount; cpuIndex++) {
             if (mask & (1 << cpuIndex)) {
                 CPU_SET(cpuIndex, &cpu_set);

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -118,7 +118,7 @@ Java_com_mobileer_oboetester_NativeEngine_areWorkaroundsEnabled(JNIEnv *env,
 
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_NativeEngine_getCpuCount(JNIEnv *env, jclass type) {
-    return get_nprocs();
+    return sysconf(_SC_NPROCESSORS_CONF);
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
Fixes #1891