### PR TITLE
OboeTester: Remove sample rate conversion in test disconnect

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDisconnectActivity.java
@@ -334,9 +334,6 @@ public class TestDisconnectActivity extends TestAudioActivity {
         requestedConfig.setPerformanceMode(perfMode);
         requestedConfig.setSharingMode(sharingMode);
         requestedConfig.setSampleRate(sampleRate);
-        if (sampleRate != 0) {
-            requestedConfig.setRateConversionQuality(StreamConfiguration.RATE_CONVERSION_QUALITY_MEDIUM);
-        }
 
         log("========================== #" + mAutomatedTestRunner.getTestCount());
         log("Requested:");


### PR DESCRIPTION
Oboe sample rate conversion should not be used in test disconnect as it defeats the purpose of setting a sample rate explicitly.