### PR TITLE
OboeTester: Add restart_if_closed param to intents

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/IntentBasedTestSupport.java
@@ -62,6 +62,7 @@ public class IntentBasedTestSupport {
     public static final String KEY_BACKGROUND = "background";
     public static final String KEY_FOREGROUND_SERVICE = "foreground_service";
     public static final String KEY_VOLUME = "volume";
+    public static final String KEY_RESTART_STREAM_IF_CLOSED = "restart_if_closed";
 
     public static final String KEY_VOLUME_TYPE = "volume_type";
     public static final float VALUE_VOLUME_INVALID = -1.0f;

--- a/apps/OboeTester/app/src/main/res/layout/stream_config.xml
+++ b/apps/OboeTester/app/src/main/res/layout/stream_config.xml
@@ -502,7 +502,7 @@
             android:id="@+id/statusView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lines="5"
+            android:lines="6"
             android:text="@string/init_status" />
     </LinearLayout>
 

--- a/apps/OboeTester/docs/AutomatedTesting.md
+++ b/apps/OboeTester/docs/AutomatedTesting.md
@@ -102,6 +102,7 @@ There are several optional parameters in common for glitch, latency, input, and 
 There are some optional parameters in common for glitch, input, and output tests:
 
     --ei duration           {seconds}    // glitch test duration, default is 10 seconds
+    --ez restart_if_closed  {"true", 1, "false", 0} // if true, restart stream if its closed or disconnected
 
 There are several optional parameters for just the "glitch" test:
 


### PR DESCRIPTION
Internal bug b/416137819

This new option will help automation test scenarios where audioserver crashed during an output stream playback