### PR TITLE
Fix isMMapEnabled()

### DIFF
--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -89,7 +89,7 @@ public:
         if (loadSymbols()) return false;
         if (mAAudio_getMMapPolicy == nullptr) return false;
         int32_t policy = mAAudio_getMMapPolicy();
-        return isPolicyEnabled(policy);
+        return (policy == Unspecified) ? mMMapSupported : isPolicyEnabled(policy);
     }
 
     bool isMMapSupported() {


### PR DESCRIPTION
If policy is Unspecified then return isMMapSupported.

Fixes #1967