### PR TITLE
Input stream not stopped in FullDuplexStream::stop

### DIFF
--- a/include/oboe/FullDuplexStream.h
+++ b/include/oboe/FullDuplexStream.h
@@ -156,7 +156,7 @@ public:
             outputResult = getOutputStream()->requestStop();
         }
         if (getInputStream()) {
-            inputResult = getOutputStream()->requestStop();
+            inputResult = getInputStream()->requestStop();
         }
         if (outputResult != Result::OK) {
             return outputResult;


### PR DESCRIPTION
Fix duplicate calls to `getOutputStream()->requestStop()`, resulting in never calling `getInputStream()->requestStop()`

Issue introduced in [this commit](https://github.com/google/oboe/commit/fae46d4c39a1918c5402cd40b84ef2cff671ff75#diff-93cf3a2be2c05a63390de19b8dc5b4104f4a3ad75d654982588d69d9b32a795a)