### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+
+#Workaround for https://github.com/dependabot/dependabot-core/issues/6888#issuecomment-1539501116
+registries:
+  maven-google:
+    type: maven-repository
+    url: "https://dl.google.com/dl/android/maven2/"
+
+updates:
+  #Check for updates to Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"               #Location of package manifests
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependencies/github-actions"
+    schedule:
+      interval: "daily"
+
+  #Check updates for Gradle dependencies
+  - package-ecosystem: "gradle"
+    registries:
+      - maven-google
+    directory: "/"               #Location of package manifests
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dependencies/gradle"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I saw that some dependencies in the GitHub action workflows were out of date, and since this project also maintains a couple of Android apps which uses Gradle dependencies I also included a dependabot configuration for the Gradle package manager. Since GitHub is always migrating to newer Node runtimes it is important to keep GitHub action dependencies up to date so they won't become incompatible all of a sudden.