### PR TITLE
Fix out-of-bounds read in SRC

### DIFF
--- a/src/flowgraph/SampleRateConverter.cpp
+++ b/src/flowgraph/SampleRateConverter.cpp
@@ -28,7 +28,8 @@ SampleRateConverter::SampleRateConverter(int32_t channelCount,
 
 void SampleRateConverter::reset() {
     FlowGraphNode::reset();
-    mInputCursor = kInitialCallCount;
+    mInputCallCount = kInitialCallCount;
+    mInputCursor = 0;
 }
 
 // Return true if there is a sample available.

--- a/src/flowgraph/SampleRateConverter.h
+++ b/src/flowgraph/SampleRateConverter.h
@@ -54,7 +54,7 @@ private:
     int32_t mNumValidInputFrames = 0; // number of valid frames currently in the input port buffer
     // We need our own callCount for upstream calls because calls occur at a different rate.
     // This means we cannot have cyclic graphs or merges that contain an SRC.
-    int64_t mInputCallCount = 0;
+    int64_t mInputCallCount = kInitialCallCount;
 
 };
 


### PR DESCRIPTION
The SampleRateConverter curser was initialized to -1 causing a read before the array bounds.
Now it is initialized to zero.

Also initialize mInputCallCount to kInitialCallCount.

This code is from a change in AAudio, ag/27104819

Fixes #2005