### PR TITLE
OboeTester: fix skip count display near top of screen for Data Paths test

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedTestRunner.java
@@ -38,6 +38,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
     private int          mTestCount;
     private int          mPassCount;
     private int          mFailCount;
+    private int          mSkipCount;
     private TestAudioActivity  mActivity;
 
     private Thread            mAutoThread;
@@ -143,6 +144,9 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
     }
     public void incrementPassCount() {
         mPassCount++;
+    }
+    public void incrementSkipCount() {
+        mSkipCount++;
     }
     public void incrementTestCount() {
         mTestCount++;
@@ -288,6 +292,7 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
         mTestCount = 0;
         mPassCount = 0;
         mFailCount = 0;
+        mSkipCount = 0;
         try {
             mActivity.runTest();
             log("Tests finished.");
@@ -328,11 +333,9 @@ public  class AutomatedTestRunner extends LinearLayout implements Runnable {
 
     @NonNull
     public String getPassFailReport() {
-        int skipped = mTestCount - (mPassCount + mFailCount);
-        String passFailReport = mPassCount + " passed. "
+        return  mPassCount + " passed. "
                 + mFailCount + " failed. "
-                + skipped + " skipped. ";
-        return passFailReport;
+                + mSkipCount + " skipped. ";
     }
 
 }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -264,6 +264,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
     protected TestResult testCurrentConfigurations() throws InterruptedException {
         mAutomatedTestRunner.incrementTestCount();
         if ((getSingleTestIndex() >= 0) && (getTestCount() != getSingleTestIndex())) {
+            mAutomatedTestRunner.incrementSkipCount();
             return null;
         }
 
@@ -364,6 +365,7 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
             mAutomatedTestRunner.incrementFailCount();
         } else if (skipped) {
             log(TEXT_SKIP + " - " + skipReason);
+            mAutomatedTestRunner.incrementSkipCount();
         } else {
             log("Result:");
             reason += didTestFail();


### PR DESCRIPTION
Was +1 because it was being calculated based on variables instead of direct counting.

See b/375050058