### PR TITLE
opensles: fix deadlock when stopping a stream

### DIFF
--- a/src/opensles/AudioInputStreamOpenSLES.cpp
+++ b/src/opensles/AudioInputStreamOpenSLES.cpp
@@ -212,7 +212,7 @@ Result AudioInputStreamOpenSLES::close() {
     LOGD("AudioInputStreamOpenSLES::%s()", __func__);
     std::lock_guard<std::mutex> lock(mLock);
     Result result = Result::OK;
-    if (getState() == StreamState::Closed){
+    if (getState() == StreamState::Closed) {
         result = Result::ErrorClosed;
     } else {
         (void) requestStop_l();

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -235,7 +235,7 @@ Result AudioOutputStreamOpenSLES::close() {
     LOGD("AudioOutputStreamOpenSLES::%s()", __func__);
     std::lock_guard<std::mutex> lock(mLock);
     Result result = Result::OK;
-    if (getState() == StreamState::Closed){
+    if (getState() == StreamState::Closed) {
         result = Result::ErrorClosed;
     } else {
         (void) requestPause_l();
@@ -250,7 +250,6 @@ Result AudioOutputStreamOpenSLES::close() {
 }
 
 Result AudioOutputStreamOpenSLES::setPlayState_l(SLuint32 newState) {
-
     LOGD("AudioOutputStreamOpenSLES::%s(%d) called", __func__, newState);
     Result result = Result::OK;
 
@@ -385,9 +384,8 @@ Result AudioOutputStreamOpenSLES::requestStop() {
 }
 
 Result AudioOutputStreamOpenSLES::requestStop_l() {
-    LOGD("AudioOutputStreamOpenSLES::%s() called", __func__);
-
     StreamState initialState = getState();
+    LOGD("AudioOutputStreamOpenSLES::%s() called, initialState = %d", __func__, initialState);
     switch (initialState) {
         case StreamState::Stopping:
         case StreamState::Stopped:


### PR DESCRIPTION
Temporarily unlock() and lock() when Destroy()ing a stream because that joins the callback thread.

Fixes a rare ANR.

Fixes #2059