### PR TITLE
OboeTester: Add CPU info to device report

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -413,7 +413,7 @@ public class DeviceReportActivity extends AppCompatActivity {
             }
 
             if (!foundAnyCore) {
-                return "############################\nCould not retrieve CPU core information. This usually means the necessary permissions are not available, or the /sys/devices/system/cpu paths do not exist on this device.";
+                return "############################\nCould not retrieve CPU core information.";
             }
 
             StringBuilder resultBuilder = new StringBuilder();


### PR DESCRIPTION
Inspired by info from #2208. This will help us understand the different cores on various devices.