### PR TITLE
OboeTester: display ro.build.date in MainActivity

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioQueryTools.java
@@ -160,6 +160,7 @@ public class AudioQueryTools {
         report.append(getSystemPropertyLine("ro.board.platform"));
         report.append(getSystemPropertyLine("ro.build.changelist"));
         report.append(getSystemPropertyLine("ro.build.description"));
+        report.append(getSystemPropertyLine("ro.build.date"));
         return report.toString();
     }
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -140,6 +140,7 @@ public class DeviceReportActivity extends AppCompatActivity {
                 .append(", ").append(Build.PRODUCT).append("\n");
 
         report.append(reportExtraDeviceInfo());
+        report.append("\n");
 
         for (AudioDeviceInfo deviceInfo : devices) {
             report.append("\n==== Device =================== " + deviceInfo.getId() + "\n");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -16,6 +16,8 @@
 
 package com.mobileer.oboetester;
 
+import static com.mobileer.oboetester.AudioQueryTools.getSystemProperty;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -111,7 +113,8 @@ public class MainActivity extends BaseOboeTesterActivity {
         mBackgroundCheckBox = (CheckBox) findViewById(R.id.boxEnableBackground);
 
         mBuildTextView = (TextView) findViewById(R.id.text_build_info);
-        mBuildTextView.setText(Build.DISPLAY);
+        mBuildTextView.setText(Build.DISPLAY
+                + "\n" + getSystemProperty("ro.build.date"));
 
         saveIntentBundleForLaterProcessing(getIntent());
     }

--- a/apps/OboeTester/app/src/main/res/layout/activity_main.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_main.xml
@@ -231,9 +231,9 @@
 
     <TextView
         android:id="@+id/text_build_info"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="1dp"
+        android:lines="3"
         android:ems="10"
         android:text="V?"
         app:layout_constraintEnd_toEndOf="@+id/callbackSize"


### PR DESCRIPTION
Because the fingerprint may no longer have a timestamp!

 b/348672935 | P2 | ro.build.fingerprint has 00000000.000000 instead of the date