### PR TITLE
OboeTester: Add missing includes.

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/MultiChannelRecording.h
+++ b/apps/OboeTester/app/src/main/cpp/MultiChannelRecording.h
@@ -17,6 +17,7 @@
 #ifndef NATIVEOBOE_MULTICHANNEL_RECORDING_H
 #define NATIVEOBOE_MULTICHANNEL_RECORDING_H
 
+#include <algorithm>
 #include <memory.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/apps/OboeTester/app/src/main/cpp/TestErrorCallback.h
+++ b/apps/OboeTester/app/src/main/cpp/TestErrorCallback.h
@@ -17,6 +17,7 @@
 #ifndef OBOETESTER_TEST_ERROR_CALLBACK_H
 #define OBOETESTER_TEST_ERROR_CALLBACK_H
 
+#include "common/OboeDebug.h"
 #include "oboe/Oboe.h"
 #include <thread>
 

--- a/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include <vector>
 
+#include "common/OboeDebug.h"
 #include "PeakDetector.h"
 #include "PseudoRandom.h"
 #include "RandomPulseGenerator.h"

--- a/apps/OboeTester/app/src/main/cpp/analyzer/PseudoRandom.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/PseudoRandom.h
@@ -18,7 +18,7 @@
 #ifndef ANALYZER_PSEUDORANDOM_H
 #define ANALYZER_PSEUDORANDOM_H
 
-#include <cctype>
+#include <cstdint>
 
 class PseudoRandom {
 public:

--- a/apps/OboeTester/app/src/main/cpp/analyzer/RoundedManchesterEncoder.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/RoundedManchesterEncoder.h
@@ -18,7 +18,7 @@
 #define ANALYZER_ROUNDED_MANCHESTER_ENCODER_H
 
 #include <math.h>
-#include <memory.h>
+#include <memory>
 #include <stdlib.h>
 #include "ManchesterEncoder.h"
 

--- a/apps/OboeTester/app/src/main/cpp/synth/SawtoothOscillatorDPW.h
+++ b/apps/OboeTester/app/src/main/cpp/synth/SawtoothOscillatorDPW.h
@@ -25,6 +25,7 @@
 #include <math.h>
 #include "SynthTools.h"
 #include "DifferentiatedParabola.h"
+#include "SawtoothOscillator.h"
 
 namespace marksynth {
 /**

--- a/apps/OboeTester/app/src/main/cpp/synth/SineOscillator.h
+++ b/apps/OboeTester/app/src/main/cpp/synth/SineOscillator.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <math.h>
+#include "SawtoothOscillator.h"
 #include "SynthTools.h"
 
 namespace marksynth {

--- a/apps/OboeTester/app/src/main/cpp/synth/SquareOscillatorDPW.h
+++ b/apps/OboeTester/app/src/main/cpp/synth/SquareOscillatorDPW.h
@@ -25,6 +25,7 @@
 #include <math.h>
 #include "SynthTools.h"
 #include "DifferentiatedParabola.h"
+#include "SawtoothOscillator.h"
 
 namespace marksynth {
 /**


### PR DESCRIPTION
Add some missing includes in the OboeTester code.

This PR includes `common/OboeDebug.h` which there was precedent for, but perhaps should not be part of the OboeTester app, unless `OboeDebug.h` is moved to the `includes` directory for Oboe.