### PR TITLE
OboeTester: make Data Paths test match CTSV

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/BaseSineAnalyzer.h
@@ -198,8 +198,9 @@ public:
     }
 
 protected:
-    // Try to get a prime period so the waveform plot changes every time.
-    static constexpr int32_t kTargetGlitchFrequency = 48000 / 113;
+    // Use a frequency that will not align with the common burst sizes.
+    // If it aligns then buffer reordering bugs could be masked.
+    static constexpr int32_t kTargetGlitchFrequency = 857; // Match CTS Verifier
 
     int32_t mSinePeriod = 1; // this will be set before use
     double  mInverseSinePeriod = 1.0;
@@ -209,7 +210,7 @@ protected:
     // in a callback and the output frame count may advance ahead of the input, or visa versa.
     double  mInputPhase = 0.0;
     double  mOutputPhase = 0.0;
-    double  mOutputAmplitude = 0.75;
+    double  mOutputAmplitude = 0.90;
     // This is the phase offset between the mInputPhase sine wave and the recorded
     // signal at the tuned frequency.
     // If this jumps around then we are probably just hearing noise.

--- a/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/DataPathAnalyzer.h
@@ -37,8 +37,8 @@ class DataPathAnalyzer : public BaseSineAnalyzer {
 public:
 
     DataPathAnalyzer() : BaseSineAnalyzer() {
-        // Add a little bit of noise to reduce blockage by speaker protection and DRC.
-        setNoiseAmplitude(0.02);
+        // Remove the noise because some phones have a high pass filter that makes it too loud!
+        setNoiseAmplitude(0.0);
     }
 
     double calculatePhaseError(double p1, double p2) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestDataPathsActivity.java
@@ -86,14 +86,9 @@ public class TestDataPathsActivity  extends BaseAutoGlitchActivity {
     public static final String KEY_USE_OUTPUT_DEVICES = "use_output_devices";
     public static final boolean VALUE_DEFAULT_USE_OUTPUT_DEVICES = true;
 
-
     public static final int DURATION_SECONDS = 4;
     private final static double MIN_REQUIRED_MAGNITUDE = 0.001;
-    private final static int MAX_SINE_FREQUENCY = 1000;
-    private final static int TYPICAL_SAMPLE_RATE = 48000;
-    private final static double FRAMES_PER_CYCLE = TYPICAL_SAMPLE_RATE / MAX_SINE_FREQUENCY;
-    private final static double PHASE_PER_BIN = 2.0 * Math.PI / FRAMES_PER_CYCLE;
-    private final static double MAX_ALLOWED_JITTER = 0.5 * PHASE_PER_BIN;
+    private final static double MAX_ALLOWED_JITTER = 0.1; // Matches CTS Verifier
     // This must match the value of kPhaseInvalid in BaseSineAnalyzer.h
     private final static double PHASE_INVALID = -999.0;
     private final static String MAGNITUDE_FORMAT = "%7.5f";


### PR DESCRIPTION
Remove the noise signal.
Use frequency 857 Hz.
Increase sine amplitude.
Raise threshold for phaseJitter.

Fixes #2216