### PR TITLE
Update OboeTester and fxlab to Android 36

### DIFF
--- a/apps/OboeTester/app/build.gradle
+++ b/apps/OboeTester/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 36
     defaultConfig {
         applicationId = "com.mobileer.oboetester"
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode 103
         versionName "2.7.14"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.cpp
@@ -331,11 +331,11 @@ int32_t  ActivityContext::saveWaveFile(const char *filename) {
     writer.setSamplesPerFrame(mRecording->getChannelCount());
     writer.setBitsPerSample(24);
     writer.setFrameCount(mRecording->getSizeInFrames());
-    float buffer[mRecording->getChannelCount()];
+    std::vector<float> buffer(mRecording->getChannelCount());
     // Read samples from start to finish.
     mRecording->rewind();
     for (int32_t frameIndex = 0; frameIndex < mRecording->getSizeInFrames(); frameIndex++) {
-        mRecording->read(buffer, 1 /* numFrames */);
+        mRecording->read(buffer.data(), 1 /* numFrames */);
         for (int32_t i = 0; i < mRecording->getChannelCount(); i++) {
             writer.write(buffer[i]);
         }

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DeviceReportActivity.java
@@ -34,6 +34,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -96,22 +97,15 @@ public class DeviceReportActivity extends AppCompatActivity {
         mMidiManager = (MidiManager) getSystemService(Context.MIDI_SERVICE);
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        MenuItem settings = menu.findItem(R.id.action_share);
-        settings.setOnMenuItemClickListener(item -> {
-            if(mAutoTextView !=null) {
-                Intent sendIntent = new Intent();
-                sendIntent.setAction(Intent.ACTION_SEND);
-                sendIntent.putExtra(Intent.EXTRA_TEXT, mAutoTextView.getText().toString());
-                sendIntent.setType("text/plain");
-                Intent shareIntent = Intent.createChooser(sendIntent, null);
-                startActivity(shareIntent);
-            }
-            return false;
-        });
-        return true;
+    public void onShareButtonClick(View view) {
+        if(mAutoTextView !=null) {
+            Intent sendIntent = new Intent();
+            sendIntent.setAction(Intent.ACTION_SEND);
+            sendIntent.putExtra(Intent.EXTRA_TEXT, mAutoTextView.getText().toString());
+            sendIntent.setType("text/plain");
+            Intent shareIntent = Intent.createChooser(sendIntent, null);
+            startActivity(shareIntent);
+        }
     }
 
     @Override

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -34,6 +34,8 @@ import android.widget.CheckBox;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.core.view.WindowCompat;
+
 /**
  * Select various Audio tests.
  */
@@ -68,6 +70,7 @@ public class MainActivity extends BaseOboeTesterActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
 
         logScreenSize();
 

--- a/apps/OboeTester/app/src/main/res/layout/activity_audio_workload_test.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_audio_workload_test.xml
@@ -14,120 +14,93 @@
      limitations under the License.
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:fitsSystemWindows="true"
     tools:context="com.mobileer.oboetester.AudioWorkloadTestActivity">
 
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/target_duration_ms"
+    <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Target Duration(ms)"
-        app:minValue="1"
-        app:maxValue="10000"
-        app:defaultValue="5000" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/num_bursts"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Buffer Size In Bursts"
-        app:minValue="1"
-        app:maxValue="1000"
-        app:defaultValue="2" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/num_voices"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Num Voices"
-        app:minValue="1"
-        app:maxValue="500"
-        app:defaultValue="1" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/alternate_num_voices"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Alternate Num Voices"
-        app:minValue="1"
-        app:maxValue="500"
-        app:defaultValue="100" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/alternating_period_ms"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Alternating Period(ms)"
-        app:minValue="1"
-        app:maxValue="5000"
-        app:defaultValue="500" />
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?attr/actionBarSize"
         android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-        <CheckBox
-            android:id="@+id/enable_adpf"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF" />
+            android:text="Workload Test"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/enable_adpf_workload_increase"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF Workload Increase" />
     </LinearLayout>
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
+    <LinearLayout
+        android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
-        <CheckBox
-            android:id="@+id/hear_workload"
-            android:layout_width="wrap_content"
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/target_duration_ms"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Hear Workload" />
-    </LinearLayout>
+            app:sliderLabel="Target Duration(ms)"
+            app:minValue="1"
+            app:maxValue="10000"
+            app:defaultValue="5000" />
 
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/num_bursts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Buffer Size In Bursts"
+            app:minValue="1"
+            app:maxValue="1000"
+            app:defaultValue="2" />
 
-    <HorizontalScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/num_voices"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Num Voices"
+            app:minValue="1"
+            app:maxValue="500"
+            app:defaultValue="1" />
+
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/alternate_num_voices"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Alternate Num Voices"
+            app:minValue="1"
+            app:maxValue="500"
+            app:defaultValue="100" />
+
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/alternating_period_ms"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Alternating Period(ms)"
+            app:minValue="1"
+            app:maxValue="5000"
+            app:defaultValue="500" />
 
         <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
             xmlns:tools="http://schemas.android.com/tools"
 
-            android:id="@+id/affinity_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -135,108 +108,162 @@
             android:paddingTop="@dimen/small_vertical_margin"
             android:paddingRight="@dimen/small_horizontal_margin"
             android:paddingBottom="@dimen/small_vertical_margin"
-            tools:context="com.mobileer.oboetester.AudioWorkloadTestActivity">
+            tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
 
-            <TextView
-                android:layout_width="match_parent"
+            <CheckBox
+                android:id="@+id/enable_adpf"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/cpu_affinity"
-                android:textSize="18sp"
-                android:textStyle="bold" />
+                android:layout_marginRight="8sp"
+                android:text="ADPF" />
+
+            <CheckBox
+                android:id="@+id/enable_adpf_workload_increase"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="ADPF Workload Increase" />
         </LinearLayout>
 
-    </HorizontalScrollView>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_open"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="openAudio"
-            android:text="@string/openAudio" />
-
-        <Button
-            android:id="@+id/button_start"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="startTest"
-            android:text="@string/startAudio" />
-
-        <Button
-            android:id="@+id/button_stop"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="stopTest"
-            android:text="@string/stopAudio" />
-
-        <Button
-            android:id="@+id/button_close"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="closeAudio"
-            android:text="@string/closeAudio" />
-
-    </LinearLayout>
-
-    <TextView
-        android:id="@+id/stream_info_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="TAP OPEN then START"
-        android:fontFamily="monospace" />
-
-    <TextView
-        android:id="@+id/current_status_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="Results:"
-        android:fontFamily="monospace" />
-
-    <TextView
-        android:id="@+id/callback_statistics_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Callback Statistics"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-    <TextView
-        android:id="@+id/callback_statistics_header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="#, voices, time(ms), xRuns, cpu"
-        android:fontFamily="monospace"/>
-
-    <ScrollView
-        android:id="@+id/callback_statistics_scroll_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-        <TextView
-            android:id="@+id/callback_statistics_text_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fontFamily="monospace"
-            android:gravity="bottom"
-            android:scrollbars="vertical"
-            android:text="statistics here after stream stop"
-            />
-    </ScrollView>
-</LinearLayout>
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/small_horizontal_margin"
+            android:paddingTop="@dimen/small_vertical_margin"
+            android:paddingRight="@dimen/small_horizontal_margin"
+            android:paddingBottom="@dimen/small_vertical_margin"
+            tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+
+            <CheckBox
+                android:id="@+id/hear_workload"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Hear Workload" />
+        </LinearLayout>
+
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+
+                android:id="@+id/affinity_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingLeft="@dimen/small_horizontal_margin"
+                android:paddingTop="@dimen/small_vertical_margin"
+                android:paddingRight="@dimen/small_horizontal_margin"
+                android:paddingBottom="@dimen/small_vertical_margin"
+                tools:context="com.mobileer.oboetester.AudioWorkloadTestActivity">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/cpu_affinity"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+        </HorizontalScrollView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_open"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="openAudio"
+                android:text="@string/openAudio" />
+
+            <Button
+                android:id="@+id/button_start"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="startTest"
+                android:text="@string/startAudio" />
+
+            <Button
+                android:id="@+id/button_stop"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="stopTest"
+                android:text="@string/stopAudio" />
+
+            <Button
+                android:id="@+id/button_close"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="closeAudio"
+                android:text="@string/closeAudio" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/stream_info_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="TAP OPEN then START"
+            android:fontFamily="monospace" />
+
+        <TextView
+            android:id="@+id/current_status_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="Results:"
+            android:fontFamily="monospace" />
+
+        <TextView
+            android:id="@+id/callback_statistics_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Callback Statistics"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/callback_statistics_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="#, voices, time(ms), xRuns, cpu"
+            android:fontFamily="monospace"/>
+
+        <ScrollView
+            android:id="@+id/callback_statistics_scroll_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/callback_statistics_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fontFamily="monospace"
+                android:gravity="bottom"
+                android:scrollbars="vertical"
+                android:text="statistics here after stream stop"
+                />
+        </ScrollView>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_audio_workload_test_runner.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_audio_workload_test_runner.xml
@@ -13,155 +13,180 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:fitsSystemWindows="true"
     tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
 
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/target_duration_ms"
+    <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Target Duration(ms)"
-        app:minValue="1"
-        app:maxValue="10000"
-        app:defaultValue="5000" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/num_bursts"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Buffer Size In Bursts"
-        app:minValue="1"
-        app:maxValue="1000"
-        app:defaultValue="2" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/num_voices"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Num Voices"
-        app:minValue="1"
-        app:maxValue="500"
-        app:defaultValue="1" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/alternate_num_voices"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Alternate Num Voices"
-        app:minValue="0"
-        app:maxValue="500"
-        app:defaultValue="100" />
-
-    <com.mobileer.oboetester.ExponentialSliderView
-        android:id="@+id/alternating_period_ms"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:sliderLabel="Alternating Period(ms)"
-        app:minValue="0"
-        app:maxValue="5000"
-        app:defaultValue="500" />
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?attr/actionBarSize"
         android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-        <CheckBox
-            android:id="@+id/enable_adpf"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF" />
+            android:text="Workload Test Runner"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/enable_adpf_workload_increase"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF Workload Increase" />
-    </LinearLayout>
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
-
-        <CheckBox
-            android:id="@+id/hear_workload"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Hear Workload" />
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_start_test"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/target_duration_ms"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="startTest"
-            android:text="@string/startAudio" />
+            app:sliderLabel="Target Duration(ms)"
+            app:minValue="1"
+            app:maxValue="10000"
+            app:defaultValue="5000" />
 
-        <Button
-            android:id="@+id/button_stop_test"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/num_bursts"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="stopTest"
-            android:text="@string/stopAudio" />
+            app:sliderLabel="Buffer Size In Bursts"
+            app:minValue="1"
+            app:maxValue="1000"
+            app:defaultValue="2" />
 
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/num_voices"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Num Voices"
+            app:minValue="1"
+            app:maxValue="500"
+            app:defaultValue="1" />
+
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/alternate_num_voices"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Alternate Num Voices"
+            app:minValue="0"
+            app:maxValue="500"
+            app:defaultValue="100" />
+
+        <com.mobileer.oboetester.ExponentialSliderView
+            android:id="@+id/alternating_period_ms"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:sliderLabel="Alternating Period(ms)"
+            app:minValue="0"
+            app:maxValue="5000"
+            app:defaultValue="500" />
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/small_horizontal_margin"
+            android:paddingTop="@dimen/small_vertical_margin"
+            android:paddingRight="@dimen/small_horizontal_margin"
+            android:paddingBottom="@dimen/small_vertical_margin"
+            tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+
+            <CheckBox
+                android:id="@+id/enable_adpf"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="ADPF" />
+
+            <CheckBox
+                android:id="@+id/enable_adpf_workload_increase"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="ADPF Workload Increase" />
+        </LinearLayout>
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/small_horizontal_margin"
+            android:paddingTop="@dimen/small_vertical_margin"
+            android:paddingRight="@dimen/small_horizontal_margin"
+            android:paddingBottom="@dimen/small_vertical_margin"
+            tools:context="com.mobileer.oboetester.AudioWorkloadTestRunnerActivity">
+
+            <CheckBox
+                android:id="@+id/hear_workload"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Hear Workload" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_start_test"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="startTest"
+                android:text="@string/startAudio" />
+
+            <Button
+                android:id="@+id/button_stop_test"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="stopTest"
+                android:text="@string/stopAudio" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/status_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:fontFamily="monospace"
+            android:text="Status: Idle"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/result_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:fontFamily="monospace"
+            android:text="Result:"
+            android:textSize="18sp"
+            android:textStyle="bold" />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/status_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:fontFamily="monospace"
-        android:text="Status: Idle"
-        android:textSize="16sp" />
-
-    <TextView
-        android:id="@+id/result_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:fontFamily="monospace"
-        android:text="Result:"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_auto_glitches.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_auto_glitches.xml
@@ -1,48 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.AutomatedGlitchActivity" >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin" >
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.AutomatedGlitchActivity">
 
     <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/duration"
-            />
-        <Spinner
-            android:id="@+id/spinner_glitch_duration"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/glitch_times"
-            />
-        <TextView
-            android:id="@+id/actualNativeApi"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/seconds_per_test"
-            />
+            android:text="Auto Glitches"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
     </LinearLayout>
 
-    <com.mobileer.oboetester.AutomatedTestRunner
-        android:id="@+id/auto_test_runner"
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" />
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/activity_vertical_margin"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin">
 
-</LinearLayout>
-</ScrollView>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/duration"
+                    />
+                <Spinner
+                    android:id="@+id/spinner_glitch_duration"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:entries="@array/glitch_times"
+                    />
+                <TextView
+                    android:id="@+id/actualNativeApi"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/seconds_per_test"
+                    />
+            </LinearLayout>
+
+            <com.mobileer.oboetester.AutomatedTestRunner
+                android:id="@+id/auto_test_runner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_cold_start_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_cold_start_latency.xml
@@ -4,13 +4,39 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".TestColdStartLatencyActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Cold Start Latency"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
         <RadioGroup
             android:layout_width="wrap_content"

--- a/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_data_paths.xml
@@ -1,103 +1,132 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.mobileer.oboetester.TestDataPathsActivity">
+    android:fitsSystemWindows="true"
+    tools:context=".TestDataPathsActivity">
 
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-        <CheckBox
-            android:id="@+id/checkbox_paths_all_channels"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="AllCh" />
+            android:text="Data Paths"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/checkbox_paths_input_presets"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="InPre" />
-
-        <CheckBox
-            android:id="@+id/checkbox_paths_all_sample_rates"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:text="AllSRs" />
-
-        <CheckBox
-            android:id="@+id/checkbox_paths_in_channel_masks"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:text="InChMasks" />
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/buttonGrid"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="OutChMasks:" />
-
-        <RadioGroup
-            android:id="@+id/group_ch_mask_options"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-            <RadioButton
-                android:id="@+id/radio_out_ch_masks_none"
+            <CheckBox
+                android:id="@+id/checkbox_paths_all_channels"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="none"
                 android:checked="true"
-                />
+                android:text="AllCh" />
 
-            <RadioButton
-                android:id="@+id/radio_out_ch_masks_some"
+            <CheckBox
+                android:id="@+id/checkbox_paths_input_presets"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="some"
-                />
+                android:checked="true"
+                android:text="InPre" />
 
-            <RadioButton
-                android:id="@+id/radio_out_ch_masks_all"
+            <CheckBox
+                android:id="@+id/checkbox_paths_all_sample_rates"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="all"
-                />
-        </RadioGroup>
+                android:checked="false"
+                android:text="AllSRs" />
+
+            <CheckBox
+                android:id="@+id/checkbox_paths_in_channel_masks"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false"
+                android:text="InChMasks" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="OutChMasks:" />
+
+            <RadioGroup
+                android:id="@+id/group_ch_mask_options"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <RadioButton
+                    android:id="@+id/radio_out_ch_masks_none"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="none"
+                    android:checked="true"
+                    />
+
+                <RadioButton
+                    android:id="@+id/radio_out_ch_masks_some"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="some"
+                    />
+
+                <RadioButton
+                    android:id="@+id/radio_out_ch_masks_all"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="all"
+                    />
+            </RadioGroup>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/text_instructions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="@string/test_datapath_instructions"
+            android:textColor="#F44336"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <com.mobileer.oboetester.AutomatedTestRunner
+            android:id="@+id/auto_test_runner"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/text_instructions"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="@string/test_datapath_instructions"
-        android:textColor="#F44336"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-    <com.mobileer.oboetester.AutomatedTestRunner
-        android:id="@+id/auto_test_runner"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" />
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_device_report.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_device_report.xml
@@ -1,28 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.mobileer.oboetester.DeviceReportActivity">
+    android:fitsSystemWindows="true"
+    tools:context=".DeviceReportActivity">
 
-    <ScrollView
-        android:id="@+id/text_log_device_scroller"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-    <TextView
-        android:id="@+id/text_log_device_report"
+    <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fontFamily="monospace"
-        android:gravity="bottom"
-        android:scrollbars="vertical"
-        android:text="@string/device_report"
-        />
-    </ScrollView>
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-</LinearLayout>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Device Report"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/shareButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_menu_share"
+            android:contentDescription="Share report"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:onClick="onShareButtonClick"
+            app:tint="@android:color/darker_gray" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/buttonGrid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
+
+        <ScrollView
+            android:id="@+id/text_log_device_scroller"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/text_log_device_report"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fontFamily="monospace"
+                android:gravity="bottom"
+                android:scrollbars="vertical"
+                android:text="@string/device_report" />
+        </ScrollView>
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_dynamic_workload.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_dynamic_workload.xml
@@ -1,123 +1,56 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+    android:fitsSystemWindows="true"
+    tools:context=".DynamicWorkloadActivity">
 
-    <include layout="@layout/merge_audio_simple" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:lines="1"
-        android:text="CPUs:"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
+    <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?attr/actionBarSize"
         android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-        <CheckBox
-            android:id="@+id/enable_perf_hint"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF" />
+            android:text="CPU Load"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/enable_workload_report"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Wkload" />
-
-        <CheckBox
-            android:id="@+id/use_alternative_adpf"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Alt ADPF" />
     </LinearLayout>
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
+    <LinearLayout
+        android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
-        <CheckBox
-            android:id="@+id/enable_adpf_workload_increase"
+        <include layout="@layout/merge_audio_simple" />
+
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="ADPF Workload Increase API" />
-    </LinearLayout>
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/small_horizontal_margin"
-        android:paddingTop="@dimen/small_vertical_margin"
-        android:paddingRight="@dimen/small_horizontal_margin"
-        android:paddingBottom="@dimen/small_vertical_margin"
-        tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
-
-        <CheckBox
-            android:id="@+id/hear_workload"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Hear Synth" />
-
-        <CheckBox
-            android:id="@+id/draw_always"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:checked="true"
-            android:text="Scroll" />
-
-        <CheckBox
-            android:id="@+id/sustained_perf_mode"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8sp"
-            android:text="Sustain" />
-    </LinearLayout>
-
-    <HorizontalScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+            android:lines="1"
+            android:text="CPUs:"
+            android:textSize="18sp"
+            android:textStyle="bold" />
 
         <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
             xmlns:tools="http://schemas.android.com/tools"
 
-            android:id="@+id/affinityLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -127,41 +60,135 @@
             android:paddingBottom="@dimen/small_vertical_margin"
             tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
 
-            <TextView
-                android:layout_width="match_parent"
+            <CheckBox
+                android:id="@+id/enable_perf_hint"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/cpu_affinity"
-                android:textSize="18sp"
-                android:textStyle="bold" />
+                android:layout_marginRight="8sp"
+                android:text="ADPF" />
+
+            <CheckBox
+                android:id="@+id/enable_workload_report"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Wkload" />
+
+            <CheckBox
+                android:id="@+id/use_alternative_adpf"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Alt ADPF" />
         </LinearLayout>
 
-    </HorizontalScrollView>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
 
-    <com.mobileer.oboetester.WorkloadView
-        android:id="@+id/dynamic_workload_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/small_horizontal_margin"
+            android:paddingTop="@dimen/small_vertical_margin"
+            android:paddingRight="@dimen/small_horizontal_margin"
+            android:paddingBottom="@dimen/small_vertical_margin"
+            tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
 
-    <TextView
-        android:id="@+id/resultView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="6"
-        android:text="@string/tap_help"
-        android:textSize="18sp"
-        android:textStyle="bold" />
+            <CheckBox
+                android:id="@+id/enable_adpf_workload_increase"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="ADPF Workload Increase API" />
+        </LinearLayout>
 
-    <com.mobileer.oboetester.MultiLineChart
-        android:id="@+id/multiline_chart"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:minHeight="100dp"
-        app:backgroundColor="@color/background_warm"
-        app:exampleDimension="24sp"
-        app:exampleDrawable="@android:drawable/ic_menu_add"
-        app:exampleString="Hello, MultiLineChart"
-        app:lineColor="@color/light_blue_600" />
-</LinearLayout>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
 
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="@dimen/small_horizontal_margin"
+            android:paddingTop="@dimen/small_vertical_margin"
+            android:paddingRight="@dimen/small_horizontal_margin"
+            android:paddingBottom="@dimen/small_vertical_margin"
+            tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+
+            <CheckBox
+                android:id="@+id/hear_workload"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Hear Synth" />
+
+            <CheckBox
+                android:id="@+id/draw_always"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:checked="true"
+                android:text="Scroll" />
+
+            <CheckBox
+                android:id="@+id/sustained_perf_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8sp"
+                android:text="Sustain" />
+        </LinearLayout>
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+
+                android:id="@+id/affinityLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingLeft="@dimen/small_horizontal_margin"
+                android:paddingTop="@dimen/small_vertical_margin"
+                android:paddingRight="@dimen/small_horizontal_margin"
+                android:paddingBottom="@dimen/small_vertical_margin"
+                tools:context="com.mobileer.oboetester.DynamicWorkloadActivity">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/cpu_affinity"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+        </HorizontalScrollView>
+
+        <com.mobileer.oboetester.WorkloadView
+            android:id="@+id/dynamic_workload_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <TextView
+            android:id="@+id/resultView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="6"
+            android:text="@string/tap_help"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <com.mobileer.oboetester.MultiLineChart
+            android:id="@+id/multiline_chart"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:minHeight="100dp"
+            app:backgroundColor="@color/background_warm"
+            app:exampleDimension="24sp"
+            app:exampleDrawable="@android:drawable/ic_menu_add"
+            app:exampleString="Hello, MultiLineChart"
+            app:lineColor="@color/light_blue_600" />
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_echo.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_echo.xml
@@ -1,122 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.mobileer.oboetester.EchoActivity"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true" >
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.EchoActivity">
 
     <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        >
-
-        <com.mobileer.oboetester.StreamConfigurationView
-            android:id="@+id/inputStreamConfiguration"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal" />
-
-        <com.mobileer.oboetester.InputMarginView
-            android:id="@+id/input_margin_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center" />
-
-        <com.mobileer.oboetester.StreamConfigurationView
-            android:id="@+id/outputStreamConfiguration"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/button_start_echo"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:onClick="onStartEcho"
-                android:text="@string/startAudio" />
-
-            <Button
-                android:id="@+id/button_stop_echo"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:onClick="onStopEcho"
-                android:text="@string/stopAudio" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/text_delay_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Delay (msec)" />
-
-            <SeekBar
-                android:id="@+id/fader_delay_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:max="1000"
-                android:progress="1000" />
-        </LinearLayout>
-
-        <com.mobileer.oboetester.CommunicationDeviceView
-            android:id="@+id/comm_device_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal" />
-
-        <com.mobileer.oboetester.VolumeBarView
-            android:id="@+id/volumeBar0"
-            android:layout_marginBottom="4dp"
-            android:layout_width="fill_parent"
-            android:layout_height="20dp" />
-
-        <com.mobileer.oboetester.VolumeBarView
-            android:id="@+id/volumeBar1"
-            android:layout_marginBottom="4dp"
-            android:layout_width="fill_parent"
-            android:layout_height="20dp" />
-
-        <com.mobileer.oboetester.VolumeBarView
-            android:id="@+id/volumeBar2"
-            android:layout_marginBottom="4dp"
-            android:layout_width="fill_parent"
-            android:layout_height="20dp" />
-
-        <com.mobileer.oboetester.VolumeBarView
-            android:id="@+id/volumeBar3"
-            android:layout_marginBottom="4dp"
-            android:layout_width="fill_parent"
-            android:layout_height="20dp" />
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
         <TextView
-            android:id="@+id/text_status"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:lines="11"
-            android:text="@string/echo_instructions"
-            android:textSize="14sp"
+            android:text="Echo Input to Output"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
             android:textStyle="bold" />
+
     </LinearLayout>
 
-</ScrollView>
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/activity_vertical_margin"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin" >
+
+            <com.mobileer.oboetester.StreamConfigurationView
+                android:id="@+id/inputStreamConfiguration"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal" />
+
+            <com.mobileer.oboetester.InputMarginView
+                android:id="@+id/input_margin_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center" />
+
+            <com.mobileer.oboetester.StreamConfigurationView
+                android:id="@+id/outputStreamConfiguration"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/button_start_echo"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:onClick="onStartEcho"
+                    android:text="@string/startAudio" />
+
+                <Button
+                    android:id="@+id/button_stop_echo"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:onClick="onStopEcho"
+                    android:text="@string/stopAudio" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/text_delay_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Delay (msec)" />
+
+                <SeekBar
+                    android:id="@+id/fader_delay_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:max="1000"
+                    android:progress="1000" />
+            </LinearLayout>
+
+            <com.mobileer.oboetester.CommunicationDeviceView
+                android:id="@+id/comm_device_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal" />
+
+            <com.mobileer.oboetester.VolumeBarView
+                android:id="@+id/volumeBar0"
+                android:layout_marginBottom="4dp"
+                android:layout_width="fill_parent"
+                android:layout_height="20dp" />
+
+            <com.mobileer.oboetester.VolumeBarView
+                android:id="@+id/volumeBar1"
+                android:layout_marginBottom="4dp"
+                android:layout_width="fill_parent"
+                android:layout_height="20dp" />
+
+            <com.mobileer.oboetester.VolumeBarView
+                android:id="@+id/volumeBar2"
+                android:layout_marginBottom="4dp"
+                android:layout_width="fill_parent"
+                android:layout_height="20dp" />
+
+            <com.mobileer.oboetester.VolumeBarView
+                android:id="@+id/volumeBar3"
+                android:layout_marginBottom="4dp"
+                android:layout_width="fill_parent"
+                android:layout_height="20dp" />
+
+            <TextView
+                android:id="@+id/text_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:lines="11"
+                android:text="@string/echo_instructions"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_error_callback.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_error_callback.xml
@@ -4,32 +4,58 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".TestErrorCallbackActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Error Callback Test"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <GridLayout
         android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:columnCount="1">
+        android:columnCount="1"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
-    <Button
-        android:id="@+id/buttonTestDeleteCrash"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_columnWeight="1"
-        android:layout_gravity="fill"
-        android:backgroundTint="@color/button_tint"
-        android:onClick="onTestDeleteCrash"
-        android:text="Delete Callback" />
+        <Button
+            android:id="@+id/buttonTestDeleteCrash"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_gravity="fill"
+            android:backgroundTint="@color/button_tint"
+            android:onClick="onTestDeleteCrash"
+            android:text="Delete Callback" />
 
-    <TextView
-        android:id="@+id/text_callback_status"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fontFamily="monospace"
-        android:gravity="bottom"
-        android:text="@string/init_status"
-        />
+        <TextView
+            android:id="@+id/text_callback_status"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fontFamily="monospace"
+            android:gravity="bottom"
+            android:text="@string/init_status"
+            />
 
-</GridLayout>
+    </GridLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_external_tap_to_tone.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_external_tap_to_tone.xml
@@ -4,61 +4,86 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:fitsSystemWindows="true"
     tools:context=".ExternalTapToToneActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="External Tap To Tone"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_start"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin">
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="startTest"
-            android:text="@string/startAudio" />
+            android:orientation="horizontal">
 
-        <Button
-            android:id="@+id/button_analyze"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+            <Button
+                android:id="@+id/button_start"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="startTest"
+                android:text="@string/startAudio" />
+
+            <Button
+                android:id="@+id/button_analyze"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="analyze"
+                android:text="@string/analyze" />
+
+            <Button
+                android:id="@+id/button_stop"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@xml/button_color_selector"
+                android:backgroundTintMode="src_atop"
+                android:onClick="stopTest"
+                android:text="@string/stopAudio" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/resultView"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="analyze"
-            android:text="@string/analyze" />
+            android:lines="2"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:text="@string/tap_help" />
 
-        <Button
-            android:id="@+id/button_stop"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@xml/button_color_selector"
-            android:backgroundTintMode="src_atop"
-            android:onClick="stopTest"
-            android:text="@string/stopAudio" />
-
+        <com.mobileer.oboetester.WaveformView
+            android:id="@+id/waveview_audio"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent" />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/resultView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:text="@string/tap_help" />
-
-    <com.mobileer.oboetester.WaveformView
-        android:id="@+id/waveview_audio"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
-
 </LinearLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_extra_tests.xml
@@ -4,13 +4,35 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".ExtraTestsActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Extra Tests"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <GridLayout
         android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:columnCount="2">
+        android:columnCount="2"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
         <Button
             android:id="@+id/buttonBackToMain"

--- a/apps/OboeTester/app/src/main/res/layout/activity_main.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_main.xml
@@ -5,18 +5,35 @@
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginLeft="4dp"
-    android:layout_marginRight="4dp"
-    android:background="@color/version_release"
+    android:fitsSystemWindows="true"
     tools:context="com.mobileer.oboetester.MainActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="OboeTester"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <TextView
         android:id="@+id/versionText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="V?"
-        app:layout_constraintEnd_toEndOf="@+id/buttonGrid"
-        app:layout_constraintStart_toStartOf="@+id/buttonGrid"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar"
         />
 
     <GridLayout

--- a/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_manual_glitches.xml
@@ -1,136 +1,166 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.ManualGlitchActivity"
-    >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin">
-
-    <com.mobileer.oboetester.StreamConfigurationView
-        android:id="@+id/inputStreamConfiguration"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.InputMarginView
-        android:id="@+id/input_margin_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center" />
-
-    <com.mobileer.oboetester.StreamConfigurationView
-        android:id="@+id/outputStreamConfiguration"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.BufferSizeView
-        android:id="@+id/buffer_size_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.ManualGlitchActivity">
 
     <LinearLayout
-        android:id="@+id/layoutGlitch"
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
         <TextView
-            android:id="@+id/textTolerance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Tolerance" />
+            android:text="Test Glitches"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <SeekBar
-            android:id="@+id/faderTolerance"
+    </LinearLayout>
+
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        tools:context="com.mobileer.oboetester.ManualGlitchActivity"
+        >
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <com.mobileer.oboetester.StreamConfigurationView
+            android:id="@+id/inputStreamConfiguration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:max="1000"
-            android:progress="1000" />
-    </LinearLayout>
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_start"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.InputMarginView
+            android:id="@+id/input_margin_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onStartAudioTest"
-            android:text="@string/startAudio" />
+            android:gravity="center" />
 
-        <Button
-            android:id="@+id/button_stop"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.StreamConfigurationView
+            android:id="@+id/outputStreamConfiguration"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onStopAudioTest"
-            android:text="@string/stopAudio"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <com.mobileer.oboetester.BufferSizeView
+            android:id="@+id/buffer_size_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <LinearLayout
+            android:id="@+id/layoutGlitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textTolerance"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Tolerance" />
+
+            <SeekBar
+                android:id="@+id/faderTolerance"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="1000"
+                android:progress="1000" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_start"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onStartAudioTest"
+                android:text="@string/startAudio" />
+
+            <Button
+                android:id="@+id/button_stop"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onStopAudioTest"
+                android:text="@string/stopAudio"
+                />
+
+            <Button
+                android:id="@+id/button_share"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onShareFile"
+                android:text="@string/share"
+                />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/text_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="14"
+            android:text="@string/loopback_instructions_glitch"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/boxForceGlitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:checked="false"
+                android:onClick="onForceGlitchClicked"
+                android:text="Force glitches"/>
+            <CheckBox
+                android:id="@+id/boxAutoScope"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:checked="true"
+                android:text="Auto draw"/>
+
+        </LinearLayout>
+        <com.mobileer.oboetester.WaveformView
+            android:id="@+id/waveview_audio"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:minHeight="200dp"
             />
-
-        <Button
-            android:id="@+id/button_share"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:onClick="onShareFile"
-            android:text="@string/share"
-            />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/text_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="14"
-        android:text="@string/loopback_instructions_glitch"
-        android:textSize="14sp"
-        android:textStyle="bold" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <CheckBox
-            android:id="@+id/boxForceGlitch"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:checked="false"
-            android:onClick="onForceGlitchClicked"
-            android:text="Force glitches"/>
-        <CheckBox
-            android:id="@+id/boxAutoScope"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:checked="true"
-            android:text="Auto draw"/>
-
-    </LinearLayout>
-    <com.mobileer.oboetester.WaveformView
-        android:id="@+id/waveview_audio"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:minHeight="200dp"
-        />
-</LinearLayout>
-</ScrollView>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_rapid_cycle.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rapid_cycle.xml
@@ -4,13 +4,39 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".TestRapidCycleActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Rapid Cycle"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
         <TextView
             android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/layout/activity_recorder.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_recorder.xml
@@ -1,104 +1,134 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.RecorderActivity" >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin" >
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.RecorderActivity">
 
-    <com.mobileer.oboetester.StreamConfigurationView
-        android:id="@+id/streamConfiguration"
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Recorder"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.InputMarginView
-        android:id="@+id/input_margin_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center" />
-
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        tools:context="com.mobileer.oboetester.RecorderActivity" >
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <Button
-            android:id="@+id/button_start_recording"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:onClick="onStartRecording"
-            android:text="@string/recordAudio"
-            />
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin" >
 
-        <Button
-            android:id="@+id/button_stop_record_play"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.StreamConfigurationView
+            android:id="@+id/streamConfiguration"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onStopRecordPlay"
-            android:text="@string/stopAudio"
-            />
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-        <Button
-            android:id="@+id/button_start_playback"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.InputMarginView
+            android:id="@+id/input_margin_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onStartPlayback"
-            android:text="@string/playAudio"
-            />
+            android:gravity="center" />
 
-        <Button
-            android:id="@+id/button_share"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onShareFile"
-            android:text="@string/share"
-            />
+            android:orientation="horizontal">
+            <Button
+                android:id="@+id/button_start_recording"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onStartRecording"
+                android:text="@string/recordAudio"
+                />
+
+            <Button
+                android:id="@+id/button_stop_record_play"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onStopRecordPlay"
+                android:text="@string/stopAudio"
+                />
+
+            <Button
+                android:id="@+id/button_start_playback"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onStartPlayback"
+                android:text="@string/playAudio"
+                />
+
+            <Button
+                android:id="@+id/button_share"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onShareFile"
+                android:text="@string/share"
+                />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/statusView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="3"
+            android:text="@string/init_status" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar0"
+            android:layout_width="fill_parent"
+            android:layout_marginBottom="4dp"
+            android:layout_height="20dp" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar1"
+            android:layout_width="fill_parent"
+            android:layout_marginBottom="4dp"
+            android:layout_height="20dp" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar2"
+            android:layout_width="fill_parent"
+            android:layout_marginBottom="4dp"
+            android:layout_height="20dp" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar3"
+            android:layout_width="fill_parent"
+            android:layout_marginBottom="4dp"
+            android:layout_height="20dp" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/statusView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="3"
-        android:text="@string/init_status" />
-
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar0"
-        android:layout_width="fill_parent"
-        android:layout_marginBottom="4dp"
-        android:layout_height="20dp" />
-
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar1"
-        android:layout_width="fill_parent"
-        android:layout_marginBottom="4dp"
-        android:layout_height="20dp" />
-
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar2"
-        android:layout_width="fill_parent"
-        android:layout_marginBottom="4dp"
-        android:layout_height="20dp" />
-
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar3"
-        android:layout_width="fill_parent"
-        android:layout_marginBottom="4dp"
-        android:layout_height="20dp" />
-
-</LinearLayout>
-</ScrollView>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_routing_crash.xml
@@ -4,13 +4,39 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".TestRouteDuringCallbackActivity">
+
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Route Callback Test"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/buttonGrid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar">
 
         <TextView
             android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_rt_latency.xml
@@ -1,123 +1,153 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.RoundTripLatencyActivity" >
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.RoundTripLatencyActivity">
 
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin" >
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-    <com.mobileer.oboetester.StreamConfigurationView
-        android:id="@+id/inputStreamConfiguration"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Round Trip Latency"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.InputMarginView
-        android:id="@+id/input_margin_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center" />
-
-    <com.mobileer.oboetester.StreamConfigurationView
-        android:id="@+id/outputStreamConfiguration"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.BufferSizeView
-        android:id="@+id/buffer_size_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <com.mobileer.oboetester.WorkloadView
-        android:id="@+id/workload_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        tools:context="com.mobileer.oboetester.RoundTripLatencyActivity" >
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin" >
 
-        <Button
-            android:id="@+id/button_measure"
-            android:layout_width="0dp"
+        <com.mobileer.oboetester.StreamConfigurationView
+            android:id="@+id/inputStreamConfiguration"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:onClick="onMeasure"
-            android:text="@string/measure"
-            android:textSize="10sp" />
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-        <Button
-            android:id="@+id/button_average"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.InputMarginView
+            android:id="@+id/input_margin_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onAverage"
-            android:text="@string/average"
-            android:textSize="10sp" />
+            android:gravity="center" />
 
-        <Button
-            android:id="@+id/button_scan"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.StreamConfigurationView
+            android:id="@+id/outputStreamConfiguration"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"
-            android:onClick="onScan"
-            android:text="@string/scan"
-            android:textSize="10sp" />
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-        <Button
-            android:id="@+id/button_cancel"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.BufferSizeView
+            android:id="@+id/buffer_size_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"
-            android:onClick="onCancel"
-            android:text="@string/cancel"
-            android:textSize="10sp" />
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-        <Button
-            android:id="@+id/button_share"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <com.mobileer.oboetester.WorkloadView
+            android:id="@+id/workload_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onShareFile"
-            android:text="@string/share"
-            android:textSize="10sp" />
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_measure"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:onClick="onMeasure"
+                android:text="@string/measure"
+                android:textSize="10sp" />
+
+            <Button
+                android:id="@+id/button_average"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onAverage"
+                android:text="@string/average"
+                android:textSize="10sp" />
+
+            <Button
+                android:id="@+id/button_scan"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:onClick="onScan"
+                android:text="@string/scan"
+                android:textSize="10sp" />
+
+            <Button
+                android:id="@+id/button_cancel"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:onClick="onCancel"
+                android:text="@string/cancel"
+                android:textSize="10sp" />
+
+            <Button
+                android:id="@+id/button_share"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onShareFile"
+                android:text="@string/share"
+                android:textSize="10sp" />
+        </LinearLayout>
+
+        <com.mobileer.oboetester.CommunicationDeviceView
+            android:id="@+id/comm_device_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <TextView
+            android:id="@+id/text_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="16"
+            android:text="@string/loopback_instructions_latency"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
     </LinearLayout>
-
-    <com.mobileer.oboetester.CommunicationDeviceView
-        android:id="@+id/comm_device_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
-    <TextView
-        android:id="@+id/text_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="16"
-        android:text="@string/loopback_instructions_latency"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-</LinearLayout>
-</ScrollView>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_tap_to_tone.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_tap_to_tone.xml
@@ -1,78 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.TapToToneActivity"
-    >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin">
-
-    <include layout="@layout/merge_audio_simple"/>
-
-    <com.mobileer.oboetester.CommunicationDeviceView
-        android:id="@+id/comm_device_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.TapToToneActivity">
 
     <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Input Device: " />
+            android:text="Tap To Tone"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <com.mobileer.audio_device.AudioDeviceSpinner
-            android:id="@+id/input_devices_spinner"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
     </LinearLayout>
 
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        tools:context="com.mobileer.oboetester.TapToToneActivity"
+        >
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <include layout="@layout/merge_audio_simple"/>
+
+        <com.mobileer.oboetester.CommunicationDeviceView
+            android:id="@+id/comm_device_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Input Device: " />
+
+            <com.mobileer.audio_device.AudioDeviceSpinner
+                android:id="@+id/input_devices_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="MIDI:" />
+
+            <Spinner
+                android:id="@+id/spinner_synth_sender"
+                style="@android:style/TextAppearance.Large"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:entries="@array/senders" />
+        </LinearLayout>
 
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/resultView"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="MIDI:" />
+            android:lines="2"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:text="@string/tap_help" />
 
-        <Spinner
-            android:id="@+id/spinner_synth_sender"
-            style="@android:style/TextAppearance.Large"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/senders" />
+        <com.mobileer.oboetester.WaveformView
+            android:id="@+id/waveview_audio"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:minHeight="100dp"
+            />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/resultView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:text="@string/tap_help" />
-
-    <com.mobileer.oboetester.WaveformView
-        android:id="@+id/waveview_audio"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:minHeight="100dp"
-        />
-</LinearLayout>
-</ScrollView>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_disconnect.xml
@@ -4,79 +4,104 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:fitsSystemWindows="true"
     tools:context="com.mobileer.oboetester.TestDisconnectActivity">
 
-    <TextView
-        android:id="@+id/text_instructions"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="@string/test_disconnect_instructions"
-        android:textColor="#F44336"
-        android:textSize="18sp"
-        android:textStyle="bold" />
-
-    <TextView
-        android:id="@+id/text_plug_events"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="plug #"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        />
-
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-        <CheckBox
-            android:id="@+id/checkbox_disco_outputs"
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="Outputs" />
+            android:text="Test Disconnect"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <CheckBox
-            android:id="@+id/checkbox_disco_inputs"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="Inputs" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_fail"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+        <TextView
+            android:id="@+id/text_instructions"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onFailTest"
-            android:text="@string/failTest" />
+            android:lines="2"
+            android:text="@string/test_disconnect_instructions"
+            android:textColor="#F44336"
+            android:textSize="18sp"
+            android:textStyle="bold" />
 
-        <Button
-            android:id="@+id/button_skip"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <TextView
+            android:id="@+id/text_plug_events"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="onSkipTest"
-            android:text="@string/skipTest" />
+            android:lines="2"
+            android:text="plug #"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            />
 
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/checkbox_disco_outputs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Outputs" />
+
+            <CheckBox
+                android:id="@+id/checkbox_disco_inputs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Inputs" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_fail"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onFailTest"
+                android:text="@string/failTest" />
+
+            <Button
+                android:id="@+id/button_skip"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:onClick="onSkipTest"
+                android:text="@string/skipTest" />
+
+        </LinearLayout>
+
+        <com.mobileer.oboetester.AutomatedTestRunner
+            android:id="@+id/auto_test_runner"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical" />
     </LinearLayout>
-
-    <com.mobileer.oboetester.AutomatedTestRunner
-        android:id="@+id/auto_test_runner"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" />
-
 </LinearLayout>

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_input.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_input.xml
@@ -1,77 +1,106 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.TestInputActivity"
-    >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    >
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.TestInputActivity">
 
-    <include layout="@layout/merge_audio_common"/>
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-    <com.mobileer.oboetester.CommunicationDeviceView
-        android:id="@+id/comm_device_view"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Test Input"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
+        android:fillViewport="true"
+        tools:context="com.mobileer.oboetester.TestInputActivity"
+        >
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        >
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar0"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <include layout="@layout/merge_audio_common"/>
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar1"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.CommunicationDeviceView
+            android:id="@+id/comm_device_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar2"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar0"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar3"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar1"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar4"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar2"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar5"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar3"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar6"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar4"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
 
-    <com.mobileer.oboetester.VolumeBarView
-        android:id="@+id/volumeBar7"
-        android:layout_marginBottom="4dp"
-        android:layout_width="fill_parent"
-        android:layout_height="20dp" />
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar5"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar6"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
+
+        <com.mobileer.oboetester.VolumeBarView
+            android:id="@+id/volumeBar7"
+            android:layout_marginBottom="4dp"
+            android:layout_width="fill_parent"
+            android:layout_height="20dp" />
+    </LinearLayout>
+    </ScrollView>
 </LinearLayout>
-</ScrollView>

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_output.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_output.xml
@@ -1,199 +1,228 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:fillViewport="true"
-    tools:context="com.mobileer.oboetester.TestOutputActivity"
-    >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    >
+    android:fitsSystemWindows="true"
+    tools:context="com.mobileer.oboetester.TestOutputActivity">
 
-    <include layout="@layout/merge_audio_common"/>
+    <LinearLayout
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-    <HorizontalScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Test Output"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        tools:context="com.mobileer.oboetester.TestOutputActivity"
+        >
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        >
+
+        <include layout="@layout/merge_audio_common"/>
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/channelText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Channels:" />
+
+                <CheckBox
+                    android:id="@+id/channelBox0"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="0" />
+
+                <CheckBox
+                    android:id="@+id/channelBox1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="1" />
+
+                <CheckBox
+                    android:id="@+id/channelBox2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="2" />
+
+                <CheckBox
+                    android:id="@+id/channelBox3"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="3" />
+
+                <CheckBox
+                    android:id="@+id/channelBox4"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="4" />
+
+                <CheckBox
+                    android:id="@+id/channelBox5"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="5" />
+
+                <CheckBox
+                    android:id="@+id/channelBox6"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="6" />
+
+                <CheckBox
+                    android:id="@+id/channelBox7"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="7" />
+
+                <CheckBox
+                    android:id="@+id/channelBox8"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="8" />
+
+                <CheckBox
+                    android:id="@+id/channelBox9"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="9" />
+
+                <CheckBox
+                    android:id="@+id/channelBox10"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="10" />
+
+                <CheckBox
+                    android:id="@+id/channelBox11"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="11" />
+
+                <CheckBox
+                    android:id="@+id/channelBox12"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="12" />
+
+                <CheckBox
+                    android:id="@+id/channelBox13"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="13" />
+
+                <CheckBox
+                    android:id="@+id/channelBox14"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="14" />
+
+                <CheckBox
+                    android:id="@+id/channelBox15"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="onChannelBoxClicked"
+                    android:text="15" />
+
+            </LinearLayout>
+        </HorizontalScrollView>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
-
             <TextView
-                android:id="@+id/channelText"
+                android:id="@+id/textVolumeSlider"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Channels:" />
+                android:text="Volume(dB): 0.0" />
 
-            <CheckBox
-                android:id="@+id/channelBox0"
-                android:layout_width="wrap_content"
+            <SeekBar
+                android:id="@+id/faderVolumeSlider"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="0" />
-
-            <CheckBox
-                android:id="@+id/channelBox1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="1" />
-
-            <CheckBox
-                android:id="@+id/channelBox2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="2" />
-
-            <CheckBox
-                android:id="@+id/channelBox3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="3" />
-
-            <CheckBox
-                android:id="@+id/channelBox4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="4" />
-
-            <CheckBox
-                android:id="@+id/channelBox5"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="5" />
-
-            <CheckBox
-                android:id="@+id/channelBox6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="6" />
-
-            <CheckBox
-                android:id="@+id/channelBox7"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="7" />
-
-            <CheckBox
-                android:id="@+id/channelBox8"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="8" />
-
-            <CheckBox
-                android:id="@+id/channelBox9"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="9" />
-
-            <CheckBox
-                android:id="@+id/channelBox10"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="10" />
-
-            <CheckBox
-                android:id="@+id/channelBox11"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="11" />
-
-            <CheckBox
-                android:id="@+id/channelBox12"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="12" />
-
-            <CheckBox
-                android:id="@+id/channelBox13"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="13" />
-
-            <CheckBox
-                android:id="@+id/channelBox14"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="14" />
-
-            <CheckBox
-                android:id="@+id/channelBox15"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="onChannelBoxClicked"
-                android:text="15" />
-
+                android:max="500"
+                android:progress="500" />
         </LinearLayout>
-    </HorizontalScrollView>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <TextView
-            android:id="@+id/textVolumeSlider"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Volume(dB): 0.0" />
-
-        <SeekBar
-            android:id="@+id/faderVolumeSlider"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:max="500"
-            android:progress="500" />
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Signal:" />
+            <Spinner
+                android:id="@+id/spinnerOutputSignal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:entries="@array/output_signals"
+                android:prompt="@string/output_signal_prompt" />
+            <CheckBox
+                android:id="@+id/enableSetStreamControlByAttributes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="VolumeByAttr" />
+        </LinearLayout>
+
+        <com.mobileer.oboetester.CommunicationDeviceView
+            android:id="@+id/comm_device_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal" />
+
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Signal:" />
-        <Spinner
-            android:id="@+id/spinnerOutputSignal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/output_signals"
-            android:prompt="@string/output_signal_prompt" />
-        <CheckBox
-            android:id="@+id/enableSetStreamControlByAttributes"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="VolumeByAttr" />
-    </LinearLayout>
-
-    <com.mobileer.oboetester.CommunicationDeviceView
-        android:id="@+id/comm_device_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" />
-
+    </ScrollView>
 </LinearLayout>
-</ScrollView>

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_plug_latency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_plug_latency.xml
@@ -4,44 +4,70 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:fitsSystemWindows="true"
     tools:context="com.mobileer.oboetester.TestPlugLatencyActivity">
 
-    <TextView
-        android:id="@+id/text_instructions"
+    <LinearLayout
+        android:id="@+id/title_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="Plug in and remove audio devices. The latency of the operation will be shown."
-        android:textColor="#F44336"
-        android:textSize="18sp"
-        android:textStyle="bold" />
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
 
-    <TextView
-        android:id="@+id/text_plug_events"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="1"
-        android:text="plug #"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        />
-
-    <ScrollView
-        android:id="@+id/text_log_device_scroller"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
         <TextView
-            android:id="@+id/text_log_device_report"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Plug Latency Test"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+        <TextView
+            android:id="@+id/text_instructions"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fontFamily="monospace"
-            android:gravity="bottom"
-            android:scrollbars="vertical"
-            android:text=""
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="Plug in and remove audio devices. The latency of the operation will be shown."
+            android:textColor="#F44336"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/text_plug_events"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="1"
+            android:text="plug #"
+            android:textSize="18sp"
+            android:textStyle="bold"
             />
-    </ScrollView>
+
+        <ScrollView
+            android:id="@+id/text_log_device_scroller"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/text_log_device_report"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fontFamily="monospace"
+                android:gravity="bottom"
+                android:scrollbars="vertical"
+                android:text=""
+                />
+        </ScrollView>
+    </LinearLayout>
 </LinearLayout>

--- a/apps/OboeTester/app/src/main/res/values/colors.xml
+++ b/apps/OboeTester/app/src/main/res/values/colors.xml
@@ -25,4 +25,6 @@
     <color name="gray_400">#FFBDBDBD</color>
     <color name="gray_600">#FF757575</color>
     <color name="background_warm">#FFf0F0E8</color>
+    <color name="color_primary">#ffffffff</color>
+    <color name="color_primary_dark">#00000000</color>
 </resources>

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -35,18 +35,18 @@
     </string>
     <string name="no_double_tap">Please do not tap while measuring.</string>
     <string name="loopback_instructions_glitch">
-        Click Show Settings to configure.\n
+        &#160;Click Show Settings to configure.\n
         This glitch measurement plays\n
         and listens to a sine wave.\n
         It works with best with a loopback dongle.\n
         Set volume to medium-high.\n
     </string>
     <string name="echo_instructions">
-        Be ready to turn down the volume\n
+        &#160;Be ready to turn down the volume\n
         if you get feedback. \n
     </string>
     <string name="loopback_instructions_latency">
-        Click Show Settings to configure.\n
+        &#160;Click Show Settings to configure.\n
         This latency measurement uses a\n
         short burst of encoded noise.\n
         It works with speakers and mic\n
@@ -55,7 +55,7 @@
     </string>
 
     <string name="auto_glitch_instructions">
-        Plug in a loopback adapter.\n
+        &#160;Plug in a loopback adapter.\n
         Then set volume to about 80%.\n
         Then press Run button.\n
     </string>
@@ -277,7 +277,7 @@
     <string name="analyze">Analyze</string>
 
     <string name="routing_crash_intro">
-        May cause a crash by changing the\n
+        &#160;May cause a crash by changing the\n
         VoiceCommunication routing while playing\n
         audio with a long duration callback.\n
         More likely to crash with Bluetooth\n
@@ -286,7 +286,7 @@
     </string>
 
     <string name="rapid_cycle_intro">
-        Maybe cause a crash or hang by rapidly\n
+        &#160;Maybe cause a crash or hang by rapidly\n
         opening, starting, and closing streams.\n
     </string>
 

--- a/apps/OboeTester/app/src/main/res/values/styles.xml
+++ b/apps/OboeTester/app/src/main/res/values/styles.xml
@@ -1,8 +1,13 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:statusBarColor">@color/color_primary_dark</item>
     </style>
 
     <style name="Widget.AppTheme.MyView" parent="">

--- a/apps/OboeTester/build.gradle
+++ b/apps/OboeTester/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.1'
+        classpath 'com.android.tools.build:gradle:8.9.0'
     }
 }
 

--- a/apps/OboeTester/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/OboeTester/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/apps/fxlab/app/build.gradle
+++ b/apps/fxlab/app/build.gradle
@@ -21,12 +21,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     defaultConfig {
         applicationId "com.mobileer.androidfxlab"
         minSdkVersion 21
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/apps/fxlab/app/src/main/res/layout/activity_main.xml
+++ b/apps/fxlab/app/src/main/res/layout/activity_main.xml
@@ -20,7 +20,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBar"

--- a/apps/fxlab/app/src/main/res/values/colors.xml
+++ b/apps/fxlab/app/src/main/res/values/colors.xml
@@ -17,7 +17,7 @@
 
 <resources>
     <color name="colorPrimary">#6200EE</color>
-    <color name="colorPrimaryDark">#3700B3</color>
+    <color name="colorPrimaryDark">#ffffff</color>
     <color name="colorAccent">#03DAC6</color>
     <color name="colorAccentDark">#018786</color>
 </resources>

--- a/apps/fxlab/app/src/main/res/values/styles.xml
+++ b/apps/fxlab/app/src/main/res/values/styles.xml
@@ -22,6 +22,8 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This PR updates OboeTester to Android API 36. In Android API 35, there was a [breaking change](https://developer.android.com/about/versions/15/behavior-changes-15#ux) for apps where old apps with navigation bars are just broken in Android API 35. This PR is helping to refactor OboeTester and fxlab to accommodate this. Below are a summary of the changes.

1. In styles.xml, we need to disable the action bar `<style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">` because old action bars just don't work correctly. Instead, we can roll out our own action bar.
2. To roll out our own action bar, we can add an linear layout that's around the size of an action bar and add a textbox manually with the activity's title.
3. In whatever top level container we use, we need to add `android:fitsSystemWindows="true"` so the notification icons and the time and the battery icons work correctly.
4. In order to keep colors consistent for Android 34- and Android 35+, we are using light backgrounds and black text for the system windows on all versions of the apps.
5. We need to wrap anything below the action bar in a linear layout or something similar so we can enforce an 16px on all 4 corners. Otherwise, the app looks too crowded. With Android API 35, top level paddings don't seem to work so we need to manually add a container below.
6. DeviceReportActivity has it's share icon changed as we're now rolling out our own action bar.
7. There was an one off raw array issue in NativeAudioContext.cpp that I couldn't compile on Android API 35 without fixing.