### PR TITLE
OboeTester - prevent null crash with automation

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -520,7 +520,15 @@ public:
     virtual FullDuplexAnalyzer *getFullDuplexAnalyzer() = 0;
 
     int32_t getResetCount() {
-        return getFullDuplexAnalyzer()->getLoopbackProcessor()->getResetCount();
+        auto analyzer = getFullDuplexAnalyzer();
+        if (analyzer == nullptr) {
+            return -1;
+        }
+        auto processor = analyzer->getLoopbackProcessor();
+        if (processor == nullptr) {
+            return -1;
+        }
+        return processor->getResetCount();
     }
 
 protected:

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -803,7 +803,11 @@ Java_com_mobileer_oboetester_AnalyzerActivity_isAnalyzerDone(JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_com_mobileer_oboetester_AnalyzerActivity_getResetCount(JNIEnv *env,
                                                                           jobject instance) {
-    return ((ActivityFullDuplex *)engine.getCurrentActivity())->getResetCount();
+    auto activity = (ActivityFullDuplex *)engine.getCurrentActivity();
+    if (activity == nullptr) {
+        return -1;
+    }
+    return activity->getResetCount();
 }
 
 // ==========================================================================

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AnalyzerActivity.java
@@ -84,6 +84,7 @@ public class AnalyzerActivity extends TestInputActivity {
         AudioStreamBase inStream = mAudioInputTester.getCurrentAudioStream();
         report.append(String.format(Locale.getDefault(), "in.burst.frames = %d\n", inStream.getFramesPerBurst()));
         report.append(String.format(Locale.getDefault(), "in.xruns = %d\n", inStream.getXRunCount()));
+        report.append(String.format(Locale.getDefault(), "in.frames.read = %d\n", inStream.getFramesRead()));
 
         // OUTPUT
         report.append(mAudioOutTester.actualConfiguration.dump());
@@ -94,6 +95,7 @@ public class AnalyzerActivity extends TestInputActivity {
         int bufferCapacity = outStream.getBufferCapacityInFrames();
         report.append(String.format(Locale.getDefault(), "out.buffer.capacity.frames = %d\n", bufferCapacity));
         report.append(String.format(Locale.getDefault(), "out.xruns = %d\n", outStream.getXRunCount()));
+        report.append(String.format(Locale.getDefault(), "out.frames.written = %d\n", outStream.getFramesWritten()));
 
         return report.toString();
     }


### PR DESCRIPTION
I tried to prevent getResetCount() from being called when the stream is not ready. But it was hard to track down the offending call.
So I just prevented the NULL crash.

I then added a dump of the frames read and written so we can see if recording is blocked due to permissions.

Surprisingly the test semed to run OK after this patch.

Fixes #2201