### PR TITLE
OboeTester: Let the final update of NativeSniffer actually update

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/NativeSniffer.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/NativeSniffer.java
@@ -24,12 +24,17 @@ abstract class NativeSniffer implements Runnable {
     public static final int SNIFFER_UPDATE_DELAY_MSEC = 200;
     protected Handler mHandler = new Handler(Looper.getMainLooper()); // UI thread
     protected volatile boolean mEnabled = true;
+    protected volatile boolean mEnableFinalUpdate = false;
 
     @Override
     public void run() {
-        if (mEnabled && !isComplete()) {
+        if ((mEnabled || mEnableFinalUpdate) && !isComplete()) {
             updateStatusText();
-            mHandler.postDelayed(this, SNIFFER_UPDATE_PERIOD_MSEC);
+            if (mEnableFinalUpdate) {
+                mEnableFinalUpdate = false;
+            } else {
+                mHandler.postDelayed(this, SNIFFER_UPDATE_PERIOD_MSEC);
+            }
         }
     }
 
@@ -42,6 +47,7 @@ abstract class NativeSniffer implements Runnable {
     public void stopSniffer() {
         mEnabled = false;
         if (mHandler != null) {
+            mEnableFinalUpdate = true;
             mHandler.removeCallbacks(this);
             // Final update of the text.
             mHandler.post(this);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/NativeSniffer.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/NativeSniffer.java
@@ -24,17 +24,16 @@ abstract class NativeSniffer implements Runnable {
     public static final int SNIFFER_UPDATE_DELAY_MSEC = 200;
     protected Handler mHandler = new Handler(Looper.getMainLooper()); // UI thread
     protected volatile boolean mEnabled = true;
-    protected volatile boolean mEnableFinalUpdate = false;
 
     @Override
     public void run() {
-        if ((mEnabled || mEnableFinalUpdate) && !isComplete()) {
+        if (!isComplete()) {
             updateStatusText();
-            if (mEnableFinalUpdate) {
-                mEnableFinalUpdate = false;
-            } else {
-                mHandler.postDelayed(this, SNIFFER_UPDATE_PERIOD_MSEC);
-            }
+        }
+
+        // When this is no longer enabled, stop calling run.
+        if (mEnabled) {
+            mHandler.postDelayed(this, SNIFFER_UPDATE_PERIOD_MSEC);
         }
     }
 
@@ -47,7 +46,6 @@ abstract class NativeSniffer implements Runnable {
     public void stopSniffer() {
         mEnabled = false;
         if (mHandler != null) {
-            mEnableFinalUpdate = true;
             mHandler.removeCallbacks(this);
             // Final update of the text.
             mHandler.post(this);


### PR DESCRIPTION
When stopSniffer() is called, there are no more updates for the sniffer because mEnabled is set to false. This is clearly a bug.

The proposed change here is to add a new variable called mEnableFinalUpdate which will handle the final update.