### PR TITLE
Incerase Data Paths duration from 3 to 4

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -87,7 +87,7 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     public static final boolean VALUE_DEFAULT_USE_OUTPUT_DEVICES = true;
 
 
-    public static final int DURATION_SECONDS = 3;
+    public static final int DURATION_SECONDS = 4;
     private final static double MIN_REQUIRED_MAGNITUDE = 0.001;
     private final static int MAX_SINE_FREQUENCY = 1000;
     private final static int TYPICAL_SAMPLE_RATE = 48000;


### PR DESCRIPTION
We were seeing some of the sample rate conversion tests failing on Pixel 7. The signal was OK but the cold start latency was a bit slow. So the test was timing out.

See b/384751468