### PR TITLE
Update workflows with write permissions

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write # Add write permission for contents
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write # Add write permission for contents
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our workflows are currently broken due to missing write permissions. See https://github.com/google/oboe/actions/runs/13594935708/job/38009571205 as one example