### PR TITLE
Improve Data Paths and Glitch tests

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -46,6 +46,7 @@ public:
     }
 
     double getPhaseOffset() {
+        ALOGD("%s(), mPhaseOffset = %f\n", __func__, mPhaseOffset);
         return mPhaseOffset;
     }
 
@@ -129,7 +130,6 @@ public:
         double magnitude = 2.0 * sqrt((sinMean * sinMean) + (cosMean * cosMean));
         if (phasePtr != nullptr) {
             double phase = atan2(cosMean, sinMean);
-
             *phasePtr = phase;
         }
         return magnitude;
@@ -153,6 +153,7 @@ public:
         if (mFramesAccumulated == mSinePeriod) {
             const double coefficient = 0.1;
             double magnitude = calculateMagnitudePhase(&mPhaseOffset);
+            ALOGD("%s(), mPhaseOffset = %f\n", __func__, mPhaseOffset);
             // One pole averaging filter.
             setMagnitude((mMagnitude * (1.0 - coefficient)) + (magnitude * coefficient));
             resetAccumulator();

--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -228,7 +228,7 @@ public:
                     // Must be a multiple of the period or the calculation will not be accurate.
                     if (transformSample(sample, mInputPhase)) {
                         // Adjust phase to account for sample rate drift.
-                 // FIXME       mInputPhase += mPhaseOffset;
+                        mInputPhase += mPhaseOffset;
 
                         mMeanSquareNoise = mSumSquareNoise * mInverseSinePeriod;
                         mMeanSquareSignal = mSumSquareSignal * mInverseSinePeriod;

--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -54,10 +54,6 @@ public:
         return mSinePeriod;
     }
 
-    float getPhaseOffset() const {
-        return mPhaseOffset;
-    }
-
     int32_t getGlitchCount() const {
         return mGlitchCount;
     }
@@ -188,8 +184,8 @@ public:
                 // Must be a multiple of the period or the calculation will not be accurate.
                 if (mFramesAccumulated == mSinePeriod * PERIODS_NEEDED_FOR_LOCK) {
                     setMagnitude(calculateMagnitudePhase(&mPhaseOffset));
-//                    ALOGD("%s() mag = %f, offset = %f, prev = %f",
-//                            __func__, mMagnitude, mPhaseOffset, mPreviousPhaseOffset);
+                    ALOGD("%s() mag = %f, mPhaseOffset = %f",
+                            __func__, mMagnitude, mPhaseOffset);
                     if (mMagnitude > mThreshold) {
                         if (fabs(mPhaseOffset) < kMaxPhaseError) {
                             mState = STATE_LOCKED;
@@ -232,7 +228,7 @@ public:
                     // Must be a multiple of the period or the calculation will not be accurate.
                     if (transformSample(sample, mInputPhase)) {
                         // Adjust phase to account for sample rate drift.
-                        mInputPhase += mPhaseOffset;
+                 // FIXME       mInputPhase += mPhaseOffset;
 
                         mMeanSquareNoise = mSumSquareNoise * mInverseSinePeriod;
                         mMeanSquareSignal = mSumSquareSignal * mInverseSinePeriod;

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -812,6 +812,12 @@ Java_com_mobileer_oboetester_TestDataPathsActivity_getMaxMagnitude(JNIEnv *env,
     return engine.mActivityDataPath.getDataPathAnalyzer()->getMaxMagnitude();
 }
 
+JNIEXPORT double JNICALL
+Java_com_mobileer_oboetester_TestDataPathsActivity_getPhaseDataPaths(JNIEnv *env,
+                                                     jobject instance) {
+    return engine.mActivityDataPath.getDataPathAnalyzer()->getPhaseOffset();
+}
+
 JNIEXPORT void JNICALL
 Java_com_mobileer_oboetester_GlitchActivity_setTolerance(JNIEnv *env,
                                                                    jobject instance,

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
@@ -99,7 +99,7 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
         requestedInConfig.setChannelCount(inChannels);
         requestedOutConfig.setChannelCount(outChannels);
 
-        testInOutConfigurations();
+        testCurrentConfigurations();
     }
 
     private void testConfiguration(int performanceMode,

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -288,7 +288,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         mFailCount = 0;
         try {
             mActivity.runTest();
-            log("Tests finished without exception.");
+            log("Tests finished.");
         } catch(Exception e) {
             log("EXCEPTION: " + e.getMessage());
         } finally {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -171,7 +171,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             StringBuffer text = new StringBuffer();
             text.append("Compare with passed test #" + passed.testIndex + "\n");
             text.append(input.comparePassedDirection("IN", passed.input));
-            text.append(TestDataPathsActivity.comparePassedField("IN", this, passed, "inputPreset"));
+            text.append(TestDataPathsActivity.comparePassedInputPreset("IN", this, passed));
             text.append(output.comparePassedDirection("OUT", passed.output));
             text.append(TestDataPathsActivity.comparePassedField("I/O",this, passed, "sampleRate"));
 
@@ -257,11 +257,11 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
     @Nullable
     protected TestResult testCurrentConfigurations() throws InterruptedException {
         mAutomatedTestRunner.incrementTestCount();
-        if ((getSingleTestIndex() >= 0) && (mAutomatedTestRunner.getTestCount() != getSingleTestIndex())) {
+        if ((getSingleTestIndex() >= 0) && (getTestCount() != getSingleTestIndex())) {
             return null;
         }
 
-        log("========================== #" + mAutomatedTestRunner.getTestCount());
+        log("========================== #" + getTestCount());
         int result = 0;
         StreamConfiguration requestedInConfig = mAudioInputTester.requestedConfiguration;
         StreamConfiguration requestedOutConfig = mAudioOutTester.requestedConfiguration;
@@ -278,6 +278,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         boolean openFailed = false;
         try {
             openAudio(); // this will fill in actualConfig
+
             log("Actual:");
             log("  SR = " + actualOutConfig.getSampleRate());
             // Set output size to a level that will avoid glitches.
@@ -297,7 +298,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         }
 
         TestResult testResult = new TestResult(
-                mAutomatedTestRunner.getTestCount(),
+                getTestCount(),
                 mTestName,
                 mAudioInputTester.actualConfiguration,
                 getInputChannel(),
@@ -350,7 +351,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         }
 
         if (openFailed || startFailed) {
-            appendFailedSummary("------ #" + mAutomatedTestRunner.getTestCount() + "\n");
+            appendFailedSummary("------ #" + getTestCount() + "\n");
             appendFailedSummary(getConfigText(requestedInConfig) + "\n");
             appendFailedSummary(getConfigText(requestedOutConfig) + "\n");
             appendFailedSummary(reason + "\n");
@@ -368,7 +369,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             resultText += reason;
             log("  " + resultText);
             if (!passed) {
-                appendFailedSummary("------ #" + mAutomatedTestRunner.getTestCount() + "\n");
+                appendFailedSummary("------ #" + getTestCount() + "\n");
                 appendFailedSummary("  " + getConfigText(actualInConfig) + "\n");
                 appendFailedSummary("  " + getConfigText(actualOutConfig) + "\n");
                 appendFailedSummary("    " + resultText + "\n");
@@ -390,6 +391,10 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             mTestResults.add(testResult);
         }
         return testResult;
+    }
+
+    protected int getTestCount() {
+        return mAutomatedTestRunner.getTestCount();
     }
 
     protected AudioDeviceInfo getDeviceInfoById(int deviceId) {
@@ -426,6 +431,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             case AudioDeviceInfo.TYPE_WIRED_HEADSET:
             case AudioDeviceInfo.TYPE_USB_HEADSET:
                 return true;
+
             case AudioDeviceInfo.TYPE_USB_DEVICE:
             default:
                 return false; // channels are discrete

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -23,7 +23,6 @@ import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Bundle;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.IOException;
@@ -307,7 +306,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         );
 
         // The test will only be worth running if we got the configuration we requested on input or output.
-        String skipReason = shouldTestBeSkipped();
+        String skipReason = whyShouldTestBeSkipped();
         boolean skipped = skipReason.length() > 0;
         boolean valid = !openFailed && !skipped;
         boolean startFailed = false;
@@ -413,16 +412,23 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         return null;
     }
 
-    protected boolean isDeviceTypeMixed(int type) {
+    /**
+     * Are outputs mixed in the air or by a loopback plug?
+     * @param type device type, eg AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+     * @return true if stereo output channels get mixed to mono input
+     */
+    protected boolean isDeviceTypeMixedForLoopback(int type) {
         switch(type) {
+            // Mixed in the air.
             case AudioDeviceInfo.TYPE_BUILTIN_SPEAKER:
             case AudioDeviceInfo.TYPE_BUILTIN_SPEAKER_SAFE:
+            // Mixed in the loopback fun-plug.
             case AudioDeviceInfo.TYPE_WIRED_HEADSET:
             case AudioDeviceInfo.TYPE_USB_HEADSET:
                 return true;
             case AudioDeviceInfo.TYPE_USB_DEVICE:
             default:
-                return false;
+                return false; // channels are discrete
         }
     }
 
@@ -468,7 +474,12 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         return false;
     }
 
-    protected String shouldTestBeSkipped() {
+    /**
+     * Figure out if a test should be skipped and return the reason.
+     *
+     * @return reason for skipping or an empty string
+     */
+    protected String whyShouldTestBeSkipped() {
         String why = "";
         StreamConfiguration requestedInConfig = mAudioInputTester.requestedConfiguration;
         StreamConfiguration requestedOutConfig = mAudioOutTester.requestedConfiguration;

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -238,7 +238,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
                 + ", ID = " + String.format(Locale.getDefault(), "%2d", config.getDeviceId())
                 + ", Perf = " + StreamConfiguration.convertPerformanceModeToText(
                         config.getPerformanceMode())
-                + ",\n   ch = " + channelText(channel, config.getChannelCount())
+                + ",\n     ch = " + channelText(channel, config.getChannelCount())
                 + ", cm = " + convertChannelMaskToText(config.getChannelMask());
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ManualGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ManualGlitchActivity.java
@@ -90,11 +90,11 @@ public class ManualGlitchActivity extends GlitchActivity {
             void onSelected(int index);
         }
 
-        NumberedRadioButtons(Context context, int numBoxes, SelectionListener listener) {
+        NumberedRadioButtons(Context context, int numBoxes, SelectionListener listener, String prompt) {
             mRow = new LinearLayout(context);
             mRow.setOrientation(LinearLayout.HORIZONTAL);
             TextView textView = new TextView(context);
-            textView.setText("IN:");
+            textView.setText(prompt);
             mRow.addView(textView);
             RadioGroup rg = new RadioGroup(context);
             rg.setOrientation(LinearLayout.HORIZONTAL);
@@ -147,10 +147,10 @@ public class ManualGlitchActivity extends GlitchActivity {
 
         mLayoutGlitch = (LinearLayout) findViewById(R.id.layoutGlitch);
         mInputChannelBoxes = new NumberedRadioButtons(this, 8,
-                (int index) -> setInputChannel(index));
+                (int index) -> setInputChannel(index), "IN:");
         mLayoutGlitch.addView(mInputChannelBoxes.getView());
         mOutputChannelBoxes = new NumberedRadioButtons(this, 8,
-                (int index) -> setOutputChannel(index));
+                (int index) -> setOutputChannel(index), "OUT:");
         mLayoutGlitch.addView(mOutputChannelBoxes.getView());
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -568,13 +568,13 @@ abstract class TestAudioActivity extends Activity {
             applyConfigurationViewsToModels();
         }
 
-        int sampleRate = 0;
+        int sampleRate = 0; // Use the OUTPUT sample rate for INPUT
 
         // Open output streams then open input streams.
         // This is so that the capacity of input stream can be expanded to
         // match the burst size of the output for full duplex.
         for (StreamContext streamContext : mStreamContexts) {
-            if (!streamContext.isInput()) {
+            if (!streamContext.isInput()) { // OUTPUT?
                 openStreamContext(streamContext);
                 int streamSampleRate = streamContext.tester.actualConfiguration.getSampleRate();
                 if (sampleRate == 0) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
@@ -37,7 +37,8 @@ import java.io.IOException;
 public class TestInputActivity  extends TestAudioActivity {
 
     protected AudioInputTester mAudioInputTester;
-    private static final int NUM_VOLUME_BARS = 4;
+    // Note that this must match the number of volume bars defined in the layout file.
+    private static final int NUM_VOLUME_BARS = 8;
     private VolumeBarView[] mVolumeBars = new VolumeBarView[NUM_VOLUME_BARS];
     private InputMarginView mInputMarginView;
     private int mInputMarginBursts = 0;
@@ -64,6 +65,10 @@ public class TestInputActivity  extends TestAudioActivity {
         mVolumeBars[1] = (VolumeBarView) findViewById(R.id.volumeBar1);
         mVolumeBars[2] = (VolumeBarView) findViewById(R.id.volumeBar2);
         mVolumeBars[3] = (VolumeBarView) findViewById(R.id.volumeBar3);
+        mVolumeBars[4] = (VolumeBarView) findViewById(R.id.volumeBar4);
+        mVolumeBars[5] = (VolumeBarView) findViewById(R.id.volumeBar5);
+        mVolumeBars[6] = (VolumeBarView) findViewById(R.id.volumeBar6);
+        mVolumeBars[7] = (VolumeBarView) findViewById(R.id.volumeBar7);
 
         mInputMarginView = (InputMarginView) findViewById(R.id.input_margin_view);
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -23,18 +23,18 @@
             android:text="InPre" />
 
         <CheckBox
-            android:id="@+id/checkbox_paths_input_devices"
+            android:id="@+id/checkbox_paths_all_channels"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
-            android:text="InDev" />
+            android:text="AllChan" />
 
         <CheckBox
-            android:id="@+id/checkbox_paths_output_devices"
+            android:id="@+id/checkbox_paths_all_sample_rates"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="OutDev" />
+            android:checked="false"
+            android:text="AllSRs" />
     </LinearLayout>
 
     <LinearLayout
@@ -49,12 +49,6 @@
             android:checked="false"
             android:text="AllOutCMs" />
 
-        <CheckBox
-            android:id="@+id/checkbox_paths_all_sample_rates"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:text="AllSRs" />
     </LinearLayout>
 
     <TextView

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -27,7 +27,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
-            android:text="AllChan" />
+            android:text="AllCh" />
 
         <CheckBox
             android:id="@+id/checkbox_paths_all_sample_rates"
@@ -43,11 +43,18 @@
         android:orientation="horizontal">
 
         <CheckBox
-            android:id="@+id/checkbox_paths_all_output_channel_masks"
+            android:id="@+id/checkbox_paths_in_channel_masks"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="false"
-            android:text="AllOutCMs" />
+            android:text="InChMasks" />
+
+        <CheckBox
+            android:id="@+id/checkbox_paths_output_channel_masks"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:text="OutChMasks" />
 
     </LinearLayout>
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -35,12 +35,6 @@
             android:layout_height="wrap_content"
             android:checked="false"
             android:text="AllSRs" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
 
         <CheckBox
             android:id="@+id/checkbox_paths_in_channel_masks"
@@ -48,14 +42,46 @@
             android:layout_height="wrap_content"
             android:checked="false"
             android:text="InChMasks" />
+    </LinearLayout>
 
-        <CheckBox
-            android:id="@+id/checkbox_paths_output_channel_masks"
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="OutChMasks:" />
+
+        <RadioGroup
+            android:id="@+id/group_ch_mask_options"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:checked="false"
-            android:text="OutChMasks" />
+            android:orientation="horizontal">
 
+            <RadioButton
+                android:id="@+id/radio_out_ch_masks_none"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="none"
+                android:checked="true"
+                />
+
+            <RadioButton
+                android:id="@+id/radio_out_ch_masks_some"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="some"
+                />
+
+            <RadioButton
+                android:id="@+id/radio_out_ch_masks_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="all"
+                />
+        </RadioGroup>
     </LinearLayout>
 
     <TextView

--- a/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
@@ -44,6 +44,7 @@
         android:orientation="horizontal" />
 
     <LinearLayout
+        android:id="@+id/layoutGlitch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_input.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_input.xml
@@ -49,5 +49,29 @@
         android:layout_marginBottom="4dp"
         android:layout_width="fill_parent"
         android:layout_height="20dp" />
+
+    <com.mobileer.oboetester.VolumeBarView
+        android:id="@+id/volumeBar4"
+        android:layout_marginBottom="4dp"
+        android:layout_width="fill_parent"
+        android:layout_height="20dp" />
+
+    <com.mobileer.oboetester.VolumeBarView
+        android:id="@+id/volumeBar5"
+        android:layout_marginBottom="4dp"
+        android:layout_width="fill_parent"
+        android:layout_height="20dp" />
+
+    <com.mobileer.oboetester.VolumeBarView
+        android:id="@+id/volumeBar6"
+        android:layout_marginBottom="4dp"
+        android:layout_width="fill_parent"
+        android:layout_height="20dp" />
+
+    <com.mobileer.oboetester.VolumeBarView
+        android:id="@+id/volumeBar7"
+        android:layout_marginBottom="4dp"
+        android:layout_width="fill_parent"
+        android:layout_height="20dp" />
 </LinearLayout>
 </ScrollView>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -258,7 +258,7 @@
     <string name="average">Average</string>
     <string name="failTest">Fail</string>
     <string name="skipTest">Skip</string>
-    <string name="test_datapath_instructions">Disconnect all headsets.\nIn quiet room, volume up, [START]</string>
+    <string name="test_datapath_instructions">Attach peripherals\nVolume up, [START]</string>
     <string name="test_disconnect_instructions">Disconnect all headsets.\nPress [RUN]</string>
 
     <string name="analyze">Analyze</string>


### PR DESCRIPTION
Support Data Paths testing for USB and wired headsets.

Add channel selectors for Manual Glitch Activity so we can test individual loopback paths.

Improve display of test results.

Prevent mismatching datapath devices such as mic and USB headphones.

This is WIP.
We still need to convert all the paths to the new style.
And we need more check boxes that reflect the test areas.
