### PR TITLE
OboeTester: remove extra mSinkMemoryDirect nullptr check

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -460,9 +460,7 @@ void ActivityTestOutput::configureAfterOpen() {
     mSinkI16->pullReset();
     mSinkI24->pullReset();
     mSinkI32->pullReset();
-    if (mSinkMemoryDirect != nullptr) {
-        mSinkMemoryDirect->pullReset();
-    }
+    mSinkMemoryDirect->pullReset();
 
     configureStreamGateway();
 }


### PR DESCRIPTION
Not needed as mSinkMemoryDirect is created in this function