### PR TITLE
AdpfWrapper: Add trace for actualDurationNanos

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -222,7 +222,7 @@ Java_com_mobileer_oboetester_OboeAudioStream_close(JNIEnv *env, jobject, jint st
 
 JNIEXPORT void JNICALL
 Java_com_mobileer_oboetester_TestAudioActivity_setUseAlternativeAdpf(JNIEnv *env, jobject, jboolean enabled) {
-    AdpfWrapper::setUseAlternative(enabled);
+    oboe::AdpfWrapper::setUseAlternative(enabled);
 }
 
 JNIEXPORT jint JNICALL

--- a/src/common/AdpfWrapper.cpp
+++ b/src/common/AdpfWrapper.cpp
@@ -23,6 +23,8 @@
 #include "OboeDebug.h"
 #include "Trace.h"
 
+using namespace oboe;
+
 typedef APerformanceHintManager* (*APH_getManager)();
 typedef APerformanceHintSession* (*APH_createSession)(APerformanceHintManager*, const int32_t*,
                                                       size_t, int64_t);

--- a/src/common/AdpfWrapper.cpp
+++ b/src/common/AdpfWrapper.cpp
@@ -21,6 +21,7 @@
 #include "oboe/AudioClock.h"
 #include "AdpfWrapper.h"
 #include "OboeDebug.h"
+#include "Trace.h"
 
 typedef APerformanceHintManager* (*APH_getManager)();
 typedef APerformanceHintSession* (*APH_createSession)(APerformanceHintManager*, const int32_t*,
@@ -64,6 +65,9 @@ static int loadAphFunctions() {
     }
 
     gAPerformanceHintBindingInitialized = true;
+
+    Trace::initialize();
+
     return 0;
 }
 
@@ -95,6 +99,9 @@ int AdpfWrapper::open(pid_t threadId,
 void AdpfWrapper::reportActualDuration(int64_t actualDurationNanos) {
     //LOGD("ADPF Oboe %s(dur=%lld)", __func__, (long long)actualDurationNanos);
     std::lock_guard<std::mutex> lock(mLock);
+    Trace::beginSection("reportActualDuration");
+    Trace::setCounter("actualDurationNanos", actualDurationNanos);
+    Trace::endSection();
     if (mHintSession != nullptr) {
         gAPH_reportActualWorkDurationFn(mHintSession, actualDurationNanos);
     }

--- a/src/common/AdpfWrapper.cpp
+++ b/src/common/AdpfWrapper.cpp
@@ -103,10 +103,10 @@ void AdpfWrapper::reportActualDuration(int64_t actualDurationNanos) {
     std::lock_guard<std::mutex> lock(mLock);
     Trace::beginSection("reportActualDuration");
     Trace::setCounter("actualDurationNanos", actualDurationNanos);
-    Trace::endSection();
     if (mHintSession != nullptr) {
         gAPH_reportActualWorkDurationFn(mHintSession, actualDurationNanos);
     }
+    Trace::endSection();
 }
 
 void AdpfWrapper::close() {

--- a/src/common/AdpfWrapper.h
+++ b/src/common/AdpfWrapper.h
@@ -24,66 +24,69 @@
 #include <unistd.h>
 #include <mutex>
 
-struct APerformanceHintManager;
-struct APerformanceHintSession;
+namespace oboe {
 
-typedef struct APerformanceHintManager APerformanceHintManager;
-typedef struct APerformanceHintSession APerformanceHintSession;
+    struct APerformanceHintManager;
+    struct APerformanceHintSession;
 
-class AdpfWrapper {
-public:
-     /**
-      * Create an ADPF session that can be used to boost performance.
-      * @param threadId
-      * @param targetDurationNanos - nominal period of isochronous task
-      * @return zero or negative error
-      */
-    int open(pid_t threadId,
-             int64_t targetDurationNanos);
+    typedef struct APerformanceHintManager APerformanceHintManager;
+    typedef struct APerformanceHintSession APerformanceHintSession;
 
-    bool isOpen() const {
-        return (mHintSession != nullptr);
-    }
+    class AdpfWrapper {
+    public:
+        /**
+         * Create an ADPF session that can be used to boost performance.
+         * @param threadId
+         * @param targetDurationNanos - nominal period of isochronous task
+         * @return zero or negative error
+         */
+        int open(pid_t threadId,
+                 int64_t targetDurationNanos);
 
-    void close();
+        bool isOpen() const {
+            return (mHintSession != nullptr);
+        }
 
-    /**
-     * Call this at the beginning of the callback that you are measuring.
-     */
-    void onBeginCallback();
+        void close();
 
-    /**
-     * Call this at the end of the callback that you are measuring.
-     * It is OK to skip this if you have a short callback.
-     */
-    void onEndCallback(double durationScaler);
+        /**
+         * Call this at the beginning of the callback that you are measuring.
+         */
+        void onBeginCallback();
 
-    /**
-     * For internal use only!
-     * This is a hack for communicating with experimental versions of ADPF.
-     * @param enabled
-     */
-    static void setUseAlternative(bool enabled) {
-        sUseAlternativeHack = enabled;
-    }
+        /**
+         * Call this at the end of the callback that you are measuring.
+         * It is OK to skip this if you have a short callback.
+         */
+        void onEndCallback(double durationScaler);
 
-    /**
-     * Report the measured duration of a callback.
-     * This is normally called by onEndCallback().
-     * You may want to call this directly in order to give an advance hint of a jump in workload.
-     * @param actualDurationNanos
-     */
-    void reportActualDuration(int64_t actualDurationNanos);
+        /**
+         * For internal use only!
+         * This is a hack for communicating with experimental versions of ADPF.
+         * @param enabled
+         */
+        static void setUseAlternative(bool enabled) {
+            sUseAlternativeHack = enabled;
+        }
 
-    void reportWorkload(int32_t appWorkload);
+        /**
+         * Report the measured duration of a callback.
+         * This is normally called by onEndCallback().
+         * You may want to call this directly in order to give an advance hint of a jump in workload.
+         * @param actualDurationNanos
+         */
+        void reportActualDuration(int64_t actualDurationNanos);
 
-private:
-    std::mutex               mLock;
-    APerformanceHintSession* mHintSession = nullptr;
-    int64_t                  mBeginCallbackNanos = 0;
-    static bool              sUseAlternativeHack;
-    int32_t                  mPreviousWorkload = 0;
-    double                   mNanosPerWorkloadUnit = 0.0;
-};
+        void reportWorkload(int32_t appWorkload);
 
+    private:
+        std::mutex mLock;
+        APerformanceHintSession *mHintSession = nullptr;
+        int64_t mBeginCallbackNanos = 0;
+        static bool sUseAlternativeHack;
+        int32_t mPreviousWorkload = 0;
+        double mNanosPerWorkloadUnit = 0.0;
+    };
+
+}
 #endif //SYNTHMARK_ADPF_WRAPPER_H

--- a/src/common/Trace.cpp
+++ b/src/common/Trace.cpp
@@ -91,7 +91,8 @@ void Trace::initialize() {
                 reinterpret_cast<fp_ATrace_isEnabled >(
                         dlsym(lib, "ATrace_isEnabled"));
 
-        if (ATrace_beginSection != nullptr && ATrace_endSection != nullptr && ATrace_isEnabled != nullptr && ATrace_isEnabled()){
+        if (ATrace_beginSection != nullptr && ATrace_endSection != nullptr
+                && ATrace_isEnabled != nullptr && ATrace_isEnabled()) {
             mIsTracingEnabled = true;
             if (ATrace_setCounter != nullptr) {
                 mIsSetCounterSupported = true;

--- a/src/common/Trace.h
+++ b/src/common/Trace.h
@@ -19,18 +19,24 @@
 
 #include <cstdint>
 
-class Trace {
+namespace oboe {
 
-public:
-    static void beginSection(const char *format, ...);
-    static void endSection();
-    static void setCounter(const char *counterName, int64_t counterValue);
-    static void initialize();
+    class Trace {
 
-private:
-    static bool mIsTracingSupported;
-    static bool mIsSetCounterSupported;
-    static bool mIsTracingEnabled;
-};
+    public:
+        static void beginSection(const char *format, ...);
 
+        static void endSection();
+
+        static void setCounter(const char *counterName, int64_t counterValue);
+
+        static void initialize();
+
+    private:
+        static bool mIsTracingEnabled;
+        static bool mIsSetCounterSupported;
+        static bool mHasErrorBeenShown;
+    };
+
+}
 #endif //OBOE_TRACE_H

--- a/src/common/Trace.h
+++ b/src/common/Trace.h
@@ -17,15 +17,20 @@
 #ifndef OBOE_TRACE_H
 #define OBOE_TRACE_H
 
+#include <cstdint>
+
 class Trace {
 
 public:
     static void beginSection(const char *format, ...);
     static void endSection();
+    static void setCounter(const char *counterName, int64_t counterValue);
     static void initialize();
 
 private:
     static bool mIsTracingSupported;
+    static bool mIsSetCounterSupported;
+    static bool mIsTracingEnabled;
 };
 
 #endif //OBOE_TRACE_H

--- a/src/common/Trace.h
+++ b/src/common/Trace.h
@@ -21,22 +21,25 @@
 
 namespace oboe {
 
-    class Trace {
+/**
+ * Wrapper for tracing use with Perfetto
+ */
+class Trace {
 
-    public:
-        static void beginSection(const char *format, ...);
+public:
+    static void beginSection(const char *format, ...);
 
-        static void endSection();
+    static void endSection();
 
-        static void setCounter(const char *counterName, int64_t counterValue);
+    static void setCounter(const char *counterName, int64_t counterValue);
 
-        static void initialize();
+    static void initialize();
 
-    private:
-        static bool mIsTracingEnabled;
-        static bool mIsSetCounterSupported;
-        static bool mHasErrorBeenShown;
-    };
+private:
+    static bool mIsTracingEnabled;
+    static bool mIsSetCounterSupported;
+    static bool mHasErrorBeenShown;
+};
 
 }
 #endif //OBOE_TRACE_H


### PR DESCRIPTION
With ATrace, we can profile the time between callbacks for the workload. Perfetto provides a nice UI to see this callback time in comparison to other metrics like CPU usage and the ADPF session batch size.

Instructions:
1. Start the perfetto trace on your computer with `adb shell -t perfetto audio sched freq power hal idle binder_driver ss --time 20s --out /data/misc/perfetto-traces/test123.pf --app com.mobileer.oboetester`
2. Pull the perfetto trace from the android phone to your computer `adb pull /data/misc/perfetto-traces/test123.pf localfile.pf`
3. Open the new file in ui.perfetto.dev

Note that ATrace_setCounter() is only supported on Android level 29 and above and ATrace_isEnabled() is enabled only when the perfetto command is run from adb shell.