### PR TITLE
Listen to USB device de/attach event.

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 80
-        versionName "2.5.9"
+        versionCode 81
+        versionName "2.5.10"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
@@ -24,7 +24,7 @@
         android:id="@+id/text_plug_events"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:lines="1"
+        android:lines="2"
         android:text="plug #"
         android:textSize="18sp"
         android:textStyle="bold"


### PR DESCRIPTION
With listening to USB device de/attach event, disconnect test can well sync on the peripherals plug state.