### PR TITLE
OboeTester: Foreground service type should depend on activity type

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioForegroundService.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioForegroundService.java
@@ -61,15 +61,15 @@ public class AudioForegroundService extends Service {
         Log.i(TAG, "Receive onStartCommand" + intent);
         switch (intent.getAction()) {
             case ACTION_START:
-                Log.i(TAG, "Receive ACTION_START" + intent.getExtras());
+                Log.i(TAG, "Receive ACTION_START " + intent.getExtras());
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    startForeground(1, buildNotification(),
-                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-                                    | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+                    int serviceTypes = intent.getIntExtra("service_types", 0);
+                    Log.i(TAG, "ServiceTypes: " + serviceTypes);
+                    startForeground(1, buildNotification(), serviceTypes);
                 }
                 break;
             case ACTION_STOP:
-                Log.i(TAG, "Receive ACTION_STOP" + intent.getExtras());
+                Log.i(TAG, "Receive ACTION_STOP " + intent.getExtras());
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     stopForeground(STOP_FOREGROUND_REMOVE);
                 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseOboeTesterActivity.java
@@ -87,7 +87,7 @@ public abstract class BaseOboeTesterActivity extends AppCompatActivity
     /**
      * If needed, request recording permission before running test.
      */
-    protected void launchTestThatRequiresRecordingPermissions(Class clazz) {
+    protected void launchTestThatDoesRecording(Class clazz) {
         mTestClass = clazz;
         if (isRecordPermissionGranted()) {
             beginTestThatRequiresRecording();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/ExtraTestsActivity.java
@@ -16,7 +16,7 @@ public class ExtraTestsActivity extends BaseOboeTesterActivity {
     }
 
     public void onLaunchExternalTapTest(View view) {
-        launchTestThatRequiresRecordingPermissions(ExternalTapToToneActivity.class);
+        launchTestThatDoesRecording(ExternalTapToToneActivity.class);
     }
 
     public void onLaunchPlugLatencyTest(View view) {
@@ -28,7 +28,7 @@ public class ExtraTestsActivity extends BaseOboeTesterActivity {
     }
 
     public void onLaunchRouteDuringCallbackTest(View view) {
-        launchTestThatRequiresRecordingPermissions(TestRouteDuringCallbackActivity.class);
+        launchTestThatDoesRecording(TestRouteDuringCallbackActivity.class);
     }
 
     public void onLaunchDynamicWorkloadTest(View view) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -206,61 +206,49 @@ public class MainActivity extends BaseOboeTesterActivity {
     }
 
     public void onLaunchTestOutput(View view) {
-        if (mForegroundServiceCheckBox.isChecked()) {
-            launchTestThatRequiresRecordingPermissions(TestOutputActivity.class);
-        } else {
-            launchTestActivity(TestOutputActivity.class);
-        }
+        launchTestActivity(TestOutputActivity.class);
     }
 
     public void onLaunchTestInput(View view) {
-        launchTestThatRequiresRecordingPermissions(TestInputActivity.class);
+        launchTestThatDoesRecording(TestInputActivity.class);
     }
 
     public void onLaunchTapToTone(View view) {
-        launchTestThatRequiresRecordingPermissions(TapToToneActivity.class);
+        launchTestThatDoesRecording(TapToToneActivity.class);
     }
 
     public void onLaunchRecorder(View view) {
-        launchTestThatRequiresRecordingPermissions(RecorderActivity.class);
+        launchTestThatDoesRecording(RecorderActivity.class);
     }
 
     public void onLaunchEcho(View view) {
-        launchTestThatRequiresRecordingPermissions(EchoActivity.class);
+        launchTestThatDoesRecording(EchoActivity.class);
     }
 
     public void onLaunchRoundTripLatency(View view) {
-        launchTestThatRequiresRecordingPermissions(RoundTripLatencyActivity.class);
+        launchTestThatDoesRecording(RoundTripLatencyActivity.class);
     }
 
     public void onLaunchManualGlitchTest(View view) {
-        launchTestThatRequiresRecordingPermissions(ManualGlitchActivity.class);
+        launchTestThatDoesRecording(ManualGlitchActivity.class);
     }
 
-    public void onLaunchAutoGlitchTest(View view) { launchTestThatRequiresRecordingPermissions(AutomatedGlitchActivity.class); }
+    public void onLaunchAutoGlitchTest(View view) { launchTestThatDoesRecording(AutomatedGlitchActivity.class); }
 
     public void onLaunchTestDisconnect(View view) {
-        launchTestThatRequiresRecordingPermissions(TestDisconnectActivity.class);
+        launchTestThatDoesRecording(TestDisconnectActivity.class);
     }
 
     public void onLaunchTestDataPaths(View view) {
-        launchTestThatRequiresRecordingPermissions(TestDataPathsActivity.class);
+        launchTestThatDoesRecording(TestDataPathsActivity.class);
     }
 
     public void onLaunchTestDeviceReport(View view)  {
-        if (mForegroundServiceCheckBox.isChecked()) {
-            launchTestThatRequiresRecordingPermissions(DeviceReportActivity.class);
-        } else {
-            launchTestActivity(DeviceReportActivity.class);
-        }
+        launchTestActivity(DeviceReportActivity.class);
     }
 
     public void onLaunchExtratests(View view) {
-        if (mForegroundServiceCheckBox.isChecked()) {
-            launchTestThatRequiresRecordingPermissions(ExtraTestsActivity.class);
-        } else {
-            launchTestActivity(ExtraTestsActivity.class);
-        }
+        launchTestActivity(ExtraTestsActivity.class);
     }
 
     private void applyUserOptions() {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestAudioActivity.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
 import android.media.AudioAttributes;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
@@ -195,6 +196,41 @@ abstract class TestAudioActivity extends AppCompatActivity {
         return mForegroundServiceEnabled;
     }
 
+    public int getServiceType() {
+        switch(getActivityType()) {
+            case ACTIVITY_TEST_OUTPUT:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK;
+            case ACTIVITY_TEST_INPUT:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_TAP_TO_TONE:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_RECORD_PLAY:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_ECHO:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_RT_LATENCY:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_GLITCHES:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_TEST_DISCONNECT:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_DATA_PATHS:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
+            case ACTIVITY_DYNAMIC_WORKLOAD:
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK;
+            default:
+                Log.i(TAG, "getServiceType() called on unknown activity type " + getActivityType());
+                return 0;
+        }
+    }
+
     public void onStreamClosed() {
     }
 
@@ -343,6 +379,7 @@ abstract class TestAudioActivity extends AppCompatActivity {
             String action = enabled ? ACTION_START : ACTION_STOP;
             Intent serviceIntent = new Intent(action, null, this,
                     AudioForegroundService.class);
+            serviceIntent.putExtra("service_types", getServiceType());
             startForegroundService(serviceIntent);
         }
     }


### PR DESCRIPTION
Currently, the OboeTester foreground service declares that its service types are both media playback and microphone, regardless of what activity is used.

Test Input and Test Output should be different service types when using a foreground service. This PR makes this change. This allows us to undo an confusing commit #2100.

Fixes #2105