### PR TITLE
OboeTester: Test downmixing with data paths test 

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -756,7 +756,8 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                     }
                 }
 
-                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2
+                        && deviceType == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) {
                     runOnUiThread(() -> mCheckBoxAllOutputChannelMasks.setEnabled(false));
 
                     for (int channelMask : mCheckBoxAllOutputChannelMasks.isChecked() ?

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.CheckBox;
@@ -127,6 +128,31 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             // Do not use INPUT_PRESET_VOICE_COMMUNICATION because AEC kills the signal.
             StreamConfiguration.INPUT_PRESET_VOICE_RECOGNITION,
             StreamConfiguration.INPUT_PRESET_VOICE_PERFORMANCE,
+    };
+
+    private static final int[] OUTPUT_CHANNEL_MASKS = {
+            StreamConfiguration.CHANNEL_MONO,
+            StreamConfiguration.CHANNEL_STEREO,
+            StreamConfiguration.CHANNEL_2POINT1,
+            StreamConfiguration.CHANNEL_TRI,
+            StreamConfiguration.CHANNEL_TRI_BACK,
+            StreamConfiguration.CHANNEL_3POINT1,
+            StreamConfiguration.CHANNEL_2POINT0POINT2,
+            StreamConfiguration.CHANNEL_2POINT1POINT2,
+            StreamConfiguration.CHANNEL_3POINT0POINT2,
+            StreamConfiguration.CHANNEL_3POINT1POINT2,
+            StreamConfiguration.CHANNEL_QUAD,
+            StreamConfiguration.CHANNEL_QUAD_SIDE,
+            StreamConfiguration.CHANNEL_SURROUND,
+            StreamConfiguration.CHANNEL_PENTA,
+            StreamConfiguration.CHANNEL_5POINT1,
+            StreamConfiguration.CHANNEL_5POINT1_SIDE,
+            StreamConfiguration.CHANNEL_6POINT1,
+            StreamConfiguration.CHANNEL_7POINT1,
+            StreamConfiguration.CHANNEL_5POINT1POINT2,
+            StreamConfiguration.CHANNEL_5POINT1POINT4,
+            StreamConfiguration.CHANNEL_7POINT1POINT2,
+            StreamConfiguration.CHANNEL_7POINT1POINT4,
     };
 
     @NonNull
@@ -541,20 +567,23 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                         }
                     }
                 }
-                int[] channelMasks = deviceInfo.getChannelMasks();
-                if (channelMasks.length > 0) {
-                    for (int channelMask : channelMasks) {
-                        int nativeChannelMask =
-                                convertJavaInChannelMaskToNativeChannelMask(channelMask);
-                        if (nativeChannelMask == JAVA_CHANNEL_UNDEFINED) {
-                            log("channelMask: " + channelMask + " not supported. Skipping.\n");
-                            continue;
-                        }
-                        log("nativeChannelMask = " + convertChannelMaskToText(nativeChannelMask) + "\n");
-                        int channelCount = Integer.bitCount(nativeChannelMask);
-                        for (int channel = 0; channel < channelCount; channel++) {
-                            testInputDeviceCombo(id, deviceType, channelCount, nativeChannelMask,
-                                    channel);
+
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+                    int[] channelMasks = deviceInfo.getChannelMasks();
+                    if (channelMasks.length > 0) {
+                        for (int channelMask : channelMasks) {
+                            int nativeChannelMask =
+                                    convertJavaInChannelMaskToNativeChannelMask(channelMask);
+                            if (nativeChannelMask == JAVA_CHANNEL_UNDEFINED) {
+                                log("channelMask: " + channelMask + " not supported. Skipping.\n");
+                                continue;
+                            }
+                            log("nativeChannelMask = " + convertChannelMaskToText(nativeChannelMask) + "\n");
+                            int channelCount = Integer.bitCount(nativeChannelMask);
+                            for (int channel = 0; channel < channelCount; channel++) {
+                                testInputDeviceCombo(id, deviceType, channelCount, nativeChannelMask,
+                                        channel);
+                            }
                         }
                     }
                 }
@@ -713,15 +742,13 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                         }
                     }
                 }
-                int[] channelMasks = deviceInfo.getChannelMasks();
-                if (channelMasks.length > 0) {
-                    for (int channelMask : channelMasks) {
-                        int nativeChannelMask =
-                                convertJavaOutChannelMaskToNativeChannelMask(channelMask);
-                        log("nativeChannelMask = " + convertChannelMaskToText(nativeChannelMask) + "\n");
-                        int channelCount = Integer.bitCount(nativeChannelMask);
+
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+                    for (int channelMask : OUTPUT_CHANNEL_MASKS) {
+                        log("channelMask = " + convertChannelMaskToText(channelMask) + "\n");
+                        int channelCount = Integer.bitCount(channelMask);
                         for (int channel = 0; channel < channelCount; channel++) {
-                            testOutputDeviceCombo(id, deviceType, channelCount, nativeChannelMask, channel);
+                            testOutputDeviceCombo(id, deviceType, channelCount, channelMask, channel);
                         }
                     }
                 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -59,6 +59,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     public static final String KEY_USE_OUTPUT_DEVICES = "use_output_devices";
     public static final boolean VALUE_DEFAULT_USE_OUTPUT_DEVICES = true;
 
+    public static final String KEY_USE_ALL_OUTPUT_CHANNEL_MASKS = "use_all_output_channel_masks";
+    public static final boolean VALUE_DEFAULT_USE_ALL_OUTPUT_CHANNEL_MASKS = false;
+
     public static final String KEY_SINGLE_TEST_INDEX = "single_test_index";
     public static final int VALUE_DEFAULT_SINGLE_TEST_INDEX = -1;
 
@@ -120,6 +123,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     private CheckBox mCheckBoxInputPresets;
     private CheckBox mCheckBoxInputDevices;
     private CheckBox mCheckBoxOutputDevices;
+    private CheckBox mCheckBoxAllOutputChannelMasks;
 
     private static final int[] INPUT_PRESETS = {
             StreamConfiguration.INPUT_PRESET_GENERIC,
@@ -130,7 +134,14 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             StreamConfiguration.INPUT_PRESET_VOICE_PERFORMANCE,
     };
 
-    private static final int[] OUTPUT_CHANNEL_MASKS = {
+    private static final int[] SHORT_OUTPUT_CHANNEL_MASKS = {
+            StreamConfiguration.CHANNEL_MONO,
+            StreamConfiguration.CHANNEL_STEREO,
+            StreamConfiguration.CHANNEL_2POINT1,
+            StreamConfiguration.CHANNEL_7POINT1POINT4,
+    };
+
+    private static final int[] ALL_OUTPUT_CHANNEL_MASKS = {
             StreamConfiguration.CHANNEL_MONO,
             StreamConfiguration.CHANNEL_STEREO,
             StreamConfiguration.CHANNEL_2POINT1,
@@ -280,6 +291,8 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
         mCheckBoxInputPresets = (CheckBox)findViewById(R.id.checkbox_paths_input_presets);
         mCheckBoxInputDevices = (CheckBox)findViewById(R.id.checkbox_paths_input_devices);
         mCheckBoxOutputDevices = (CheckBox)findViewById(R.id.checkbox_paths_output_devices);
+        mCheckBoxAllOutputChannelMasks =
+                (CheckBox)findViewById(R.id.checkbox_paths_all_output_channel_masks);
     }
 
     @Override
@@ -744,7 +757,10 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 }
 
                 if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
-                    for (int channelMask : OUTPUT_CHANNEL_MASKS) {
+                    runOnUiThread(() -> mCheckBoxAllOutputChannelMasks.setEnabled(false));
+
+                    for (int channelMask : mCheckBoxAllOutputChannelMasks.isChecked() ?
+                            ALL_OUTPUT_CHANNEL_MASKS : SHORT_OUTPUT_CHANNEL_MASKS) {
                         log("channelMask = " + convertChannelMaskToText(channelMask) + "\n");
                         int channelCount = Integer.bitCount(channelMask);
                         for (int channel = 0; channel < channelCount; channel++) {
@@ -799,6 +815,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 mCheckBoxInputPresets.setEnabled(true);
                 mCheckBoxInputDevices.setEnabled(true);
                 mCheckBoxOutputDevices.setEnabled(true);
+                mCheckBoxAllOutputChannelMasks.setEnabled(true);
                 keepScreenOn(false);
             });
         }
@@ -816,6 +833,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 VALUE_DEFAULT_USE_INPUT_DEVICES);
         boolean shouldUseOutputDevices = mBundleFromIntent.getBoolean(KEY_USE_OUTPUT_DEVICES,
                 VALUE_DEFAULT_USE_OUTPUT_DEVICES);
+        boolean shouldUseAllOutputChannelMasks =
+                mBundleFromIntent.getBoolean(KEY_USE_ALL_OUTPUT_CHANNEL_MASKS,
+                VALUE_DEFAULT_USE_ALL_OUTPUT_CHANNEL_MASKS);
         int singleTestIndex = mBundleFromIntent.getInt(KEY_SINGLE_TEST_INDEX,
                 VALUE_DEFAULT_SINGLE_TEST_INDEX);
 
@@ -823,6 +843,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             mCheckBoxInputPresets.setChecked(shouldUseInputPresets);
             mCheckBoxInputDevices.setChecked(shouldUseInputDevices);
             mCheckBoxOutputDevices.setChecked(shouldUseOutputDevices);
+            mCheckBoxAllOutputChannelMasks.setChecked(shouldUseAllOutputChannelMasks);
             mAutomatedTestRunner.setTestIndexText(singleTestIndex);
         });
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -35,6 +35,13 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:text="OutDev" />
+
+        <CheckBox
+            android:id="@+id/checkbox_paths_all_output_channel_masks"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:text="AllOutCMs" />
     </LinearLayout>
 
     <TextView

--- a/apps/OboeTester/docs/AutomatedTesting.md
+++ b/apps/OboeTester/docs/AutomatedTesting.md
@@ -113,6 +113,7 @@ There are several optional parameters for just the "data_paths" test:
     --ez use_input_presets  {"true", 1, "false", 0}  // Whether to test various input presets. Note use of "-ez"
     --ez use_input_devices  {"true", 1, "false", 0}  // Whether to test various input devices. Note use of "-ez"
     --ez use_output_devices {"true", 1, "false", 0}  // Whether to test various output devices. Note use of "-ez"
+    --ez use_all_output_channel_masks {"true", 1, "false", 0}  // Whether to test all output channel masks. Note use of "-ez". Default is false
     --ei single_test_index  {testId}  // Index for testing one specific test
 
 There are some optional parameters for just the "output" test:


### PR DESCRIPTION
Currently, the data paths test only plays output channel masks explicitly declared in AudioDeviceInfo.

AudioFlinger handles downmixing for extra channels. Thus, we can actually test that downmixing works for channel masks that the device does not explicitly support.

This PR changes output configs to an arbitrary set of channel masks (mono, stereo, 2.1, 7.1.4) with an checkbox to test all supported channel masks.

Fixes #1912 