### PR TITLE
OboeTester: Remove arrows from spinners that leave the view

### DIFF
--- a/apps/OboeTester/app/src/main/res/layout/stream_config.xml
+++ b/apps/OboeTester/app/src/main/res/layout/stream_config.xml
@@ -24,6 +24,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:shrinkColumns="1"
+            android:background="#00FFFFFF"
             >
 
             <TableRow>


### PR DESCRIPTION
Fixes #2307 