### PR TITLE
DO NOT MERGE: OboeTester: Add game mode for testing dynamic workload activity

### DIFF
--- a/apps/OboeTester/app/src/main/AndroidManifest.xml
+++ b/apps/OboeTester/app/src/main/AndroidManifest.xml
@@ -30,7 +30,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:requestLegacyExternalStorage="true"
-        android:banner="@mipmap/ic_launcher">
+        android:banner="@mipmap/ic_launcher"
+        android:appCategory="game">
+        <meta-data android:name="android.game_mode_config"
+            android:resource="@xml/game_mode_config" />
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/apps/OboeTester/app/src/main/res/layout/activity_dynamic_workload.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_dynamic_workload.xml
@@ -13,17 +13,8 @@
 
     <include layout="@layout/merge_audio_simple" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:lines="1"
-        android:text="CPUs:"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
-
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
@@ -53,6 +44,18 @@
             android:layout_height="wrap_content"
             android:layout_marginRight="8sp"
             android:text="Alt ADPF" />
+    </LinearLayout>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/small_horizontal_margin"
+        android:paddingTop="@dimen/small_vertical_margin"
+        android:paddingRight="@dimen/small_horizontal_margin"
+        android:paddingBottom="@dimen/small_vertical_margin"
+        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
 
         <CheckBox
             android:id="@+id/hear_workload"
@@ -68,6 +71,64 @@
             android:layout_marginRight="8sp"
             android:checked="true"
             android:text="Scroll" />
+    </LinearLayout>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/small_horizontal_margin"
+        android:paddingTop="@dimen/small_vertical_margin"
+        android:paddingRight="@dimen/small_horizontal_margin"
+        android:paddingBottom="@dimen/small_vertical_margin"
+        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/game_state_mode_prompt" />
+
+        <Spinner
+            android:id="@+id/spinner_game_state_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/game_state_modes"
+            android:prompt="@string/game_state_mode_prompt" />
+    </LinearLayout>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/small_horizontal_margin"
+        android:paddingTop="@dimen/small_vertical_margin"
+        android:paddingRight="@dimen/small_horizontal_margin"
+        android:paddingBottom="@dimen/small_vertical_margin"
+        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+
+        <CheckBox
+            android:id="@+id/checkbox_is_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="8sp"
+            android:checked="false"
+            android:text="Is Loading" />
+
+        <TextView
+            android:id="@+id/actual_game_mode_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/actual_game_mode" />
+
+        <TextView
+            android:id="@+id/actual_game_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="\?" />
     </LinearLayout>
 
     <HorizontalScrollView

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -309,4 +309,14 @@
         <item>50000</item>
     </string-array>
 
+    <string name="game_state_mode_prompt">Game State Mode:</string>
+    <string-array name="game_state_modes">
+        <item>UNKNOWN</item>
+        <item>NONE</item>
+        <item>GAMEPLAY_INTERRUPTIBLE</item>
+        <item>GAMEPLAY_UNINTERRUPTIBLE</item>
+        <item>CONTENT</item>
+    </string-array>
+    <string name="actual_game_mode">Actual Game Mode :</string>
+
 </resources>

--- a/apps/OboeTester/app/src/main/res/xml/game_mode_config.xml
+++ b/apps/OboeTester/app/src/main/res/xml/game_mode_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<game-mode-config
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsBatteryGameMode="true"
+    android:supportsPerformanceGameMode="true"
+    />


### PR DESCRIPTION
Note that GameMode and GameState are different.
[GameMode](https://developer.android.com/games/optimize/adpf/gamemode/gamemode-api) is the actual performance mode of the game (STANDARD, PERFORMANCE, BATTERY).
[GameState](GameState) takes in at least 2 parameters, isLoading and Mode (GAMEPLAY_INTERRUPTIBLE, GAMEPLAY_UNINTERRUPTIBLE, CONTENT), and is the app specified state and used for system optimization.

GameManager allows apps to set GameState and users to set the GameMode. To set the GameMode, you must switch the game mode manually with the [Game Dashboard](https://developer.android.com/games/optimize/adpf/gamemode/gamemode-api#switch_game_modes) outside of the game.

It seems like GameMode is an API that allows apps to handle each of the 3 modes (STANDARD, PERFORMANCE, BATTERY) differently.

If audio apps were to use the game mode API, they can consider changing different buffer sizes depending on the mode.