### PR TITLE
Docs: Get rid of docs/AppsUsingOboe.md

### DIFF
--- a/docs/AppsUsingOboe.md
+++ b/docs/AppsUsingOboe.md
@@ -1,3 +1,0 @@
-# Projects using Oboe or AAudio
-
-This page was moved to the Wiki at [AppsUsingOboe](https://github.com/google/oboe/wiki/AppsUsingOboe).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ Oboe documentation
 ===
 - [Android Audio History](AndroidAudioHistory.md)
 - [API reference](https://google.github.io/oboe/)
-- [Apps using Oboe](AppsUsingOboe.md)
+- [Apps using Oboe](https://github.com/google/oboe/wiki/AppsUsingOboe)
 - [FAQs](FAQ.md)
 - [Full Guide to Oboe](FullGuide.md)
 - [Getting Started with Oboe](GettingStarted.md)


### PR DESCRIPTION
`docs/AppsUsingOboe.md` just links to https://github.com/google/oboe/wiki/AppsUsingOboe. We should just get rid of the former.