### PR TITLE
oboe: remove OpenSL ES direct links

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -16,9 +16,6 @@
 
 #include <cassert>
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
-
 #include "common/OboeDebug.h"
 #include "oboe/AudioStreamBuilder.h"
 #include "AudioInputStreamOpenSLES.h"
@@ -151,8 +148,8 @@ Result AudioInputStreamOpenSLES::open() {
 
     // Configure the stream.
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
-                                            SL_IID_ANDROIDCONFIGURATION,
-                                            &configItf);
+            EngineOpenSLES::getInstance().getIidAndroidConfiguration(),
+            &configItf);
 
     if (SL_RESULT_SUCCESS != result) {
         LOGW("%s() GetInterface(SL_IID_ANDROIDCONFIGURATION) failed with %s",
@@ -190,7 +187,9 @@ Result AudioInputStreamOpenSLES::open() {
         goto error;
     }
 
-    result = (*mObjectInterface)->GetInterface(mObjectInterface, SL_IID_RECORD, &mRecordInterface);
+    result = (*mObjectInterface)->GetInterface(mObjectInterface,
+                                               EngineOpenSLES::getInstance().getIidRecord(),
+                                               &mRecordInterface);
     if (SL_RESULT_SUCCESS != result) {
         LOGE("GetInterface RECORD result:%s", getSLErrStr(result));
         goto error;

--- a/src/opensles/AudioInputStreamOpenSLES.h
+++ b/src/opensles/AudioInputStreamOpenSLES.h
@@ -18,10 +18,8 @@
 #define AUDIO_INPUT_STREAM_OPENSL_ES_H_
 
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
-
 #include "oboe/Oboe.h"
+#include "EngineOpenSLES.h"
 #include "AudioStreamOpenSLES.h"
 
 namespace oboe {

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -16,8 +16,6 @@
 
 #include <cassert>
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
 #include <common/AudioClock.h>
 
 #include "common/OboeDebug.h"
@@ -180,8 +178,8 @@ Result AudioOutputStreamOpenSLES::open() {
 
     // Configure the stream.
     result = (*mObjectInterface)->GetInterface(mObjectInterface,
-                                               SL_IID_ANDROIDCONFIGURATION,
-                                               (void *)&configItf);
+            EngineOpenSLES::getInstance().getIidAndroidConfiguration(),
+            (void *)&configItf);
     if (SL_RESULT_SUCCESS != result) {
         LOGW("%s() GetInterface(SL_IID_ANDROIDCONFIGURATION) failed with %s",
              __func__, getSLErrStr(result));
@@ -207,7 +205,9 @@ Result AudioOutputStreamOpenSLES::open() {
         goto error;
     }
 
-    result = (*mObjectInterface)->GetInterface(mObjectInterface, SL_IID_PLAY, &mPlayInterface);
+    result = (*mObjectInterface)->GetInterface(mObjectInterface,
+                                               EngineOpenSLES::getInstance().getIidPlay(),
+                                               &mPlayInterface);
     if (SL_RESULT_SUCCESS != result) {
         LOGE("GetInterface PLAY result:%s", getSLErrStr(result));
         goto error;

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -18,10 +18,8 @@
 #define AUDIO_OUTPUT_STREAM_OPENSL_ES_H_
 
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
-
 #include "oboe/Oboe.h"
+#include "EngineOpenSLES.h"
 #include "AudioStreamOpenSLES.h"
 
 namespace oboe {

--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -16,13 +16,12 @@
 #include <cassert>
 #include <android/log.h>
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
 #include <oboe/AudioStream.h>
 #include <common/AudioClock.h>
 
 #include "common/OboeDebug.h"
 #include "oboe/AudioStreamBuilder.h"
+#include "EngineOpenSLES.h"
 #include "AudioStreamOpenSLES.h"
 #include "OpenSLESUtilities.h"
 
@@ -442,8 +441,9 @@ static void bqCallbackGlue(SLAndroidSimpleBufferQueueItf bq, void *context) {
 
 SLresult AudioStreamOpenSLES::registerBufferQueueCallback() {
     // The BufferQueue
-    SLresult result = (*mObjectInterface)->GetInterface(mObjectInterface, SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
-                                                &mSimpleBufferQueueInterface);
+    SLresult result = (*mObjectInterface)->GetInterface(mObjectInterface,
+            EngineOpenSLES::getInstance().getIidAndroidSimpleBufferQueue(),
+            &mSimpleBufferQueueInterface);
     if (SL_RESULT_SUCCESS != result) {
         LOGE("get buffer queue interface:%p result:%s",
              mSimpleBufferQueueInterface,

--- a/src/opensles/AudioStreamOpenSLES.h
+++ b/src/opensles/AudioStreamOpenSLES.h
@@ -19,9 +19,6 @@
 
 #include <memory>
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
-
 #include "oboe/Oboe.h"
 #include "common/MonotonicCounter.h"
 #include "opensles/AudioStreamBuffered.h"

--- a/src/opensles/EngineOpenSLES.cpp
+++ b/src/opensles/EngineOpenSLES.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <dlfcn.h>
+
 #include "common/OboeDebug.h"
 #include "EngineOpenSLES.h"
 #include "OpenSLESUtilities.h"
@@ -24,40 +25,77 @@ using namespace oboe;
 // OpenSL ES is deprecated in SDK 30.
 // So we use custom dynamic linking to access the library.
 #define LIB_OPENSLES_NAME "libOpenSLES.so"
-typedef SLresult  (*prototype_slCreateEngine)(
-        SLObjectItf             *pEngine,
-        SLuint32                numOptions,
-        const SLEngineOption    *pEngineOptions,
-        SLuint32                numInterfaces,
-        const SLInterfaceID     *pInterfaceIds,
-        const SLboolean         *pInterfaceRequired
-);
-static prototype_slCreateEngine gFunction_slCreateEngine = nullptr;
-static void *gLibOpenSlesLibraryHandle = nullptr;
-
-// Load the OpenSL ES library and the one primary entry point.
-// @return true if linked OK
-static bool linkOpenSLES() {
-    if (gLibOpenSlesLibraryHandle == nullptr && gFunction_slCreateEngine == nullptr) {
-        // Use RTLD_NOW to avoid the unpredictable behavior that RTLD_LAZY can cause.
-        // Also resolving all the links now will prevent a run-time penalty later.
-        gLibOpenSlesLibraryHandle = dlopen(LIB_OPENSLES_NAME, RTLD_NOW);
-        if (gLibOpenSlesLibraryHandle == nullptr) {
-            LOGE("linkOpenSLES() could not find " LIB_OPENSLES_NAME);
-        } else {
-            gFunction_slCreateEngine = (prototype_slCreateEngine) dlsym(
-                    gLibOpenSlesLibraryHandle,
-                    "slCreateEngine");
-            LOGD("linkOpenSLES(): dlsym(%s) returned %p", "slCreateEngine",
-                 gFunction_slCreateEngine);
-        }
-    }
-    return gFunction_slCreateEngine != nullptr;
-}
 
 EngineOpenSLES &EngineOpenSLES::getInstance() {
     static EngineOpenSLES sInstance;
     return sInstance;
+}
+
+// Satisfy extern in OpenSLES.h
+// These are required because of b/337360630, which was causing
+// Oboe to have link failures if libOpenSLES.so was not available.
+SL_API const SLInterfaceID SL_IID_ENGINE = nullptr;
+SL_API const SLInterfaceID SL_IID_ANDROIDSIMPLEBUFFERQUEUE = nullptr;
+SL_API const SLInterfaceID SL_IID_ANDROIDCONFIGURATION = nullptr;
+SL_API const SLInterfaceID SL_IID_RECORD = nullptr;
+SL_API const SLInterfaceID SL_IID_BUFFERQUEUE = nullptr;
+SL_API const SLInterfaceID SL_IID_VOLUME = nullptr;
+SL_API const SLInterfaceID SL_IID_PLAY = nullptr;
+
+// Load the OpenSL ES library and the one primary entry point.
+// @return true if linked OK
+bool EngineOpenSLES::linkOpenSLES() {
+    if (mLibOpenSlesLibraryHandle == nullptr && mFunction_slCreateEngine == nullptr) {
+        // Use RTLD_NOW to avoid the unpredictable behavior that RTLD_LAZY can cause.
+        // Also resolving all the links now will prevent a run-time penalty later.
+        mLibOpenSlesLibraryHandle = dlopen(LIB_OPENSLES_NAME, RTLD_NOW);
+        if (mLibOpenSlesLibraryHandle == nullptr) {
+            LOGE("linkOpenSLES() could not find " LIB_OPENSLES_NAME);
+        } else {
+            mFunction_slCreateEngine = (prototype_slCreateEngine) dlsym(
+                    mLibOpenSlesLibraryHandle,
+                    "slCreateEngine");
+            LOGD("%s(): dlsym(%s) returned %p", __func__,
+                 "slCreateEngine", mFunction_slCreateEngine);
+            if (mFunction_slCreateEngine == nullptr) {
+                LOGE("%s(): dlsym(slCreateEngine) returned null, not found!", __func__);
+                return false;
+            }
+
+            // Load IID interfaces.
+            LOCAL_SL_IID_ENGINE = getIidPointer("SL_IID_ENGINE");
+            if (LOCAL_SL_IID_ENGINE == nullptr) return false;
+            LOCAL_SL_IID_ANDROIDSIMPLEBUFFERQUEUE = getIidPointer(
+                    "SL_IID_ANDROIDSIMPLEBUFFERQUEUE");
+            if (LOCAL_SL_IID_ANDROIDSIMPLEBUFFERQUEUE == nullptr) return false;
+            LOCAL_SL_IID_ANDROIDCONFIGURATION = getIidPointer(
+                    "SL_IID_ANDROIDCONFIGURATION");
+            if (LOCAL_SL_IID_ANDROIDCONFIGURATION == nullptr) return false;
+            LOCAL_SL_IID_RECORD = getIidPointer("SL_IID_RECORD");
+            if (LOCAL_SL_IID_RECORD == nullptr) return false;
+            LOCAL_SL_IID_BUFFERQUEUE = getIidPointer("SL_IID_BUFFERQUEUE");
+            if (LOCAL_SL_IID_BUFFERQUEUE == nullptr) return false;
+            LOCAL_SL_IID_VOLUME = getIidPointer("SL_IID_VOLUME");
+            if (LOCAL_SL_IID_VOLUME == nullptr) return false;
+            LOCAL_SL_IID_PLAY = getIidPointer("SL_IID_PLAY");
+            if (LOCAL_SL_IID_PLAY == nullptr) return false;
+        }
+    }
+    return true;
+}
+
+// A symbol like SL_IID_PLAY is a pointer to a structure.
+// The dlsym() function returns the address of the pointer, not the structure.
+// The get the address of the structure we have to dereference the pointer.
+SLInterfaceID EngineOpenSLES::getIidPointer(const char *symbolName) {
+    SLInterfaceID *iid_address = (SLInterfaceID *) dlsym(
+            mLibOpenSlesLibraryHandle,
+            symbolName);
+    if (iid_address == nullptr) {
+        LOGE("%s(): dlsym(%s) returned null, not found!", __func__, symbolName);
+        return (SLInterfaceID) nullptr;
+    }
+    return *iid_address; // Get address of the structure.
 }
 
 SLresult EngineOpenSLES::open() {
@@ -72,7 +110,7 @@ SLresult EngineOpenSLES::open() {
         };
 
         // create engine
-        result = (*gFunction_slCreateEngine)(&mEngineObject, 0, NULL, 0, NULL, NULL);
+        result = (*mFunction_slCreateEngine)(&mEngineObject, 0, NULL, 0, NULL, NULL);
         if (SL_RESULT_SUCCESS != result) {
             LOGE("EngineOpenSLES - slCreateEngine() result:%s", getSLErrStr(result));
             goto error;
@@ -86,7 +124,9 @@ SLresult EngineOpenSLES::open() {
         }
 
         // get the engine interface, which is needed in order to create other objects
-        result = (*mEngineObject)->GetInterface(mEngineObject, SL_IID_ENGINE, &mEngineInterface);
+        result = (*mEngineObject)->GetInterface(mEngineObject,
+                                                EngineOpenSLES::getInstance().getIidEngine(),
+                                                &mEngineInterface);
         if (SL_RESULT_SUCCESS != result) {
             LOGE("EngineOpenSLES - GetInterface() engine result:%s", getSLErrStr(result));
             goto error;
@@ -119,8 +159,8 @@ SLresult EngineOpenSLES::createAudioPlayer(SLObjectItf *objectItf,
                                            SLDataSource *audioSource,
                                            SLDataSink *audioSink) {
 
-    const SLInterfaceID ids[] = {SL_IID_BUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION};
-    const SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
+    SLInterfaceID ids[] = {LOCAL_SL_IID_BUFFERQUEUE, LOCAL_SL_IID_ANDROIDCONFIGURATION};
+    SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 
     return (*mEngineInterface)->CreateAudioPlayer(mEngineInterface, objectItf, audioSource,
                                                   audioSink,
@@ -131,8 +171,9 @@ SLresult EngineOpenSLES::createAudioRecorder(SLObjectItf *objectItf,
                                              SLDataSource *audioSource,
                                              SLDataSink *audioSink) {
 
-    const SLInterfaceID ids[] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION };
-    const SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
+    SLInterfaceID ids[] = {LOCAL_SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
+                           LOCAL_SL_IID_ANDROIDCONFIGURATION };
+    SLboolean reqs[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 
     return (*mEngineInterface)->CreateAudioRecorder(mEngineInterface, objectItf, audioSource,
                                                     audioSink,

--- a/src/opensles/EngineOpenSLES.h
+++ b/src/opensles/EngineOpenSLES.h
@@ -25,12 +25,23 @@
 
 namespace oboe {
 
+typedef SLresult  (*prototype_slCreateEngine)(
+        SLObjectItf             *pEngine,
+        SLuint32                numOptions,
+        const SLEngineOption    *pEngineOptions,
+        SLuint32                numInterfaces,
+        const SLInterfaceID     *pInterfaceIds,
+        const SLboolean         *pInterfaceRequired
+);
+
 /**
  * INTERNAL USE ONLY
  */
 class EngineOpenSLES {
 public:
     static EngineOpenSLES &getInstance();
+
+    bool linkOpenSLES();
 
     SLresult open();
 
@@ -45,6 +56,14 @@ public:
                                  SLDataSource *audioSource,
                                  SLDataSink *audioSink);
 
+    SLInterfaceID getIidEngine() { return LOCAL_SL_IID_ENGINE; }
+    SLInterfaceID getIidAndroidSimpleBufferQueue() { return LOCAL_SL_IID_ANDROIDSIMPLEBUFFERQUEUE; }
+    SLInterfaceID getIidAndroidConfiguration() { return LOCAL_SL_IID_ANDROIDCONFIGURATION; }
+    SLInterfaceID getIidRecord() { return LOCAL_SL_IID_RECORD; }
+    SLInterfaceID getIidBufferQueue() { return LOCAL_SL_IID_BUFFERQUEUE; }
+    SLInterfaceID getIidVolume() { return LOCAL_SL_IID_VOLUME; }
+    SLInterfaceID getIidPlay() { return LOCAL_SL_IID_PLAY; }
+
 private:
     // Make this a safe Singleton
     EngineOpenSLES()= default;
@@ -52,11 +71,24 @@ private:
     EngineOpenSLES(const EngineOpenSLES&)= delete;
     EngineOpenSLES& operator=(const EngineOpenSLES&)= delete;
 
+    SLInterfaceID getIidPointer(const char *symbolName);
+
     std::mutex             mLock;
     int32_t                mOpenCount = 0;
 
     SLObjectItf            mEngineObject = nullptr;
     SLEngineItf            mEngineInterface = nullptr;
+
+    // These symbols are loaded using dlsym().
+    prototype_slCreateEngine mFunction_slCreateEngine = nullptr;
+    void                  *mLibOpenSlesLibraryHandle = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_ENGINE = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_ANDROIDSIMPLEBUFFERQUEUE = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_ANDROIDCONFIGURATION = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_RECORD = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_BUFFERQUEUE = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_VOLUME = nullptr;
+    SLInterfaceID          LOCAL_SL_IID_PLAY = nullptr;
 };
 
 } // namespace oboe

--- a/src/opensles/EngineOpenSLES.h
+++ b/src/opensles/EngineOpenSLES.h
@@ -73,9 +73,19 @@ private:
 
     SLInterfaceID getIidPointer(const char *symbolName);
 
+    /**
+     * Close the OpenSL ES engine.
+     * This must be called under mLock
+     */
+    void close_l();
+
     std::mutex             mLock;
     int32_t                mOpenCount = 0;
 
+    static constexpr int32_t kLinkStateUninitialized = 0;
+    static constexpr int32_t kLinkStateGood = 1;
+    static constexpr int32_t kLinkStateBad = 2;
+    int32_t                mDynamicLinkState = kLinkStateUninitialized;
     SLObjectItf            mEngineObject = nullptr;
     SLEngineItf            mEngineInterface = nullptr;
 

--- a/src/opensles/OutputMixerOpenSLES.h
+++ b/src/opensles/OutputMixerOpenSLES.h
@@ -20,8 +20,7 @@
 #include <atomic>
 #include <mutex>
 
-#include <SLES/OpenSLES.h>
-#include <SLES/OpenSLES_Android.h>
+#include "EngineOpenSLES.h"
 
 namespace oboe {
 


### PR DESCRIPTION
Use dlsym() to find the address of symbols like SL_IID_PLAY. This allows Oboe to be run on a device that does not have "libOpenSLES.so".

This fixes b/337360630