### PR TITLE
Workload Tests: Close the audio stream when the activity is closed

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
@@ -65,6 +65,13 @@ public:
     AudioWorkloadTest() = default;
 
     /**
+     * @brief Destructor. Close the stream when this class is destroyed.
+     */
+    ~AudioWorkloadTest() {
+        close();
+    }
+
+    /**
      * @brief Opens a float stereo audio stream.
      * Configures the stream for low latency output.
      * @return 0 on success, or a negative Oboe error code on failure.
@@ -344,7 +351,6 @@ public:
 
         if (currentTimeMs - mStartTimeMs > mTargetDurationMs) {
             mRunning = false;
-            stop();
             return oboe::DataCallbackResult::Stop;
         }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestActivity.java
@@ -188,6 +188,12 @@ public class AudioWorkloadTestActivity extends BaseOboeTesterActivity {
         mCloseButton.setEnabled(false);
     }
 
+    @Override
+    protected void onDestroy() {
+        close();
+        super.onDestroy();
+    }
+
     public void openAudio(View view) {
         int result = open();
         if (result != OPERATION_SUCCESS) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestActivity.java
@@ -189,9 +189,9 @@ public class AudioWorkloadTestActivity extends BaseOboeTesterActivity {
     }
 
     @Override
-    protected void onDestroy() {
+    protected void onStop() {
         close();
-        super.onDestroy();
+        super.onStop();
     }
 
     public void openAudio(View view) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestRunnerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestRunnerActivity.java
@@ -102,6 +102,12 @@ public class AudioWorkloadTestRunnerActivity extends BaseOboeTesterActivity {
         enableParamsUI(true);
     }
 
+    @Override
+    protected void onDestroy() {
+        stop();
+        super.onDestroy();
+    }
+
     public void startTest(View view) {
         int targetDurationMs = mTargetDurationMsSlider.getValue();
         int numBursts = mNumBurstsSlider.getValue();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestRunnerActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/AudioWorkloadTestRunnerActivity.java
@@ -103,9 +103,9 @@ public class AudioWorkloadTestRunnerActivity extends BaseOboeTesterActivity {
     }
 
     @Override
-    protected void onDestroy() {
+    protected void onStop() {
         stop();
-        super.onDestroy();
+        super.onStop();
     }
 
     public void startTest(View view) {


### PR DESCRIPTION
Workload tests leave the stream open even when the activity is closed. This PR fixes that