### PR TITLE
Fixed typo. Renamed *SIMIPLE* => *SIMPLE* by removing the letter `I`.

### DIFF
--- a/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.h
+++ b/samples/iolib/src/main/cpp/player/SimpleMultiPlayer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef _PLAYER_SIMIPLEMULTIPLAYER_H_
-#define _PLAYER_SIMIPLEMULTIPLAYER_H_
+#ifndef _PLAYER_SIMPLEMULTIPLAYER_H_
+#define _PLAYER_SIMPLEMULTIPLAYER_H_
 
 #include <vector>
 
@@ -114,4 +114,4 @@ private:
 };
 
 }
-#endif //_PLAYER_SIMIPLEMULTIPLAYER_H_
+#endif //_PLAYER_SIMPLEMULTIPLAYER_H_


### PR DESCRIPTION
Fixed a small typo. Removed 3 instances of the letter `I`.