### PR TITLE
Samples: Add 24 bit and 32 bit support for parsing wav files

### DIFF
--- a/samples/parselib/src/main/cpp/wav/AudioEncoding.h
+++ b/samples/parselib/src/main/cpp/wav/AudioEncoding.h
@@ -27,6 +27,8 @@ public:
     static const int PCM_16 = 0;
     static const int PCM_8 = 1;
     static const int PCM_IEEEFLOAT = 2;
+    static const int PCM_24 = 3;
+    static const int PCM_32 = 4;
 };
 
 } // namespace parselib

--- a/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
+++ b/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
@@ -54,8 +54,11 @@ int WavStreamReader::getSampleEncoding() {
             case 24:
                 return AudioEncoding::PCM_24;
 
-            default:
+            case 32:
                 return AudioEncoding::PCM_32;
+
+            default:
+                return AudioEncoding::INVALID;
         }
     } else if (mFmtChunk->mEncodingId == WavFmtChunkHeader::ENCODING_IEEE_FLOAT) {
         return AudioEncoding::PCM_IEEEFLOAT;

--- a/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
+++ b/samples/parselib/src/main/cpp/wav/WavStreamReader.cpp
@@ -52,11 +52,10 @@ int WavStreamReader::getSampleEncoding() {
                 return AudioEncoding::PCM_16;
 
             case 24:
-                // TODO - Support 24-bit WAV data
-                return AudioEncoding::INVALID; // for now
+                return AudioEncoding::PCM_24;
 
             default:
-                return AudioEncoding::INVALID;
+                return AudioEncoding::PCM_32;
         }
     } else if (mFmtChunk->mEncodingId == WavFmtChunkHeader::ENCODING_IEEE_FLOAT) {
         return AudioEncoding::PCM_IEEEFLOAT;


### PR DESCRIPTION
24 bit and 32 bit support was added in #1221. I tested that they work with DrumThumper.

This PR now declares that those audio encodings are valid.