### PR TITLE
OboeTester: add sine wave oscillator as a reference for input

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/FullDuplexAnalyzer.h
@@ -29,10 +29,6 @@ class FullDuplexAnalyzer : public FullDuplexStreamWithConversion {
 public:
     FullDuplexAnalyzer(LoopbackProcessor *processor)
             : mLoopbackProcessor(processor) {
-        // If we are measuring glitches then we should set this >1 to avoid input underruns.
-        // Underruns are more common when doing sample rate conversion because of the variable
-        // callback sizes.
-        setNumInputBurstsCushion(3);
     }
 
     /**

--- a/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
@@ -63,7 +63,7 @@ public:
         float sample = frameData[getInputChannel()];
         mInfiniteRecording.write(sample);
 
-        if (transformSample(sample, mOutputPhase)) {
+        if (transformSample(sample)) {
             // Analyze magnitude and phase on every period.
             if (mPhaseOffset != kPhaseInvalid) {
                 double diff = fabs(calculatePhaseError(mPhaseOffset, mPreviousPhaseOffset));

--- a/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/GlitchAnalyzer.h
@@ -229,7 +229,7 @@ public:
                     // Track incoming signal and slowly adjust magnitude to account
                     // for drift in the DRC or AGC.
                     // Must be a multiple of the period or the calculation will not be accurate.
-                    if (transformSample(sample, mInputPhase)) {
+                    if (transformSample(sample)) {
                         // Adjust phase to account for sample rate drift.
                         mInputPhase += mPhaseOffset;
 
@@ -249,7 +249,6 @@ public:
                         }
                     }
                 }
-                incrementInputPhase();
             } break;
 
             case STATE_GLITCHING: {
@@ -287,14 +286,6 @@ public:
     }
 
     int maxMeasurableGlitchLength() const { return 2 * mSinePeriod; }
-
-    // advance and wrap phase
-    void incrementInputPhase() {
-        mInputPhase += mPhaseIncrement;
-        if (mInputPhase > M_PI) {
-            mInputPhase -= (2.0 * M_PI);
-        }
-    }
 
     bool isOutputEnabled() override { return mState != STATE_IDLE; }
 
@@ -399,7 +390,6 @@ private:
     sine_state_t  mState = STATE_IDLE;
     int64_t       mLastGlitchPosition;
 
-    double  mInputPhase = 0.0;
     double  mMaxGlitchDelta = 0.0;
     int32_t mGlitchCount = 0;
     int32_t mConsecutiveBadFrames = 0;


### PR DESCRIPTION
This will prevent glitches caused by the number of input and output frames being different in the full duplex callback.

Fixes #2068