### PR TITLE
OboeTester: Display Actual Device Id

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfigurationView.java
@@ -51,6 +51,7 @@ public class StreamConfigurationView extends LinearLayout {
 
     protected Spinner mNativeApiSpinner;
     private TextView mActualNativeApiView;
+    private TextView mActualDeviceIdView;
 
     private TextView mActualMMapView;
     private CheckBox mRequestedMMapView;
@@ -193,6 +194,8 @@ public class StreamConfigurationView extends LinearLayout {
         mNativeApiSpinner.setSelection(StreamConfiguration.NATIVE_API_UNSPECIFIED);
 
         mActualNativeApiView = (TextView) findViewById(R.id.actualNativeApi);
+
+        mActualDeviceIdView = (TextView) findViewById(R.id.actualDeviceId);
 
         mChannelConversionBox = (CheckBox) findViewById(R.id.checkChannelConversion);
 
@@ -446,6 +449,9 @@ public class StreamConfigurationView extends LinearLayout {
 
         value = actualConfiguration.getNativeApi();
         mActualNativeApiView.setText(StreamConfiguration.convertNativeApiToText(value));
+
+        value = actualConfiguration.getDeviceId();
+        mActualDeviceIdView.setText(String.valueOf(value));
 
         mActualMMapView.setText(yesOrNo(actualConfiguration.isMMap()));
         int sharingMode = actualConfiguration.getSharingMode();

--- a/apps/OboeTester/app/src/main/res/layout/stream_config.xml
+++ b/apps/OboeTester/app/src/main/res/layout/stream_config.xml
@@ -57,6 +57,11 @@
                     android:id="@+id/devices_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"/>
+                <TextView
+                    android:id="@+id/actualDeviceId"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="\?" />
 
             </TableRow>
 


### PR DESCRIPTION
It's good to know what the default device id is for AAudio and that the device id is ignored for OpenSL ES.