### PR TITLE
Add a collection to track the life time for aaudio streams.

### DIFF
--- a/include/oboe/AudioStream.h
+++ b/include/oboe/AudioStream.h
@@ -780,6 +780,13 @@ public:
         return ResultWithValue<PlaybackParameters>(Result::ErrorUnimplemented);
     }
 
+    /*
+     * Make a shared_ptr that will prevent this stream from being deleted.
+     */
+    std::shared_ptr<oboe::AudioStream> lockWeakThis() {
+        return mWeakThis.lock();
+    }
+
 protected:
 
     /**
@@ -887,13 +894,6 @@ protected:
      */
     void setWeakThis(std::shared_ptr<oboe::AudioStream> &sharedStream) {
         mWeakThis = sharedStream;
-    }
-
-    /*
-     * Make a shared_ptr that will prevent this stream from being deleted.
-     */
-    std::shared_ptr<oboe::AudioStream> lockWeakThis() {
-        return mWeakThis.lock();
     }
 
     std::weak_ptr<AudioStream> mWeakThis; // weak pointer to this object


### PR DESCRIPTION
There can be callback fired by the framework at any time. The callback is called with raw pointer. To avoid use after free crash, create a collection class to track the life time for all aaudio streams.

Fixes #2007.