### PR TITLE
OboeTester: save all WAV files in Data Paths test

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -165,7 +165,7 @@ public:
 
             ALOGD("%s(), phaseOffset = %f\n", __func__, mPhaseOffset);
             if (mPhaseOffset != kPhaseInvalid) {
-                // One pole averaging filter.
+                // One pole averaging filter for magnitude.
                 setMagnitude((mMagnitude * (1.0 - coefficient)) + (magnitude * coefficient));
             }
             resetAccumulator();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AutomatedGlitchActivity.java
@@ -110,6 +110,8 @@ public class AutomatedGlitchActivity  extends BaseAutoGlitchActivity {
 
             compareFailedTestsWithNearestPassingTest();
 
+            reportSavedWaveFiles();
+
         } catch (InterruptedException e) {
             compareFailedTestsWithNearestPassingTest();
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/BaseAutoGlitchActivity.java
@@ -442,13 +442,21 @@ public class BaseAutoGlitchActivity extends GlitchActivity {
         return getExternalFilesDir(Environment.DIRECTORY_MUSIC);
     }
 
+    void reportSavedWaveFiles() {
+        logAnalysis("\n --------\n"
+                + "Audio for each test saved in:\n  "
+                + getRecordingDir().getAbsolutePath()
+                + "/glitch_{###}.wav\n");
+    }
+
     private void saveRecordingAsWave() {
-        File waveFile = new File(getRecordingDir(), String.format("glitch_%03d.wav", getTestCount()));
+        File waveFile = new File(getRecordingDir(),
+                String.format("glitch_%03d.wav", getTestCount()));
         int saveResult = saveWaveFile(waveFile.getAbsolutePath());
-        if (saveResult > 0) {
-            appendFailedSummary("Saved in " + waveFile.getAbsolutePath() + "\n");
-        } else {
-            appendFailedSummary("saveWaveFile() returned " + saveResult + "\n");
+        if (saveResult <= 0) {
+            appendSummary("ERROR: saving "
+                    + waveFile.getAbsolutePath()
+                    + " returned " + saveResult + "\n");
         }
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -873,6 +873,8 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
 
             compareFailedTestsWithNearestPassingTest();
 
+            reportSavedWaveFiles();
+
         } catch (InterruptedException e) {
             compareFailedTestsWithNearestPassingTest();
         } catch (Exception e) {


### PR DESCRIPTION
Delete old files when the test starts.

This will help us compare passing vs failing signals.
