### PR TITLE
Adds missing include for algorithm header

### DIFF
--- a/src/aaudio/AAudioExtensions.h
+++ b/src/aaudio/AAudioExtensions.h
@@ -17,6 +17,7 @@
 #ifndef OBOE_AAUDIO_EXTENSIONS_H
 #define OBOE_AAUDIO_EXTENSIONS_H
 
+#include <algorithm>
 #include <dlfcn.h>
 #include <set>
 #include <stdint.h>

--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -20,6 +20,9 @@
 
 #include "oboe/AudioClock.h"
 #include "oboe/AudioStream.h"
+
+#include <algorithm>
+
 #include "oboe/Utilities.h"
 #include "OboeDebug.h"
 


### PR DESCRIPTION
Fixes build errors caused by missing declarations of std::any_of
and std::clamp by explicitly including <algorithm>.