### PR TITLE
OboeTester: measure latency with varying buffer sizes to detect MMAP errors

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestInputActivity.java
@@ -42,7 +42,7 @@ public class TestInputActivity  extends TestAudioActivity {
     private static final int NUM_VOLUME_BARS = 8;
     private VolumeBarView[] mVolumeBars = new VolumeBarView[NUM_VOLUME_BARS];
     private InputMarginView mInputMarginView;
-    private int mInputMarginBursts = 0;
+    int mInputMarginBursts = 0;
     private WorkloadView mWorkloadView;
 
     public native void setMinimumFramesBeforeRead(int frames);

--- a/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
@@ -62,7 +62,7 @@
             android:layout_weight="1"
             android:onClick="onMeasure"
             android:text="@string/measure"
-            android:textSize="12sp" />
+            android:textSize="10sp" />
 
         <Button
             android:id="@+id/button_average"
@@ -71,7 +71,17 @@
             android:layout_height="wrap_content"
             android:onClick="onAverage"
             android:text="@string/average"
-            android:textSize="12sp" />
+            android:textSize="10sp" />
+
+        <Button
+            android:id="@+id/button_scan"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:onClick="onScan"
+            android:text="@string/scan"
+            android:textSize="10sp" />
 
         <Button
             android:id="@+id/button_cancel"
@@ -81,7 +91,7 @@
             android:enabled="false"
             android:onClick="onCancel"
             android:text="@string/cancel"
-            android:textSize="12sp" />
+            android:textSize="10sp" />
 
         <Button
             android:id="@+id/button_share"
@@ -90,7 +100,7 @@
             android:layout_height="wrap_content"
             android:onClick="onShareFile"
             android:text="@string/share"
-            android:textSize="12sp" />
+            android:textSize="10sp" />
     </LinearLayout>
 
     <com.mobileer.oboetester.CommunicationDeviceView

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="playAudio">Play</string>
     <string name="measure">Measure</string>
     <string name="cancel">Cancel</string>
+    <string name="scan">Scan</string>
     <string name="clear">Clear</string>
     <string name="clear_comm">clearCommunicationDevice()</string>
     <string name="runTest">Run</string>


### PR DESCRIPTION
This can be used to detect errors in the DSP MMAP position timestamps
used by the AAudio IsochronousClockModel.

If the DSP position is off then it can cause a discontinuity in round-trip latency as a function of buffer size.
So we change the buffer size and look for the discontinuity.