### PR TITLE
OboeTester: optimize AudioWorkloadTest.h

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
@@ -149,6 +149,10 @@ public:
             std::cerr << "Error: Stream not open." << std::endl;
             return static_cast<int32_t>(oboe::Result::ErrorInvalidState);
         }
+        if (mRunning) {
+            std::cerr << "Error: Stream already started." << std::endl;
+            return static_cast<int32_t>(oboe::Result::ErrorUnavailable);
+        }
         mTargetDurationMs = targetDurationMillis;
         mNumBursts = numBursts;
         mNumVoices = numVoices;
@@ -256,6 +260,7 @@ public:
                 return static_cast<int32_t>(result);
             }
         }
+        mRunning = false;
         return 0;
     }
 
@@ -273,6 +278,7 @@ public:
                 return static_cast<int32_t>(result);
             }
         }
+        mRunning = false;
         return 0;
     }
 

--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
@@ -80,7 +80,7 @@ public:
     int32_t open() {
         std::lock_guard<std::mutex> lock(mStreamLock);
         if (mStream) {
-            std::cerr << "Error: Stream already open." << std::endl;
+            LOGE("Error: Stream already open.");
             return static_cast<int32_t>(oboe::Result::ErrorUnavailable);
         }
 
@@ -94,7 +94,7 @@ public:
 
         oboe::Result result = builder.openStream(mStream);
         if (result != oboe::Result::OK) {
-            std::cerr << "Error opening stream: " << oboe::convertToText(result) << std::endl;
+            LOGE("Error opening stream: %s", oboe::convertToText(result));
             return static_cast<int32_t>(result);
         }
 
@@ -152,11 +152,11 @@ public:
                   bool adpfWorkloadIncreaseEnabled, bool hearWorkload) {
         std::lock_guard<std::mutex> lock(mStreamLock);
         if (!mStream) {
-            std::cerr << "Error: Stream not open." << std::endl;
+            LOGE("Error: Stream not open.");
             return static_cast<int32_t>(oboe::Result::ErrorInvalidState);
         }
         if (mRunning) {
-            std::cerr << "Error: Stream already started." << std::endl;
+            LOGE("Error: Stream already started.");
             return static_cast<int32_t>(oboe::Result::ErrorUnavailable);
         }
         mTargetDurationMs = targetDurationMillis;
@@ -181,7 +181,7 @@ public:
         oboe::Result result = mStream->start();
         if (result != oboe::Result::OK) {
             mRunning = false;
-            std::cerr << "Error starting stream: " << oboe::convertToText(result) << std::endl;
+            LOGE("Error starting stream: %s", oboe::convertToText(result));
             return static_cast<int32_t>(result);
         }
 
@@ -212,7 +212,7 @@ public:
         }
 
         if (sched_setaffinity(pthread_self(), sizeof(cpu_set_t), &cpuset) != 0) {
-            std::cerr << "Error setting CPU affinity." << std::endl;
+            LOGE("Error setting CPU affinity.");
             return -1;
         }
         return 0;
@@ -259,17 +259,17 @@ public:
         if (mStream) {
             oboe::Result result = mStream->requestStop();
             if (result != oboe::Result::OK) {
-                std::cerr << "Error stopping stream: " << oboe::convertToText(result) << std::endl;
+                LOGE("Error stopping stream: %s", oboe::convertToText(result));
                 return static_cast<int32_t>(result);
             }
             oboe::StreamState next;
             result = mStream->waitForStateChange(oboe::StreamState::Stopping, &next, kTimeoutInNanos);
             if (result != oboe::Result::OK) {
-                std::cerr << "Error while waiting for stream to stop: " << oboe::convertToText(result) << std::endl;
+                LOGE("Error while waiting for stream to stop: %s", oboe::convertToText(result));
                 return static_cast<int32_t>(result);
             }
             if (next != oboe::StreamState::Stopped) {
-                std::cerr << "Error: Stream did not stop. State: " << oboe::convertToText(next) << std::endl;
+                LOGE("Error: Stream did not stop. State: %s", oboe::convertToText(next));
                 return static_cast<int32_t>(oboe::Result::ErrorInvalidState);
             }
         }
@@ -287,7 +287,7 @@ public:
             oboe::Result result = mStream->close();
             mStream = nullptr;
             if (result != oboe::Result::OK) {
-                std::cerr << "Error closing stream: " << oboe::convertToText(result) << std::endl;
+                LOGE("Error closing stream: %s", oboe::convertToText(result));
                 return static_cast<int32_t>(result);
             }
         }

--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
@@ -170,7 +170,7 @@ public:
         mBufferSizeInFrames = mStream->getBufferSizeInFrames();
         {
             std::lock_guard<std::mutex> synthWorkloadLock(mSynthWorkloadLock);
-            mSynthWorkload = std::make_shared<SynthWorkload>((int) 0.2 * mSampleRate, (int) 0.3 * mSampleRate);
+            mSynthWorkload = std::make_unique<SynthWorkload>((int) 0.2 * mSampleRate, (int) 0.3 * mSampleRate);
         }
         oboe::Result result = mStream->start();
         if (result != oboe::Result::OK) {
@@ -417,7 +417,7 @@ private:
 
     // Lock to protect mSynthWorkload
     std::mutex mSynthWorkloadLock;
-    std::shared_ptr<SynthWorkload> mSynthWorkload; // Pointer to the synthetic workload generator
+    std::unique_ptr<SynthWorkload> mSynthWorkload; // Pointer to the synthetic workload generator
 };
 
 #endif // AUDIO_WORKLOAD_TEST_H

--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTest.h
@@ -263,7 +263,7 @@ public:
                 return static_cast<int32_t>(result);
             }
             oboe::StreamState next;
-            result = mStream->waitForStateChange(oboe::StreamState::Stopping, &next, 0);
+            result = mStream->waitForStateChange(oboe::StreamState::Stopping, &next, kTimeoutInNanos);
             if (result != oboe::Result::OK) {
                 std::cerr << "Error while waiting for stream to stop: " << oboe::convertToText(result) << std::endl;
                 return static_cast<int32_t>(result);
@@ -399,6 +399,8 @@ public:
 
 private:
     const std::string kTestName = "AudioWorkloadTest";
+
+    static constexpr int kTimeoutInNanos = 500 * oboe::kNanosPerMillisecond;
 
     // Lock for protecting mStream
     std::mutex                         mStreamLock;

--- a/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTestRunner.h
+++ b/apps/OboeTester/app/src/main/cpp/cpu/AudioWorkloadTestRunner.h
@@ -76,7 +76,7 @@ public:
             bool adpfWorkloadIncreaseEnabled,
             bool hearWorkload) {
         if (mIsRunning) {
-            std::cerr << "Error: Test already running." << std::endl;
+            LOGE("Error: Test already running.");
             return -1;
         }
 

--- a/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
+++ b/apps/OboeTester/app/src/main/cpp/jni-bridge.cpp
@@ -1188,15 +1188,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     g_javaVM = vm; // Cache the JavaVM pointer
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
-        std::cerr << "JNI_OnLoad: Failed to get JNIEnv." << std::endl;
-        return JNI_ERR; // Indicates an error
+        LOGE("JNI_OnLoad: Failed to get JNIEnv.");
+        return JNI_ERR;
     }
 
     const char* callbackStatusClassName =
             "com/mobileer/oboetester/AudioWorkloadTestActivity$CallbackStatus";
     jclass localCallbackStatusClass = env->FindClass(callbackStatusClassName);
     if (localCallbackStatusClass == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not find class " << callbackStatusClassName << std::endl;
+        LOGE("JNI_OnLoad: Could not find class %s", callbackStatusClassName);
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return JNI_ERR;
     }
@@ -1204,15 +1204,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     g_callbackStatusClass = (jclass)env->NewGlobalRef(localCallbackStatusClass);
     env->DeleteLocalRef(localCallbackStatusClass); // Clean up the local reference
     if (g_callbackStatusClass == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not create global ref for " << callbackStatusClassName
-                << std::endl;
+        LOGE("JNI_OnLoad: Could not create global ref for %s", callbackStatusClassName);
         return JNI_ERR;
     }
 
     g_callbackStatusConstructor = env->GetMethodID(g_callbackStatusClass, "<init>", "(IJJII)V");
     if (g_callbackStatusConstructor == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not find constructor for " << callbackStatusClassName
-                << std::endl;
+        LOGE("JNI_OnLoad: Could not find constructor for %s", callbackStatusClassName);
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return JNI_ERR;
     }
@@ -1220,30 +1218,27 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     const char* arrayListClassName = "java/util/ArrayList";
     jclass localArrayListClass = env->FindClass(arrayListClassName);
     if (localArrayListClass == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not find class " << arrayListClassName << std::endl;
+        LOGE("JNI_OnLoad: Could not find class %s", arrayListClassName);
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return JNI_ERR;
     }
     g_arrayListClass = (jclass)env->NewGlobalRef(localArrayListClass);
     env->DeleteLocalRef(localArrayListClass); // Clean up local reference
     if (g_arrayListClass == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not create global ref for " << arrayListClassName
-                << std::endl;
+        LOGE("JNI_OnLoad: Could not create global ref for %s", arrayListClassName);
         return JNI_ERR;
     }
 
     g_arrayListConstructor = env->GetMethodID(g_arrayListClass, "<init>", "()V");
     if (g_arrayListConstructor == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not find constructor for " << arrayListClassName
-                << std::endl;
+        LOGE("JNI_OnLoad: Could not find constructor for %s", arrayListClassName);
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return JNI_ERR;
     }
 
     g_arrayListAddMethod = env->GetMethodID(g_arrayListClass, "add", "(Ljava/lang/Object;)Z");
     if (g_arrayListAddMethod == nullptr) {
-        std::cerr << "JNI_OnLoad: Could not find 'add' method for " << arrayListClassName
-                << std::endl;
+        LOGE("JNI_OnLoad: Could not find 'add' method for %s", arrayListClassName);
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return JNI_ERR;
     }
@@ -1256,7 +1251,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved) {
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
-        std::cerr << "JNI_OnUnload: Failed to get JNIEnv." << std::endl;
+        LOGE("JNI_OnUnload: Failed to get JNIEnv.");
         return;
     }
 
@@ -1284,8 +1279,7 @@ Java_com_mobileer_oboetester_AudioWorkloadTestActivity_getCallbackStatistics(JNI
     if (g_callbackStatusClass == nullptr || g_callbackStatusConstructor == nullptr ||
         g_arrayListClass == nullptr || g_arrayListConstructor == nullptr ||
         g_arrayListAddMethod == nullptr) {
-        std::cerr << "Error: JNI IDs not cached. Initialization in JNI_OnLoad might have failed."
-                << std::endl;
+        LOGE("Error: JNI IDs not cached. Initialization in JNI_OnLoad might have failed.");
         return nullptr;
     }
 
@@ -1294,7 +1288,7 @@ Java_com_mobileer_oboetester_AudioWorkloadTestActivity_getCallbackStatistics(JNI
 
     jobject javaList = env->NewObject(g_arrayListClass, g_arrayListConstructor);
     if (javaList == nullptr) {
-        std::cerr << "Error: Could not create new ArrayList object." << std::endl;
+        LOGE("Error: Could not create new ArrayList object.");
         if (env->ExceptionCheck()) env->ExceptionDescribe();
         return nullptr;
     }
@@ -1310,7 +1304,7 @@ Java_com_mobileer_oboetester_AudioWorkloadTestActivity_getCallbackStatistics(JNI
                 (jint)status.cpuIndex
         );
         if (javaStatus == nullptr) {
-            std::cerr << "Error: Could not create new CallbackStatus object." << std::endl;
+            LOGE("Error: Could not create new CallbackStatus object.");
             if (env->ExceptionCheck()) env->ExceptionDescribe();
             env->DeleteLocalRef(javaList);
             return nullptr;


### PR DESCRIPTION
This change several changes to make AudioWorkloadTest run better and have less crashes.

1. SynthWorkload is now created with an unique_ptr to reduce the number of crashes as SynthWorkload uses new on an array.
2. IsRunning is set to false when the stream is close/stopped.
3. Added more checks in open and start to make sure the system is in the right place when the functions are called.
4. We added waitForStateChange for stop to make sure that the system indeeds stops.
5. LOGE is used instead of std::cerr to not have blocking logs.

Fixes #2258
