### PR TITLE
OboeTester: Override previous channel mask/count selection

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -520,11 +520,17 @@ public class StreamConfigurationView extends LinearLayout {
     }
 
     private void onChannelCountSpinnerSelected() {
-        mIsChannelMaskLastSelected = false;
+        if (mChannelCountSpinner.getSelectedItemPosition() != 0) {
+            mChannelMaskSpinner.setSelection(0); // Override the previous channel mask selection
+            mIsChannelMaskLastSelected = false;
+        }
     }
 
     private void onChannelMaskSpinnerSelected() {
-        mIsChannelMaskLastSelected = true;
+        if (mChannelMaskSpinner.getSelectedItemPosition() != 0) {
+            mChannelCountSpinner.setSelection(0); // Override the previous channel count selection
+            mIsChannelMaskLastSelected = true;
+        }
     }
 
     private void onRequestAudioEffectClicked(boolean isChecked) {


### PR DESCRIPTION
The previous channel count/mask selection is currently ignored correctly but the UI does not indicate that.

This PR explicitly updates the UI.

Fixes #1944 