### PR TITLE
fxlab: Add default effects

### DIFF
--- a/apps/fxlab/app/src/main/kotlin/com/mobileer/androidfxlab/MainActivity.kt
+++ b/apps/fxlab/app/src/main/kotlin/com/mobileer/androidfxlab/MainActivity.kt
@@ -154,7 +154,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun addDefaultEffects() {
-        val defaultEffects = listOf("Overdrive", "White Chorus", "Echo")
+        val defaultEffects = listOf("Gain", "Echo", "Tremolo")
         for (effectName in defaultEffects) {
             NativeInterface.effectDescriptionMap[effectName]?.let {
                 val toAdd = Effect(it)


### PR DESCRIPTION
Add a set of reasonable default effects:
1. Gain: This lets you increase the volume of the output.
2. Echo: This will create a sense of space and ambience with decaying repeats of the sound.
3. Tremolo: This produced a rapid wavering sound.