### PR TITLE
OboeTester: Don't crash cold start latency for invalid paths

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
@@ -52,7 +52,9 @@ int32_t TestColdStartLatency::open(bool useInput, bool useLowLatency, bool useMm
     // Revert MMAP back to its previous state
     AAudioExtensions::getInstance().setMMapEnabled(wasMMapEnabled);
 
-    mDeviceId = mStream->getDeviceId();
+    if (mDeviceId) {
+        mDeviceId = mStream->getDeviceId();
+    }
 
     return (int32_t) result;
 }
@@ -67,6 +69,9 @@ int32_t TestColdStartLatency::start() {
 }
 
 int32_t TestColdStartLatency::close() {
+    if (!mStream) {
+        return (int32_t)Result::OK;
+    }
     Result result1 = mStream->requestStop();
     Result result2 = mStream->close();
     return (int32_t)((result1 != Result::OK) ? result1 : result2);

--- a/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
@@ -52,7 +52,7 @@ int32_t TestColdStartLatency::open(bool useInput, bool useLowLatency, bool useMm
     // Revert MMAP back to its previous state
     AAudioExtensions::getInstance().setMMapEnabled(wasMMapEnabled);
 
-    if (mDeviceId) {
+    if (result != Result::OK) {
         mDeviceId = mStream->getDeviceId();
     }
 

--- a/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
+++ b/apps/OboeTester/app/src/main/cpp/TestColdStartLatency.cpp
@@ -52,7 +52,7 @@ int32_t TestColdStartLatency::open(bool useInput, bool useLowLatency, bool useMm
     // Revert MMAP back to its previous state
     AAudioExtensions::getInstance().setMMapEnabled(wasMMapEnabled);
 
-    if (result != Result::OK) {
+    if (result == Result::OK) {
         mDeviceId = mStream->getDeviceId();
     }
 

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestColdStartLatencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestColdStartLatencyActivity.java
@@ -29,6 +29,7 @@ import android.widget.CheckBox;
 import android.widget.RadioButton;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -133,7 +134,18 @@ public class TestColdStartLatencyActivity extends AppCompatActivity {
                 loopCount++;
                 try {
                     sleep(closedSleepTimeMillis);
-                    openStream(useInput, useLowLatency, useMmap, useExclusive);
+                    int result = openStream(useInput, useLowLatency, useMmap, useExclusive);
+                    if (result != 0) {
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                Toast.makeText(TestColdStartLatencyActivity.this,
+                                        "Error opening stream. Error: " + result,
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        });
+                        break;
+                    }
                     log("-------#" + loopCount + " Device Id: " + getAudioDeviceId());
                     log("open() Latency: " + getOpenTimeMicros() / 1000 + " msec");
                     sleep(openSleepTimeMillis);


### PR DESCRIPTION
Fixes b/440110746

For example, when you start cold start latency with input, no MMAP but exclusive set, the stream crashes. We should send a toast instead