### PR TITLE
OboeTester: AUTO GLITCH improvements

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -43,7 +43,7 @@ public:
 
     void setMagnitude(double magnitude) {
         mMagnitude = magnitude;
-        mScaledTolerance = mMagnitude * mTolerance;
+        mScaledTolerance = mMagnitude * getTolerance();
     }
 
     double getPhaseOffset() {

--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -63,7 +63,7 @@ public:
         if (mState != STATE_LOCKED
                 || mMeanSquareSignal < threshold
                 || mMeanSquareNoise < threshold) {
-            return 0.0;
+            return -999.0; // error indicator
         } else {
             double signalToNoise = mMeanSquareSignal / mMeanSquareNoise; // power ratio
             double signalToNoiseDB = 10.0 * log(signalToNoise);
@@ -204,14 +204,14 @@ public:
                     mSumSquareSignal += predicted * predicted;
                     mSumSquareNoise += diff * diff;
 
-
                     // Track incoming signal and slowly adjust magnitude to account
                     // for drift in the DRC or AGC.
                     // Must be a multiple of the period or the calculation will not be accurate.
                     if (transformSample(sample, mInputPhase)) {
                         mMeanSquareNoise = mSumSquareNoise * mInverseSinePeriod;
                         mMeanSquareSignal = mSumSquareSignal * mInverseSinePeriod;
-                        resetAccumulator();
+                        mSumSquareNoise = 0.0;
+                        mSumSquareSignal = 0.0;
 
                         if (abs(mPhaseOffset) > kMaxPhaseError) {
                             result = ERROR_GLITCHES;
@@ -286,8 +286,6 @@ public:
     // reset the sine wave detector
     void resetAccumulator() override {
         BaseSineAnalyzer::resetAccumulator();
-        mSumSquareSignal = 0.0;
-        mSumSquareNoise = 0.0;
     }
 
     void relock() {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
@@ -139,10 +139,10 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
                 }
             }
 
-            analyzeTestResults();
+            compareFailedTestsWithNearestPassingTest();
 
         } catch (InterruptedException e) {
-            analyzeTestResults();
+            compareFailedTestsWithNearestPassingTest();
 
         } catch (Exception e) {
             log(e.getMessage());

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mobileer.oboetester;
 
 import android.os.Bundle;
@@ -5,6 +21,12 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Spinner;
 
+/**
+ * Look for glitches with various configurations.
+ * A sine wave is played and continuously recorded using loopback.
+ * An analyzer locks to the phase and magnitude of the detected sine wave.
+ * It then compares the incoming signal with a predicted sine wave.
+ */
 public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
 
     private Spinner mDurationSpinner;
@@ -43,6 +65,8 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
 
         mDurationSpinner = (Spinner) findViewById(R.id.spinner_glitch_duration);
         mDurationSpinner.setOnItemSelectedListener(new DurationSpinnerListener());
+
+        setAnalyzerText(getString(R.string.auto_glitch_instructions));
     }
 
     @Override
@@ -75,8 +99,6 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
         requestedInConfig.setChannelCount(inChannels);
         requestedOutConfig.setChannelCount(outChannels);
 
-        setTolerance(0.3f); // FIXME remove
-
         testInOutConfigurations();
     }
 
@@ -98,10 +120,17 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
 
             mTestResults.clear();
 
+            // Test with STEREO on both input and output.
+            testConfiguration(StreamConfiguration.PERFORMANCE_MODE_LOW_LATENCY,
+                    StreamConfiguration.SHARING_MODE_EXCLUSIVE,
+                    UNSPECIFIED, STEREO, STEREO);
+
+            // Test EXCLUSIVE mode with a configuration most likely to work.
             testConfiguration(StreamConfiguration.PERFORMANCE_MODE_LOW_LATENCY,
                     StreamConfiguration.SHARING_MODE_EXCLUSIVE,
                     UNSPECIFIED);
 
+            // Test various combinations.
             for (int perfMode : PERFORMANCE_MODES) {
                 for (int sampleRate : SAMPLE_RATES) {
                     testConfiguration(perfMode,

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -288,14 +288,14 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
                 getOutputChannel()
         );
 
-        // The test would only be worth running if we got the configuration we requested on input or output.
+        // The test will only be worth running if we got the configuration we requested on input or output.
         String skipReason = shouldTestBeSkipped();
         boolean skipped = skipReason.length() > 0;
         boolean valid = !openFailed && !skipped;
         boolean startFailed = false;
         if (valid) {
             try {
-                startAudioTest();
+                startAudioTest();   // Start running the test in the background.
             } catch (IOException e) {
                 e.printStackTrace();
                 valid = false;
@@ -361,6 +361,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
                 mAutomatedTestRunner.incrementPassCount();
                 result = TEST_RESULT_PASSED;
             }
+
         }
         mAutomatedTestRunner.flushLog();
 
@@ -408,7 +409,18 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         appendFailedSummary(text + "\n");
     }
 
+    private int countPassingTests() {
+        int numPassed = 0;
+        for (TestResult other : mTestResults) {
+            if (other.passed()) {
+                numPassed++;
+            }
+        }
+        return numPassed;
+    }
+
     protected void analyzeTestResults() {
+        if (countPassingTests() == 0) return;
         logAnalysis("\n==== ANALYSIS ===========");
         logAnalysis("Compare failed configuration with closest one that passed.");
         // Analyze each failed test.
@@ -427,6 +439,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             }
         }
     }
+
 
     @Nullable
     private TestResult[] findClosestPassingTestResults(TestResult testResult) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -419,10 +419,13 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         return numPassed;
     }
 
-    protected void analyzeTestResults() {
-        if (countPassingTests() == 0) return;
-        logAnalysis("\n==== ANALYSIS ===========");
-        logAnalysis("Compare failed configuration with closest one that passed.");
+    protected void compareFailedTestsWithNearestPassingTest() {
+        logAnalysis("\n==== COMPARISON ANALYSIS ===========");
+        if (countPassingTests() == 0) {
+            logAnalysis("Comparison skipped because NO tests passed.");
+            return;
+        }
+        logAnalysis("Compare failed tests with others that passed.");
         // Analyze each failed test.
         for (TestResult testResult : mTestResults) {
             if (testResult.failed()) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -62,7 +62,7 @@ public class GlitchActivity extends AnalyzerActivity {
     }
 
     // Note that these strings must match the enum result_code in LatencyAnalyzer.h
-    String stateToString(int resultCode) {
+    static String stateToString(int resultCode) {
         switch (resultCode) {
             case STATE_IDLE:
                 return "IDLE";
@@ -79,6 +79,10 @@ public class GlitchActivity extends AnalyzerActivity {
             default:
                 return "UNKNOWN";
         }
+    }
+
+    static String magnitudeToString(double magnitude) {
+        return String.format(Locale.US, "%6.4f", magnitude);
     }
 
     // Periodically query for glitches from the native detector.
@@ -195,7 +199,12 @@ public class GlitchActivity extends AnalyzerActivity {
 
         @Override
         public String getShortReport() {
-            String resultText = "#glitches = " + getLastGlitchCount()
+            String resultText = "amplitude: peak = " + magnitudeToString(mPeakAmplitude)
+                    + ", sine = " + magnitudeToString(mSineAmplitude) + "\n";
+            if (mPeakAmplitude < 0.01) {
+                resultText += "WARNING: volume is very low!\n";
+            }
+            resultText += "#glitches = " + getLastGlitchCount()
                     + ", #resets = " + getLastResetCount()
                     + ", max no glitch = " + getMaxSecondsWithNoGlitch() + " secs\n";
             resultText += String.format(Locale.getDefault(), "SNR = %5.1f db", mSignalToNoiseDB);
@@ -234,7 +243,8 @@ public class GlitchActivity extends AnalyzerActivity {
 
     /**
      * Set tolerance to deviations from expected value.
-     * The normalized value will be converted in the native code.
+     * The normalized value will be scaled by the measured magnitude
+     * of the sine wave..
      * @param tolerance normalized between 0.0 and 1.0
      */
     public native void setTolerance(float tolerance);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -22,7 +22,6 @@ import static com.mobileer.oboetester.StreamConfiguration.convertChannelMaskToTe
 import android.app.Activity;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
-import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.util.Log;
@@ -761,12 +760,12 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 testOutputDevices();
             }
 
-            analyzeTestResults();
+            compareFailedTestsWithNearestPassingTest();
 
             runOnUiThread(() -> keepScreenOn(false));
 
         } catch (InterruptedException e) {
-            analyzeTestResults();
+            compareFailedTestsWithNearestPassingTest();
         } catch (Exception e) {
             log(e.getMessage());
             showErrorToast(e.getMessage());

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -53,6 +53,12 @@
         Set volume to medium-high.\n
     </string>
 
+    <string name="auto_glitch_instructions">
+        Plug in a loopback adapter.\n
+        Then set volume to about 80%.\n
+        Then press Run button.\n
+    </string>
+
     <string name="api_prompt">Choose an API</string>
     <string-array name="output_modes">
         <item>Unspecified</item>


### PR DESCRIPTION
* Reduce tolerance for glitches.
* Ask user to plugin loopback adapter and turn up volume. 
* Print peak.amplitude and sine.amplitude in report. Warn if peak.amplitude too low.
* Don't compare with other passed tests if none passed. 
* Fix SNR calculation. Was always 0.0.

Fixes #1902