### PR TITLE
OboeTester: divide oscillator amplitude by channel count

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -430,12 +430,12 @@ void ActivityTestOutput::configureAfterOpen() {
         // Go up by a minor third or a perfect fourth just intoned interval.
         const float interval = (mChannelCount > 8) ? (6.0f / 5.0f) : (4.0f / 3.0f);
         for (int i = 0; i < mChannelCount; i++) {
-            sineOscillators[i].setSampleRate(outputStream->getSampleRate() / mChannelCount);
+            sineOscillators[i].setSampleRate(outputStream->getSampleRate());
             sineOscillators[i].frequency.setValue(frequency);
-            sineOscillators[i].amplitude.setValue(AMPLITUDE_SINE);
-            sawtoothOscillators[i].setSampleRate(outputStream->getSampleRate() / mChannelCount);
+            sineOscillators[i].amplitude.setValue(AMPLITUDE_SINE / mChannelCount);
+            sawtoothOscillators[i].setSampleRate(outputStream->getSampleRate());
             sawtoothOscillators[i].frequency.setValue(frequency);
-            sawtoothOscillators[i].amplitude.setValue(AMPLITUDE_SAWTOOTH);
+            sawtoothOscillators[i].amplitude.setValue(AMPLITUDE_SAWTOOTH / mChannelCount);
 
             frequency *= interval; // each wave is at a higher frequency
             setChannelEnabled(i, true);

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -430,10 +430,10 @@ void ActivityTestOutput::configureAfterOpen() {
         // Go up by a minor third or a perfect fourth just intoned interval.
         const float interval = (mChannelCount > 8) ? (6.0f / 5.0f) : (4.0f / 3.0f);
         for (int i = 0; i < mChannelCount; i++) {
-            sineOscillators[i].setSampleRate(outputStream->getSampleRate());
+            sineOscillators[i].setSampleRate(outputStream->getSampleRate() / mChannelCount);
             sineOscillators[i].frequency.setValue(frequency);
             sineOscillators[i].amplitude.setValue(AMPLITUDE_SINE);
-            sawtoothOscillators[i].setSampleRate(outputStream->getSampleRate());
+            sawtoothOscillators[i].setSampleRate(outputStream->getSampleRate() / mChannelCount);
             sawtoothOscillators[i].frequency.setValue(frequency);
             sawtoothOscillators[i].amplitude.setValue(AMPLITUDE_SAWTOOTH);
 


### PR DESCRIPTION
This way combining channels will not result in overflows when downmixing