### PR TITLE
Samples: Remove some fixed size constants

### DIFF
--- a/samples/SoundBoard/src/main/cpp/Synth.h
+++ b/samples/SoundBoard/src/main/cpp/Synth.h
@@ -37,6 +37,7 @@ public:
 
     Synth(const int32_t sampleRate, const int32_t channelCount, const int32_t numSignals) {
         mNumSignals = numSignals;
+        mOscs = std::make_unique<SynthSound[]>(numSignals);
         float curFrequency = kOscBaseFrequency;
         float curAmplitude = kOscBaseAmplitude;
         for (int i = 0; i < numSignals; ++i) {
@@ -83,7 +84,7 @@ public:
 private:
     // Rendering objects
     int32_t mNumSignals;
-    std::array<SynthSound, kMaxTracks> mOscs;
+    std::unique_ptr<SynthSound[]> mOscs;
     Mixer mMixer;
     MonoToStereo mConverter = MonoToStereo(&mMixer);
     IRenderableAudio *mOutputStage; // This will point to either the mixer or converter, so it needs to be raw

--- a/samples/shared/Mixer.h
+++ b/samples/shared/Mixer.h
@@ -31,19 +31,19 @@ class Mixer : public IRenderableAudio {
 public:
     void renderAudio(float *audioData, int32_t numFrames) {
 
-        int numBytes = numFrames * mChannelCount;
-        if (numBytes > mBufferSize) {
-            mMixingBuffer = std::make_unique<float[]>(numBytes);
-            mBufferSize = numBytes;
+        int numSamples = numFrames * mChannelCount;
+        if (numSamples > mBufferSize) {
+            mMixingBuffer = std::make_unique<float[]>(numSamples);
+            mBufferSize = numSamples;
         }
 
         // Zero out the incoming container array
-        memset(audioData, 0, sizeof(float) * numFrames * mChannelCount);
+        memset(audioData, 0, sizeof(float) * numSamples);
 
         for (int i = 0; i < mTracks.size(); ++i) {
             mTracks[i]->renderAudio(mMixingBuffer.get(), numFrames);
 
-            for (int j = 0; j < numFrames * mChannelCount; ++j) {
+            for (int j = 0; j < numSamples; ++j) {
                 audioData[j] += mMixingBuffer[j];
             }
         }

--- a/samples/shared/Mixer.h
+++ b/samples/shared/Mixer.h
@@ -20,9 +20,6 @@
 #include <array>
 #include "IRenderableAudio.h"
 
-constexpr int32_t kBufferSize = 192*10;  // Temporary buffer is used for mixing
-constexpr uint8_t kMaxTracks = 100;
-
 /**
  * A Mixer object which sums the output from multiple tracks into a single output. The number of
  * input channels on each track must match the number of output channels (default 1=mono). This can
@@ -34,35 +31,38 @@ class Mixer : public IRenderableAudio {
 public:
     void renderAudio(float *audioData, int32_t numFrames) {
 
+        int numBytes = numFrames * mChannelCount;
+        if (numBytes > mBufferSize) {
+            mMixingBuffer = std::make_unique<float[]>(numBytes);
+            mBufferSize = numBytes;
+        }
+
         // Zero out the incoming container array
         memset(audioData, 0, sizeof(float) * numFrames * mChannelCount);
 
-        for (int i = 0; i < mNextFreeTrackIndex; ++i) {
-            mTracks[i]->renderAudio(mixingBuffer, numFrames);
+        for (int i = 0; i < mTracks.size(); ++i) {
+            mTracks[i]->renderAudio(mMixingBuffer.get(), numFrames);
 
             for (int j = 0; j < numFrames * mChannelCount; ++j) {
-                audioData[j] += mixingBuffer[j];
+                audioData[j] += mMixingBuffer[j];
             }
         }
     }
 
     void addTrack(IRenderableAudio *renderer){
-        mTracks[mNextFreeTrackIndex++] = renderer;
+        mTracks.push_back(renderer);
     }
 
     void setChannelCount(int32_t channelCount){ mChannelCount = channelCount; }
 
     void removeAllTracks(){
-        for (int i = 0; i < mNextFreeTrackIndex; i++){
-            mTracks[i] = nullptr;
-        }
-        mNextFreeTrackIndex = 0;
+        mTracks.clear();
     }
 
 private:
-    float mixingBuffer[kBufferSize];
-    std::array<IRenderableAudio*, kMaxTracks> mTracks;
-    uint8_t mNextFreeTrackIndex = 0;
+    int32_t mBufferSize = 0;
+    std::unique_ptr<float[]> mMixingBuffer;
+    std::vector<IRenderableAudio*> mTracks;
     int32_t mChannelCount = 1; // Default to mono
 };
 


### PR DESCRIPTION
This PR fixes some issues with potential overflow of buffers.
1. Mixer buffer in Mixer.h could be too small if frame size is large. Fix here is to use std::unique_ptr<float[]> instead of a raw array. Mixer.h is used by MegaDrone, Soundboard, and RhythmGame.
2. If the number of tracks goes over 100 in Mixer.h, there will be a buffer overflow. Fix here is to use std::vector<IRenderableAudio*> instead of an std::array.
3. If the number of tracks goes over 100 in Synth.h, there will be a buffer overflow. Fix here is to use std::unique_ptr<SynthSound[]> instead of an std::array.

Fixes #1921