### PR TITLE
Unit Tests: Make full duplex tests less sensitive

### DIFF
--- a/tests/testFullDuplexStream.cpp
+++ b/tests/testFullDuplexStream.cpp
@@ -102,7 +102,7 @@ protected:
 
     void checkInputAndOutputBufferSizesMatch() {
         // Expect the large majority of callbacks to have the same sized input and output
-        EXPECT_GE(mGoodCallbackCount, mCallbackCount * 9 / 10);
+        EXPECT_GE(mGoodCallbackCount, mCallbackCount * 4 / 5);
     }
 
     AudioStreamBuilder mInputBuilder;


### PR DESCRIPTION
Fixes #2008

This is a newish test and we want to make the test a bit less sensitive to start conditions.