### PR TITLE
oboe: log warning if start times out

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
@@ -56,7 +56,7 @@ static constexpr int32_t kMillisPerSecond   = 1000;  // by definition
 static constexpr int32_t kMaxLatencyMillis  = 1000;  // arbitrary and generous
 
 struct LatencyReport {
-    int32_t latencyInFrames = 0.0;
+    int32_t latencyInFrames = 0;
     double correlation = 0.0;
 
     void reset() {

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -113,8 +113,12 @@ Result AudioStream::start(int64_t timeoutNanoseconds)
     Result result = requestStart();
     if (result != Result::OK) return result;
     if (timeoutNanoseconds <= 0) return result;
-    return waitForStateTransition(StreamState::Starting,
+    result = waitForStateTransition(StreamState::Starting,
                                   StreamState::Started, timeoutNanoseconds);
+    if (result != Result::OK) {
+        LOGE("AudioStream::%s() timed out before moving from STARTING to STARTED", __func__);
+    }
+    return result;
 }
 
 Result AudioStream::pause(int64_t timeoutNanoseconds)


### PR DESCRIPTION
This would have helped us catch a service bug sooner.