### PR TITLE
AAudioLoader: Add explicit checks that NDK is used

### DIFF
--- a/src/aaudio/AAudioLoader.cpp
+++ b/src/aaudio/AAudioLoader.cpp
@@ -550,7 +550,7 @@ AAudioLoader::signature_I_PSII AAudioLoader::load_I_PSII(const char *functionNam
 
 // The aaudio device type and aaudio policy were added in NDK 28,
 // which is the first version to support Android W (API 36).
-#if __NDK_MAJOR__ >= 28
+#if __NDK_MAJOR__ >= 29
 
     ASSERT_INT32(AAudio_DeviceType);
     static_assert((int32_t)DeviceType::BuiltinEarpiece == AAUDIO_DEVICE_BUILTIN_EARPIECE, ERRMSG);

--- a/src/aaudio/AAudioLoader.h
+++ b/src/aaudio/AAudioLoader.h
@@ -62,8 +62,11 @@ typedef int32_t aaudio_session_id_t;
 #include <aaudio/AAudio.h>
 #endif
 
-#ifndef __NDK_MAJOR__
+#ifdef __NDK_MAJOR__
+#define OBOE_USING_NDK 1
+#else
 #define __NDK_MAJOR__ 0
+#define OBOE_USING_NDK 0
 #endif
 
 #if __NDK_MAJOR__ < 24
@@ -72,8 +75,8 @@ typedef uint32_t aaudio_channel_mask_t;
 typedef int32_t aaudio_spatialization_behavior_t;
 #endif
 
-#if __NDK_MAJOR__ < 36
-// Defined in W
+#if OBOE_USING_NDK && __NDK_MAJOR__ < 29
+// Defined in Android B
 typedef void (*AAudioStream_presentationEndCallback)(
         AAudioStream* stream,
         void* userData);
@@ -103,8 +106,8 @@ typedef void (*AAudioStream_presentationEndCallback)(
 #define __ANDROID_API_B__ 36
 #endif
 
-#if __NDK_MAJOR__ < 28
-// These were defined in W
+#if OBOE_USING_NDK && __NDK_MAJOR__ < 29
+// These were defined in Android B
 typedef int32_t AAudio_DeviceType;
 typedef int32_t aaudio_policy_t;
 #endif


### PR DESCRIPTION
This makes it so when Oboe is used without the NDK, symbols are not defined explicitly. This does not affect 99% of use cases.