### PR TITLE
OboeTester: DataPaths input margin increased from 1 to 3

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.cpp
@@ -57,13 +57,14 @@ oboe::DataCallbackResult FullDuplexAnalyzer::onBothStreamsReadyFloat(
             mRecording->write(buffer, 1);
         }
         // Handle mismatch in numFrames.
-        buffer[0] = 0.0f; // gap in output
+        const float gapMarker = -0.9f; // Recognizable value so we can tell underruns from DSP gaps.
+        buffer[0] = gapMarker; // gap in output
         for (int i = numBoth; i < numInputFrames; i++) {
             buffer[1] = *inputFloat;
             inputFloat += inputStride;
             mRecording->write(buffer, 1);
         }
-        buffer[1] = 0.0f; // gap in input
+        buffer[1] = gapMarker; // gap in input
         for (int i = numBoth; i < numOutputFrames; i++) {
             buffer[0] = *outputFloat;
             outputFloat += outputStride;

--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
@@ -29,7 +29,10 @@ class FullDuplexAnalyzer : public FullDuplexStreamWithConversion {
 public:
     FullDuplexAnalyzer(LoopbackProcessor *processor)
             : mLoopbackProcessor(processor) {
-        setNumInputBurstsCushion(1);
+        // If we are measuring glitches then we should set this >1 to avoid input underruns.
+        // Underruns are more common when doing sample rate conversion because of the variable
+        // callback sizes.
+        setNumInputBurstsCushion(3);
     }
 
     /**


### PR DESCRIPTION
This prevents underruns when doing sample rate conversion.

Fixes #2046