### PR TITLE
OboeTester: update the current communications device

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/CommunicationDeviceView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/CommunicationDeviceView.java
@@ -16,6 +16,7 @@
 
 package com.mobileer.oboetester;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -34,6 +35,8 @@ import android.widget.TextView;
 
 import com.mobileer.audio_device.CommunicationDeviceSpinner;
 
+import java.util.Locale;
+
 public class CommunicationDeviceView extends LinearLayout {
 
     private AudioManager mAudioManager;
@@ -45,6 +48,14 @@ public class CommunicationDeviceView extends LinearLayout {
     private boolean mScoStateReceiverRegistered = false;
     private CommunicationDeviceSpinner mDeviceSpinner;
     private int mScoState;
+    private CommDeviceSniffer mCommDeviceSniffer = new CommDeviceSniffer();;
+
+    protected class CommDeviceSniffer extends NativeSniffer {
+        @Override
+        public void updateStatusText() {
+            showCommDeviceStatus();
+        }
+    }
 
     public CommunicationDeviceView(Context context) {
         super(context);
@@ -129,9 +140,12 @@ public class CommunicationDeviceView extends LinearLayout {
 
     public void onStart() {
         registerScoStateReceiver();
+        mCommDeviceSniffer.startSniffer();
     }
 
+
     public void onStop() {
+        mCommDeviceSniffer.stopSniffer();
         mSpeakerphoneCheckbox.setChecked(false);
         setSpeakerPhoneOn(false);
         mScoCheckbox.setChecked(false);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/EchoActivity.java
@@ -43,7 +43,7 @@ public class EchoActivity extends TestInputActivity {
     private Button mStopButton;
     private TextView mStatusTextView;
 
-    private ColdStartSniffer mNativeSniffer = new ColdStartSniffer(this);
+    private ColdStartSniffer mNativeSniffer = new ColdStartSniffer();
 
     protected static final int MAX_DELAY_TIME_PROGRESS = 1000;
 
@@ -70,10 +70,6 @@ public class EchoActivity extends TestInputActivity {
         private int mInputLatency;
         private int mOutputLatency;
 
-        public ColdStartSniffer(Activity activity) {
-            super(activity);
-        }
-
         @Override
         public void startSniffer() {
             stableCallCount = 0;
@@ -82,16 +78,10 @@ public class EchoActivity extends TestInputActivity {
             super.startSniffer();
         }
 
-        public void run() {
+        @Override
+        public boolean isComplete() {
             mInputLatency = getColdStartInputMillis();
             mOutputLatency = getColdStartOutputMillis();
-            updateStatusText();
-            if (!isComplete()) {
-                reschedule();
-            }
-        }
-
-        private boolean isComplete() {
             if (mInputLatency > 0 && mOutputLatency > 0) {
                 stableCallCount++;
             }
@@ -112,11 +102,6 @@ public class EchoActivity extends TestInputActivity {
                     + "\n");
             message.append("stable.call.count = " + stableCallCount +  "\n");
             return message.toString();
-        }
-
-        @Override
-        public String getShortReport() {
-            return getCurrentStatusReport();
         }
 
         @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -51,14 +51,10 @@ public class GlitchActivity extends AnalyzerActivity {
     native double getPeakAmplitude();
     native double getSineAmplitude();
 
-    private GlitchSniffer mGlitchSniffer;
     protected NativeSniffer mNativeSniffer = createNativeSniffer();
 
     synchronized NativeSniffer createNativeSniffer() {
-        if (mGlitchSniffer == null) {
-            mGlitchSniffer = new GlitchSniffer();
-        }
-        return mGlitchSniffer;
+        return new GlitchSniffer();
     }
 
     // Note that these strings must match the enum result_code in LatencyAnalyzer.h
@@ -372,11 +368,11 @@ public class GlitchActivity extends AnalyzerActivity {
     }
 
     public double getMaxSecondsWithNoGlitch() {
-        return mGlitchSniffer.getMaxSecondsWithNoGlitch();
+        return ((GlitchSniffer)mNativeSniffer).getMaxSecondsWithNoGlitch();
     }
 
     public String getShortReport() {
-        return mGlitchSniffer.getShortReport();
+        return ((GlitchSniffer)mNativeSniffer).getShortReport();
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/GlitchActivity.java
@@ -52,11 +52,11 @@ public class GlitchActivity extends AnalyzerActivity {
     native double getSineAmplitude();
 
     private GlitchSniffer mGlitchSniffer;
-    private NativeSniffer mNativeSniffer = createNativeSniffer();
+    protected NativeSniffer mNativeSniffer = createNativeSniffer();
 
     synchronized NativeSniffer createNativeSniffer() {
         if (mGlitchSniffer == null) {
-            mGlitchSniffer = new GlitchSniffer(this);
+            mGlitchSniffer = new GlitchSniffer();
         }
         return mGlitchSniffer;
     }
@@ -105,10 +105,6 @@ public class GlitchActivity extends AnalyzerActivity {
         private double mPeakAmplitude;
         private double mSineAmplitude;
 
-        public GlitchSniffer(Activity activity) {
-            super(activity);
-        }
-
         @Override
         public void startSniffer() {
             long now = System.currentTimeMillis();
@@ -124,7 +120,7 @@ public class GlitchActivity extends AnalyzerActivity {
             super.startSniffer();
         }
 
-        public void run() {
+        private void gatherData() {
             int state = getAnalyzerState();
             mSignalToNoiseDB = getSignalToNoiseDB();
             mPeakAmplitude = getPeakAmplitude();
@@ -168,8 +164,6 @@ public class GlitchActivity extends AnalyzerActivity {
             mLastGlitchFrames = glitchFrames;
             mLastLockedFrames = lockedFrames;
             mLastResetCount = resetCount;
-
-            reschedule();
         }
 
         private String getCurrentStatusReport() {
@@ -197,7 +191,6 @@ public class GlitchActivity extends AnalyzerActivity {
             return message.toString();
         }
 
-        @Override
         public String getShortReport() {
             String resultText = "amplitude: peak = " + magnitudeToString(mPeakAmplitude)
                     + ", sine = " + magnitudeToString(mSineAmplitude) + "\n";
@@ -214,6 +207,7 @@ public class GlitchActivity extends AnalyzerActivity {
 
         @Override
         public void updateStatusText() {
+            gatherData();
             mLastGlitchReport = getCurrentStatusReport();
             setAnalyzerText(mLastGlitchReport);
         }
@@ -382,7 +376,7 @@ public class GlitchActivity extends AnalyzerActivity {
     }
 
     public String getShortReport() {
-        return mNativeSniffer.getShortReport();
+        return mGlitchSniffer.getShortReport();
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -159,10 +159,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     // Periodically query for magnitude and phase from the native detector.
     protected class DataPathSniffer extends NativeSniffer {
 
-        public DataPathSniffer(Activity activity) {
-            super(activity);
-        }
-
         @Override
         public void startSniffer() {
             mMagnitude = -1.0;
@@ -174,8 +170,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             super.startSniffer();
         }
 
-        @Override
-        public void run() {
+        private void gatherData() {
             mMagnitude = getMagnitude();
             mMaxMagnitude = getMaxMagnitude();
             Log.d(TAG, String.format(Locale.getDefault(), "magnitude = %7.4f, maxMagnitude = %7.4f",
@@ -197,9 +192,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
                 mPhase = phase;
                 mPhaseCount++;
             }
-            if (mEnabled) {
-                reschedule();
-            }
         }
 
         public String getCurrentStatusReport() {
@@ -214,7 +206,6 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
             return message.toString();
         }
 
-        @Override
         public String getShortReport() {
             return "maxMag = " + getMagnitudeText(mMaxMagnitude)
                     + ", jitter = " + getJitterText();
@@ -222,6 +213,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
 
         @Override
         public void updateStatusText() {
+            gatherData();
             mLastGlitchReport = getCurrentStatusReport();
             runOnUiThread(() -> {
                 setAnalyzerText(mLastGlitchReport);
@@ -235,7 +227,12 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
 
     @Override
     NativeSniffer createNativeSniffer() {
-        return new TestDataPathsActivity.DataPathSniffer(this);
+        return new TestDataPathsActivity.DataPathSniffer();
+    }
+
+    @Override
+    public String getShortReport() {
+        return ((DataPathSniffer) mNativeSniffer).getShortReport();
     }
 
     native double getMagnitude();


### PR DESCRIPTION
Call getCommunicationsDevice() periodically and show the result.

This can be used to detect the "grace period" after calling setCommunicationDevice().

Also cleaned up NativeSniffer.