### PR TITLE
Update DuplexCallback.h in fxlab

### DIFF
--- a/apps/fxlab/app/src/main/cpp/DuplexCallback.h
+++ b/apps/fxlab/app/src/main/cpp/DuplexCallback.h
@@ -43,10 +43,6 @@ public:
         std::fill(outputData, outputData + numFrames * outputChannelCount, 0);
         oboe::ResultWithValue<int32_t> result = inRef.read(inputBuffer.get(), numFrames, 0);
         int32_t framesRead = result.value();
-        if (!result) {
-            inRef.requestStop();
-            return oboe::DataCallbackResult::Stop;
-        }
         if (mSpinUpCallbacks > 0 && framesRead > 0) {
             mSpinUpCallbacks--;
             return oboe::DataCallbackResult::Continue;


### PR DESCRIPTION
In cases where the stream does not start immediately when starting the app, the audio stream is stopped immediately, which means the demo does not work. This if statement is unnecessary since any errors will be handled by ErrorCallback.