### PR TITLE
OboeTester: add a Rapid Cycle test

### DIFF
--- a/apps/OboeTester/app/CMakeLists.txt
+++ b/apps/OboeTester/app/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 link_directories(${CMAKE_CURRENT_LIST_DIR}/..)
 
-# Increment this number when adding files to OboeTester => 104
+# Increment this number when adding files to OboeTester => 105
 # The change in this file will help Android Studio resync
 # and generate new build files that reference the new code.
 file(GLOB_RECURSE app_native_sources src/main/cpp/*)

--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -139,6 +139,12 @@
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
             android:exported="true" />
 
+        <activity
+            android:name=".TestRapidCycleActivity"
+            android:label="@string/title_rapid_cycle"
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
+            android:exported="true" />
+
         <service
             android:name=".MidiTapTester"
             android:permission="android.permission.BIND_MIDI_DEVICE_SERVICE"

--- a/apps/OboeTester/app/src/main/cpp/TestRapidCycle.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestRapidCycle.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <aaudio/AAudioExtensions.h>
+
+#include "common/OboeDebug.h"
+#include "common/AudioClock.h"
+#include "TestRapidCycle.h"
+
+using namespace oboe;
+
+// open start start an Oboe stream
+int32_t TestRapidCycle::start(bool useOpenSL) {
+    mThreadEnabled = true;
+    mCycleCount = 0;
+    mCycleThread = std::thread([this, useOpenSL]() {
+        cycleRapidly(useOpenSL);
+    });
+    return 0;
+}
+int32_t TestRapidCycle::stop() {
+    mThreadEnabled = false;
+    mCycleThread.join();
+    return 0;
+}
+
+void TestRapidCycle::cycleRapidly(bool useOpenSL) {
+    while(mThreadEnabled && (oneCycle(useOpenSL) == 0));
+}
+
+int32_t TestRapidCycle::oneCycle(bool useOpenSL) {
+    mCycleCount++;
+    mDataCallback = std::make_shared<MyDataCallback>();
+
+    AudioStreamBuilder builder;
+    oboe::Result result = builder.setFormat(oboe::AudioFormat::Float)
+            ->setAudioApi(useOpenSL ? oboe::AudioApi::OpenSLES : oboe::AudioApi::AAudio)
+            ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
+            ->setChannelCount(kChannelCount)
+            ->setDataCallback(mDataCallback)
+            ->setUsage(oboe::Usage::Notification)
+            ->openStream(mStream);
+    if (result != oboe::Result::OK) {
+        return (int32_t) result;
+    }
+
+    mStream->setDelayBeforeCloseMillis(0);
+
+    result = mStream->requestStart();
+    if (result != oboe::Result::OK) {
+        mStream->close();
+        return (int32_t) result;
+    }
+// Sleep for some random time.
+    int32_t durationMicros = (int32_t)(drand48() * kMaxSleepMicros);
+    LOGD("TestRapidCycle::oneCycle() - Sleep for %d micros", durationMicros);
+    usleep(durationMicros);
+    LOGD("TestRapidCycle::oneCycle() - Woke up, stop stream");
+    oboe::Result result1 =  mStream->requestStop();
+    oboe::Result result2 =   mStream->close();
+    return (int32_t)((result1 != oboe::Result::OK) ? result1 : result2);
+}
+
+// Callback that sleeps then touches the audio buffer.
+DataCallbackResult TestRapidCycle::MyDataCallback::onAudioReady(
+        AudioStream *audioStream,
+        void *audioData,
+        int32_t numFrames) {
+    float *floatData = (float *) audioData;
+    const int numSamples = numFrames * kChannelCount;
+
+    // Fill buffer with white noise.
+    for (int i = 0; i < numSamples; i++) {
+        floatData[i] = ((float)drand48() - 0.5f) * 2 * 0.1f;
+    }
+
+    return oboe::DataCallbackResult::Continue;
+}

--- a/apps/OboeTester/app/src/main/cpp/TestRapidCycle.h
+++ b/apps/OboeTester/app/src/main/cpp/TestRapidCycle.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOETESTER_TEST_RAPID_CYCLE_H
+#define OBOETESTER_TEST_RAPID_CYCLE_H
+
+#include "oboe/Oboe.h"
+#include <thread>
+
+
+/**
+ * Try to cause a crash by changing routing during a data callback.
+ * We use Use::VoiceCommunication for the stream and
+ * setSpeakerPhoneOn(b) to force a routing change.
+ * This works best when connected to a BT headset.
+ */
+class TestRapidCycle {
+public:
+
+    int32_t start(bool useOpenSL);
+    int32_t stop();
+
+    int32_t getCycleCount() {
+        return mCycleCount.load();
+    }
+
+private:
+
+    void cycleRapidly(bool useOpenSL);
+    int32_t oneCycle(bool useOpenSL);
+
+    class MyDataCallback : public oboe::AudioStreamDataCallback {    public:
+
+        MyDataCallback() {}
+
+        oboe::DataCallbackResult onAudioReady(
+                oboe::AudioStream *audioStream,
+                void *audioData,
+                int32_t numFrames) override;
+    };
+
+    std::shared_ptr<oboe::AudioStream> mStream;
+    std::shared_ptr<MyDataCallback> mDataCallback;
+    std::atomic<int32_t> mCycleCount{0};
+    std::atomic<bool> mThreadEnabled{false};
+    std::thread mCycleThread;
+
+    static constexpr int kChannelCount = 1;
+    static constexpr int kMaxSleepMicros = 25000;
+};
+
+#endif //OBOETESTER_TEST_RAPID_CYCLE_H

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -31,6 +31,7 @@
 #include "TestColdStartLatency.h"
 #include "TestErrorCallback.h"
 #include "TestRoutingCrash.h"
+#include "TestRapidCycle.h"
 
 static NativeAudioContext engine;
 
@@ -978,4 +979,24 @@ Java_com_mobileer_oboetester_TestColdStartLatencyActivity_getAudioDeviceId(
     return sColdStartLatency.getDeviceId();
 }
 
+}
+
+
+static TestRapidCycle sRapidCycle;
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRapidCycleActivity_startRapidCycleTest(JNIEnv *env, jobject thiz,
+                                                                        jboolean use_open_sl) {
+    return sRapidCycle.start(use_open_sl);
+}
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRapidCycleActivity_stopRapidCycleTest(JNIEnv *env, jobject thiz) {
+    return sRapidCycle.stop();
+}
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_mobileer_oboetester_TestRapidCycleActivity_getCycleCount(JNIEnv *env, jobject thiz) {
+    return sRapidCycle.getCycleCount();
 }

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -979,24 +979,22 @@ Java_com_mobileer_oboetester_TestColdStartLatencyActivity_getAudioDeviceId(
     return sColdStartLatency.getDeviceId();
 }
 
-}
-
-
 static TestRapidCycle sRapidCycle;
 
-extern "C"
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_TestRapidCycleActivity_startRapidCycleTest(JNIEnv *env, jobject thiz,
                                                                         jboolean use_open_sl) {
     return sRapidCycle.start(use_open_sl);
 }
-extern "C"
+
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_TestRapidCycleActivity_stopRapidCycleTest(JNIEnv *env, jobject thiz) {
     return sRapidCycle.stop();
 }
-extern "C"
+
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_TestRapidCycleActivity_getCycleCount(JNIEnv *env, jobject thiz) {
     return sRapidCycle.getCycleCount();
 }
+
+} // extern "C"

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
@@ -38,4 +38,8 @@ public class ExtraTestsActivity extends BaseOboeTesterActivity {
     public void onLaunchColdStartLatencyTest(View view) {
         launchTestActivity(TestColdStartLatencyActivity.class);
     }
+
+    public void onLaunchRapidCycleTest(View view) {
+        launchTestActivity(TestRapidCycleActivity.class);
+    }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRapidCycleActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestRapidCycleActivity.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobileer.oboetester;
+
+import static com.mobileer.oboetester.TestAudioActivity.TAG;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+/**
+ * Try to hang streams by rapidly opening and closing.
+ * See b/348615156
+ */
+public class TestRapidCycleActivity extends AppCompatActivity {
+
+    private TextView mStatusView;
+    private MyStreamSniffer mStreamSniffer;
+    private AudioManager mAudioManager;
+    private RadioButton mApiOpenSLButton;
+    private RadioButton mApiAAudioButton;
+    private Button mStartButton;
+    private Button mStopButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_rapid_cycle);
+        mStatusView = (TextView) findViewById(R.id.text_callback_status);
+        mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+
+        mStartButton = (Button) findViewById(R.id.button_start_test);
+        mStopButton = (Button) findViewById(R.id.button_stop_test);
+        mApiOpenSLButton = (RadioButton) findViewById(R.id.audio_api_opensl);
+        mApiOpenSLButton.setChecked(true);
+        mApiAAudioButton = (RadioButton) findViewById(R.id.audio_api_aaudio);
+        setButtonsEnabled(false);
+    }
+
+    public void onStartCycleTest(View view) { startCycleTest(); }
+    public void onStopCycleTest(View view) {
+        stopCycleTest();
+    }
+
+    private void setButtonsEnabled(boolean running) {
+        mStartButton.setEnabled(!running);
+        mStopButton.setEnabled(running);
+        mApiOpenSLButton.setEnabled(!running);
+        mApiAAudioButton.setEnabled(!running);
+    }
+
+    // Change routing while the stream is playing.
+    // Keep trying until we crash.
+    protected class MyStreamSniffer extends Thread {
+        boolean enabled = true;
+        StringBuffer statusBuffer = new StringBuffer();
+
+        @Override
+        public void run() {
+            boolean useOpenSL = mApiOpenSLButton.isChecked();
+            startRapidCycleTest(useOpenSL);
+            try {
+                while (enabled) {
+                    statusBuffer = new StringBuffer();
+                    sleep(100);
+                    log("#" + getCycleCount() + " open/close cycles\n");
+                }
+            } catch (InterruptedException e) {
+            } finally {
+                stopRapidCycleTest();
+            }
+        }
+
+        // Log to screen and logcat.
+        private void log(String text) {
+            Log.d(TAG, "RapidCycle: " + text);
+            statusBuffer.append(text);
+            showStatus(statusBuffer.toString());
+        }
+
+        // Stop the test thread.
+        void finish() {
+            enabled = false;
+            interrupt();
+            try {
+                join(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    protected void showStatus(final String message) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mStatusView.setText(message);
+            }
+        });
+    }
+
+    private native int startRapidCycleTest(boolean useOpenSL);
+    private native int stopRapidCycleTest();
+    private native int getCycleCount();
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        Log.i(TAG, "onPause() called so stop the test =========================");
+        stopCycleTest();
+    }
+
+    private void startCycleTest() {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        setButtonsEnabled(true);
+        mStreamSniffer = new MyStreamSniffer();
+        mStreamSniffer.start();
+    }
+
+    private void stopCycleTest() {
+        if (mStreamSniffer != null) {
+            mStreamSniffer.finish();
+            mStreamSniffer = null;
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            setButtonsEnabled(false);
+        }
+    }
+}

--- a/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
@@ -81,5 +81,15 @@
             android:backgroundTint="@color/button_tint"
             android:onClick="onLaunchColdStartLatencyTest"
             android:text="Cold Start Latency" />
+
+        <Button
+            android:id="@+id/buttonRapidCycle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_gravity="fill"
+            android:backgroundTint="@color/button_tint"
+            android:onClick="onLaunchRapidCycleTest"
+            android:text="Rapid Cycle" />
     </GridLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_rapid_cycle.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rapid_cycle.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TestRapidCycleActivity">
+
+    <LinearLayout
+        android:id="@+id/buttonGrid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="monospace"
+            android:gravity="bottom"
+            android:text="@string/rapid_cycle_intro" />
+
+        <RadioGroup
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkedButton="@+id/direction_output"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:gravity="bottom"
+                android:text="API:" />
+            <RadioButton
+                android:id="@+id/audio_api_opensl"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="OpenSL ES" />
+
+            <RadioButton
+                android:id="@+id/audio_api_aaudio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="AAudio" />
+        </RadioGroup>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_start_test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="@color/button_tint"
+                android:onClick="onStartCycleTest"
+                android:text="Start Test" />
+            <Button
+                android:id="@+id/button_stop_test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="@color/button_tint"
+                android:onClick="onStopCycleTest"
+                android:text="Stop Test" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/text_callback_status"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fontFamily="monospace"
+            android:gravity="bottom"
+            android:lines="10"
+            android:text="@string/init_status" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
     <string name="title_route_during_callback">Route Callback Test</string>
     <string name="title_dynamic_load">Dynamic CPU Load</string>
     <string name="title_cold_start_latency">Cold Start Latency</string>
+    <string name="title_rapid_cycle">Rapid Cycle</string>
 
     <string name="need_record_audio_permission">"This app needs RECORD_AUDIO permission"</string>
     <string name="share">Share</string>
@@ -270,6 +271,12 @@
         More likely to crash with Bluetooth\n
         headsets. Fixed in SDK 34 (U).\n
         Issue #1763
+    </string>
+
+    <string name="rapid_cycle_intro">
+        Maybe cause a crash by rapidly\n
+        opening, starting, stopping and\n
+        closing streams.
     </string>
 
     <string-array name="conversion_qualities">

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -251,7 +251,7 @@ Result AudioOutputStreamOpenSLES::close() {
 
 Result AudioOutputStreamOpenSLES::setPlayState_l(SLuint32 newState) {
 
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
+    LOGD("AudioOutputStreamOpenSLES::%s(%d) called", __func__, newState);
     Result result = Result::OK;
 
     if (mPlayInterface == nullptr){
@@ -268,7 +268,7 @@ Result AudioOutputStreamOpenSLES::setPlayState_l(SLuint32 newState) {
 }
 
 Result AudioOutputStreamOpenSLES::requestStart() {
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
+    LOGD("AudioOutputStreamOpenSLES::%s() called", __func__);
 
     mLock.lock();
     StreamState initialState = getState();
@@ -318,7 +318,7 @@ Result AudioOutputStreamOpenSLES::requestStart() {
 }
 
 Result AudioOutputStreamOpenSLES::requestPause() {
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
+    LOGD("AudioOutputStreamOpenSLES::%s() called", __func__);
     std::lock_guard<std::mutex> lock(mLock);
     return requestPause_l();
 }
@@ -361,7 +361,7 @@ Result AudioOutputStreamOpenSLES::requestFlush() {
 }
 
 Result AudioOutputStreamOpenSLES::requestFlush_l() {
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
+    LOGD("AudioOutputStreamOpenSLES::%s() called", __func__);
     if (getState() == StreamState::Closed) {
         return Result::ErrorClosed;
     }
@@ -385,7 +385,7 @@ Result AudioOutputStreamOpenSLES::requestStop() {
 }
 
 Result AudioOutputStreamOpenSLES::requestStop_l() {
-    LOGD("AudioOutputStreamOpenSLES(): %s() called", __func__);
+    LOGD("AudioOutputStreamOpenSLES::%s() called", __func__);
 
     StreamState initialState = getState();
     switch (initialState) {


### PR DESCRIPTION
This was an attempt to reproduce b/348615156
b/348615156 | P2 | [Oboe/OpenSLES] Deadlock is caused when close function is called immediately after stream playback.