### PR TITLE
Prevent deprecation warning for shared openStream() call

### DIFF
--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -648,6 +648,14 @@ public:
 private:
 
     /**
+     * Use this internally to implement opening with a shared_ptr.
+     *
+     * @param stream pointer to a variable to receive the stream address
+     * @return OBOE_OK if successful or a negative error code.
+     */
+    Result openStreamInternal(AudioStream **streamPP);
+
+    /**
      * @param other
      * @return true if channels, format and sample rate match
      */

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -90,6 +90,10 @@ bool AudioStreamBuilder::isCompatible(AudioStreamBase &other) {
 
 Result AudioStreamBuilder::openStream(AudioStream **streamPP) {
     LOGW("Passing AudioStream pointer deprecated, Use openStream(std::shared_ptr<oboe::AudioStream> &stream) instead.");
+    return openStreamInternal(streamPP);
+}
+
+Result AudioStreamBuilder::openStreamInternal(AudioStream **streamPP) {
     auto result = isValidConfig();
     if (result != Result::OK) {
         LOGW("%s() invalid config %d", __func__, result);
@@ -214,7 +218,7 @@ Result AudioStreamBuilder::openManagedStream(oboe::ManagedStream &stream) {
 Result AudioStreamBuilder::openStream(std::shared_ptr<AudioStream> &sharedStream) {
     sharedStream.reset();
     AudioStream *streamptr;
-    auto result = openStream(&streamptr);
+    auto result = openStreamInternal(&streamptr);
     if (result == Result::OK) {
         sharedStream.reset(streamptr);
         // Save a weak_ptr in the stream for use with callbacks.


### PR DESCRIPTION
Call an internal method that does not print the warning.

Fixes #1949