### PR TITLE
docs: Update guide to note additional latency with default sample rate conversion quality

### DIFF
--- a/docs/FullGuide.md
+++ b/docs/FullGuide.md
@@ -491,6 +491,10 @@ builder.setDataCallback(myCallback);
 builder.setPerformanceMode(PerformanceMode::LowLatency);
 ```
 
+### Setting the Sample Rate Conversion Quality
+
+If your streams use different sample rates to the hardware device sample rates then you may experience additional latency in your streams. This is due to the fact the audio buffer must be resampled to/from the the hardware format to your desired software format. This latency can be particularly large if the Sample Rate Conversion Quality is left to the default setting of `oboe::SampleRateConversionQuality::None` as system level APIs (or the hardware itself) will handle the resampling which is MUCH slower and will not be reported as part of the `calculateLatencyMillis()` value. To rectify this (particularly important for the input stream), you should set the following when constructing your stream - `setSampleRateConversionQuality(oboe::SampleRateConversionQuality::Fastest)`.
+
 ## Thread safety
 
 The Oboe API is not completely [thread safe](https://en.wikipedia.org/wiki/Thread_safety).


### PR DESCRIPTION
Hey Oboe folks 👋

My company has been using Oboe to build a realtime music learning app where simultaneously a video of the band is played whilst the microphone listens to the user's playing of their instrument. We use Oboe for both the audio input (recording of the user playing) and output (playback of the band, part of a low-level custom player using FFmpeg and Oboe for the audio backend). As you can imagine having precise synchronisation between the playback and recording in our setup is paramount as we analyse the user's rhythm and pitch after they have performed.

After doing a deep dive into some poor scores I noticed that there was a large amount of additional and device dependant latency in our recordings. Initially, I thought this was an issue with our playback (asset encoding or internal timing of the playback) but after creating an isolated testbench (repro can be found here https://github.com/thomas-coldwell/oboe/tree/%40thomas/loopback-test and tested by running the HelloOboe project which I tweaked and pulling off the raw PCM data file) I finally figured out that the root cause of this latency was **the sample rate conversion quality setting**

With this set to `None` I got +250ms on a OnePlus 6 and +180ms (on a Samsung A40) of additional latency in the recording. However, as soon as I switched this to `Fastest` I then got around ~20ms of latency on both which corresponds nicely with the actual input and output stream latency value I get when I call `calculateLatencyMillis()`.

^^ Sorry for the full story but thought it would be good to give a repro and context around this. As its such a big factor in ensuring minimal round trip latency I think adding this section to the docs would help point other devs in the right direct here 🙌  