### PR TITLE
Redefine AAudio_DeviceType_t

### DIFF
--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -185,7 +185,7 @@ public:
             return MMapPolicy::Unspecified;
         }
         return static_cast<MMapPolicy>(mLibLoader->aaudio_getPlatformMMapPolicy(
-                static_cast<AAudio_DeviceType>(deviceType),
+                static_cast<AAudio_DeviceType_t>(deviceType),
                 static_cast<aaudio_direction_t>(direction)));
     }
 
@@ -195,7 +195,7 @@ public:
             return MMapPolicy::Unspecified;
         }
         return static_cast<MMapPolicy>(mLibLoader->aaudio_getPlatformMMapExclusivePolicy(
-                static_cast<AAudio_DeviceType>(deviceType),
+                static_cast<AAudio_DeviceType_t>(deviceType),
                 static_cast<aaudio_direction_t>(direction)));
     }
 

--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -529,9 +529,9 @@ AAudioLoader::signature_I AAudioLoader::load_I(const char *functionName) {
 
 // The aaudio device type and aaudio policy were added in NDK 28,
 // which is the first version to support Android W (API 36).
-#if __NDK_MAJOR__ >= 28
+#if __NDK_MAJOR__ >= 29
 
-    ASSERT_INT32(AAudio_DeviceType);
+    ASSERT_INT32(AAudio_DeviceType_t);
     static_assert((int32_t)DeviceType::BuiltinEarpiece == AAUDIO_DEVICE_BUILTIN_EARPIECE, ERRMSG);
     static_assert((int32_t)DeviceType::BuiltinSpeaker == AAUDIO_DEVICE_BUILTIN_SPEAKER, ERRMSG);
     static_assert((int32_t)DeviceType::WiredHeadset == AAUDIO_DEVICE_WIRED_HEADSET, ERRMSG);

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -96,11 +96,11 @@ typedef int32_t aaudio_spatialization_behavior_t;
 #define __ANDROID_API_B__ 36
 #endif
 
-#if __NDK_MAJOR__ < 28
-// These were defined in W
-typedef int32_t AAudio_DeviceType;
+#if __NDK_MAJOR__ < 29
+// These was defined in W
 typedef int32_t aaudio_policy_t;
 #endif
+typedef int32_t AAudio_DeviceType_t; // This is different because AAudio_DeviceType is an enum type
 
 namespace oboe {
 


### PR DESCRIPTION
[AAudio_DeviceType](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/av/media/libaaudio/include/aaudio/AAudio.h;l=1?q=frameworks%2Fav%2Fmedia%2Flibaaudio%2Finclude%2Faaudio%2FAAudio.h&ss=android%2Fplatform%2Fsuperproject%2Fmain) is now defined in AOSP.

The issue is that this is a `typedef enum AAudio_DeviceType : int32_t`. We can't recreate it with `typedef int32_t AAudio_DeviceType;` like we do now as the types are different as the former is an enum type with a strict set of values. I propose that we create AAudio_DeviceType_t as an int32_t so at least we can cast to it.

Also, it seems like Android B is NDK 29 now that we have quarterly releases.