### PR TITLE
AdpfWrapper: Use CLOCK_MONOTONIC instead of CLOCK_REALTIME

### DIFF
--- a/src/common/AdpfWrapper.cpp
+++ b/src/common/AdpfWrapper.cpp
@@ -110,13 +110,13 @@ void AdpfWrapper::close() {
 
 void AdpfWrapper::onBeginCallback() {
     if (isOpen()) {
-        mBeginCallbackNanos = oboe::AudioClock::getNanoseconds(CLOCK_REALTIME);
+        mBeginCallbackNanos = oboe::AudioClock::getNanoseconds();
     }
 }
 
 void AdpfWrapper::onEndCallback(double durationScaler) {
     if (isOpen()) {
-        int64_t endCallbackNanos = oboe::AudioClock::getNanoseconds(CLOCK_REALTIME);
+        int64_t endCallbackNanos = oboe::AudioClock::getNanoseconds();
         int64_t actualDurationNanos = endCallbackNanos - mBeginCallbackNanos;
         int64_t scaledDurationNanos = static_cast<int64_t>(actualDurationNanos * durationScaler);
         reportActualDuration(scaledDurationNanos);


### PR DESCRIPTION
There doesn't seem to be any upsides in using CLOCK_REALTIME over CLOCK_MONOTONIC in AdpfWrapper.cpp. Since the rest of the Oboe codebase uses CLOCK_MONOTONIC, we should also use it here.