### PR TITLE
OboeTester: Fix race condition with setWorkload in Dynamic Workload Activity

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.cpp
@@ -25,13 +25,14 @@ oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
         int numFrames) {
     oboe::DataCallbackResult callbackResult = oboe::DataCallbackResult::Stop;
     int64_t startTimeNanos = getNanoseconds();
+    int32_t numWorkloadVoices = mNumWorkloadVoices;
 
     // Record which CPU this is running on.
     orCurrentCpuMask(sched_getcpu());
 
     // Tell ADPF in advance what our workload will be.
     if (mWorkloadReportingEnabled) {
-        audioStream->reportWorkload(mNumWorkloadVoices);
+        audioStream->reportWorkload(numWorkloadVoices);
     }
 
     // Change affinity if app requested a change.
@@ -54,8 +55,8 @@ oboe::DataCallbackResult OboeStreamCallbackProxy::onAudioReady(
         callbackResult = mCallback->onAudioReady(audioStream, audioData, numFrames);
     }
 
-    mSynthWorkload.onCallback(mNumWorkloadVoices);
-    if (mNumWorkloadVoices > 0) {
+    mSynthWorkload.onCallback(numWorkloadVoices);
+    if (numWorkloadVoices > 0) {
         // Render into the buffer or discard the synth voices.
         float *buffer = (audioStream->getChannelCount() == 2 && mHearWorkload)
                         ? static_cast<float *>(audioData) : nullptr;

--- a/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
+++ b/apps/OboeTester/app/src/main/cpp/OboeStreamCallbackProxy.h
@@ -251,7 +251,7 @@ private:
     std::atomic<float>         mMaxCpuLoad{0.0f};
     int64_t                    mPreviousCallbackTimeNs = 0;
     DoubleStatistics           mStatistics;
-    int32_t                    mNumWorkloadVoices = 0;
+    std::atomic<int32_t>       mNumWorkloadVoices{0};
     SynthWorkload              mSynthWorkload;
     bool                       mHearWorkload = false;
     bool                       mWorkloadReportingEnabled = false;

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
@@ -40,7 +40,7 @@ import java.util.Locale;
  */
 public class DynamicWorkloadActivity extends TestOutputActivityBase {
     private static final int WORKLOAD_HIGH_MIN = 30;
-    private static final int WORKLOAD_HIGH_MAX = 150;
+    private static final int WORKLOAD_HIGH_MAX = 1500;
     // When the CPU is completely saturated then the load will be above 1.0.
     public static final double LOAD_RECOVERY_HIGH = 1.0;
     // Use a slightly lower value for going low so that the comparator has hysteresis.

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DynamicWorkloadActivity.java
@@ -40,7 +40,7 @@ import java.util.Locale;
  */
 public class DynamicWorkloadActivity extends TestOutputActivityBase {
     private static final int WORKLOAD_HIGH_MIN = 30;
-    private static final int WORKLOAD_HIGH_MAX = 1500;
+    private static final int WORKLOAD_HIGH_MAX = 150;
     // When the CPU is completely saturated then the load will be above 1.0.
     public static final double LOAD_RECOVERY_HIGH = 1.0;
     // Use a slightly lower value for going low so that the comparator has hysteresis.


### PR DESCRIPTION
If the workload is set in the middle of onAudioReady(), the new workload can be used for the synth before audioStream->reportWorkload() is called for this workload.

The fix here is to use an atomic variable and the same workload throughout the function.