### PR TITLE
Use a shared_ptr when creating a child stream

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -54,7 +54,7 @@ public:
      */
     explicit AudioStream(const AudioStreamBuilder &builder);
 
-    virtual ~AudioStream() = default;
+    virtual ~AudioStream();
 
     /**
      * Open a stream based on the current settings.

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -609,14 +609,13 @@ public:
     }
 
     /**
-     * Create and open a stream object based on the current settings.
-     *
-     * The caller owns the pointer to the AudioStream object
-     * and must delete it when finished.
+     * WARNING - this method has been disabled and will fail.
+     * Opening a stream using this method led to crashes so
+     * it is no longer available.
      *
      * @deprecated Use openStream(std::shared_ptr<oboe::AudioStream> &stream) instead.
      * @param stream pointer to a variable to receive the stream address
-     * @return OBOE_OK if successful or a negative error code
+     * @return Result::ErrorUnavailable
      */
     Result openStream(AudioStream **stream);
 
@@ -633,15 +632,13 @@ public:
     Result openStream(std::shared_ptr<oboe::AudioStream> &stream);
 
     /**
-     * Create and open a ManagedStream object based on the current builder state.
-     *
-     * The caller must create a unique ptr, and pass by reference so it can be
-     * modified to point to an opened stream. The caller owns the unique ptr,
-     * and it will be automatically closed and deleted when going out of scope.
+     * WARNING - this method has been disabled and will fail.
+     * Opening a stream using this method led to crashes so
+     * it is no longer available.
      *
      * @deprecated Use openStream(std::shared_ptr<oboe::AudioStream> &stream) instead.
      * @param stream Reference to the ManagedStream (uniqueptr) used to keep track of stream
-     * @return OBOE_OK if successful or a negative error code.
+     * @return Result::ErrorUnavailable
      */
     Result openManagedStream(ManagedStream &stream);
 
@@ -653,13 +650,14 @@ private:
      * @param stream pointer to a variable to receive the stream address
      * @return OBOE_OK if successful or a negative error code.
      */
-    Result openStreamInternal(AudioStream **streamPP);
+    Result openStreamInternal(std::shared_ptr<oboe::AudioStream> &stream);
 
     /**
      * @param other
      * @return true if channels, format and sample rate match
      */
     bool isCompatible(AudioStreamBase &other);
+
 
     /**
      * Create an AudioStream object. The AudioStream must be opened before use.

--- a/include/oboe/AudioStreamCallback.h
+++ b/include/oboe/AudioStreamCallback.h
@@ -162,6 +162,8 @@ public:
      *
      * This callback could be used to reopen a new stream on another device.
      *
+     * Do NOT delete the audioStream. It is managed by a shared_ptr.
+     *
      * @param audioStream pointer to the associated stream
      * @param error
      */

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -30,6 +30,12 @@ namespace oboe {
  */
 AudioStream::AudioStream(const AudioStreamBuilder &builder)
         : AudioStreamBase(builder) {
+    LOGD("Constructor for AudioStream at %p", this);
+}
+
+AudioStream::~AudioStream() {
+    // This is to help debug use after free bugs.
+    LOGD("Destructor for AudioStream at %p", this);
 }
 
 Result AudioStream::close() {

--- a/src/common/FilterAudioStream.h
+++ b/src/common/FilterAudioStream.h
@@ -38,7 +38,8 @@ public:
      *
      * @param builder containing all the stream's attributes
      */
-    FilterAudioStream(const AudioStreamBuilder &builder, AudioStream *childStream)
+    FilterAudioStream(const AudioStreamBuilder &builder,
+                      std::shared_ptr<AudioStream> childStream)
     : AudioStream(builder)
     , mChildStream(childStream) {
         // Intercept the callback if used.
@@ -65,10 +66,6 @@ public:
     }
 
     virtual ~FilterAudioStream() = default;
-
-    AudioStream *getChildStream() const {
-        return mChildStream.get();
-    }
 
     Result configureFlowGraph();
 
@@ -216,7 +213,7 @@ public:
 
 private:
 
-    std::unique_ptr<AudioStream>             mChildStream; // this stream wraps the child stream
+    std::shared_ptr<AudioStream>             mChildStream;
     std::unique_ptr<DataConversionFlowGraph> mFlowGraph; // for converting data
     std::unique_ptr<uint8_t[]>               mBlockingBuffer; // temp buffer for write()
     double                                   mRateScaler = 1.0; // ratio parent/child sample rates

--- a/tests/testFullDuplexStream.cpp
+++ b/tests/testFullDuplexStream.cpp
@@ -55,7 +55,7 @@ protected:
         mOutputBuilder.setFormat(AudioFormat::Float);
         mOutputBuilder.setDataCallback(this);
 
-        Result r = mOutputBuilder.openStream(&mOutputStream);
+        Result r = mOutputBuilder.openStream(mOutputStream);
         ASSERT_EQ(r, Result::OK) << "Failed to open output stream " << convertToText(r);
 
         mInputBuilder.setDirection(Direction::Input);
@@ -68,11 +68,11 @@ protected:
         mInputBuilder.setBufferCapacityInFrames(mOutputStream->getBufferCapacityInFrames() * 2);
         mInputBuilder.setSampleRate(mOutputStream->getSampleRate());
 
-        r = mInputBuilder.openStream(&mInputStream);
+        r = mInputBuilder.openStream(mInputStream);
         ASSERT_EQ(r, Result::OK) << "Failed to open input stream " << convertToText(r);
 
-        setInputStream(mInputStream);
-        setOutputStream(mOutputStream);
+        setInputStream(mInputStream.get());
+        setOutputStream(mOutputStream.get());
     }
 
     void startStream() {
@@ -107,8 +107,8 @@ protected:
 
     AudioStreamBuilder mInputBuilder;
     AudioStreamBuilder mOutputBuilder;
-    AudioStream *mInputStream = nullptr;
-    AudioStream *mOutputStream = nullptr;
+    std::shared_ptr<AudioStream> mInputStream;
+    std::shared_ptr<AudioStream> mOutputStream;
     std::atomic<int32_t> mCallbackCount{0};
     std::atomic<int32_t> mGoodCallbackCount{0};
 };


### PR DESCRIPTION
This is used when Oboe does sample rate conversion. Or format or channel count conversion.

It used to use a raw pointer, which could cause crashes.

Fixes #2035