### PR TITLE
OboeTester: improve CPU LOAD test

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -157,6 +157,10 @@ public:
         return oboeCallbackProxy.getAndResetMaxCpuLoad();
     }
 
+    uint32_t getAndResetCpuMask() {
+        return oboeCallbackProxy.getAndResetCpuMask();
+    }
+
     std::string getCallbackTimeString() {
         return oboeCallbackProxy.getCallbackTimeString();
     }

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -519,6 +519,11 @@ Java_com_mobileer_oboetester_OboeAudioStream_getAndResetMaxCpuLoad(JNIEnv *env, 
     return engine.getCurrentActivity()->getAndResetMaxCpuLoad();
 }
 
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_OboeAudioStream_getAndResetCpuMask(JNIEnv *env, jobject instance, jint streamIndex) {
+    return (jint) engine.getCurrentActivity()->getAndResetCpuMask();
+}
+
 JNIEXPORT jstring JNICALL
 Java_com_mobileer_oboetester_OboeAudioStream_getCallbackTimeString(JNIEnv *env, jobject instance) {
     return env->NewStringUTF(engine.getCurrentActivity()->getCallbackTimeString().c_str());

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioStreamBase.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioStreamBase.java
@@ -245,6 +245,7 @@ public abstract class AudioStreamBase {
 
     public float getCpuLoad() { return 0.0f; }
     public float getAndResetMaxCpuLoad() { return 0.0f; }
+    public int getAndResetCpuMask() { return 0; }
 
     public String getCallbackTimeStr() { return "?"; };
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/OboeAudioStream.java
@@ -294,6 +294,12 @@ abstract class OboeAudioStream extends AudioStreamBase {
     private native float getAndResetMaxCpuLoad(int streamIndex);
 
     @Override
+    public int getAndResetCpuMask() {
+        return getAndResetCpuMask(streamIndex);
+    }
+    private native int getAndResetCpuMask(int streamIndex);
+
+    @Override
     public String getCallbackTimeStr() {
         return getCallbackTimeString();
     }


### PR DESCRIPTION
Show CPU migrations.
Fix clearing of CPU affinity.
Disable drawing during the benchmarking phase so it will converge.