### PR TITLE
Refactor: Use View Binding and remove Data Binding

### DIFF
--- a/apps/fxlab/app/build.gradle
+++ b/apps/fxlab/app/build.gradle
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
-
-apply plugin: 'kotlin-android'
-
-apply plugin: 'kotlin-kapt'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 android {
     compileSdkVersion 36
@@ -30,6 +29,9 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    buildFeatures {
+        viewBinding true
     }
     buildTypes {
         release {
@@ -48,9 +50,6 @@ android {
         cmake {
             path "./CMakeLists.txt"
         }
-    }
-    dataBinding {
-        enabled = true
     }
     namespace 'com.mobileer.androidfxlab'
 }

--- a/apps/fxlab/app/src/main/kotlin/com/mobileer/androidfxlab/MainActivity.kt
+++ b/apps/fxlab/app/src/main/kotlin/com/mobileer/androidfxlab/MainActivity.kt
@@ -37,7 +37,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.databinding.DataBindingUtil
 import com.mobileer.androidfxlab.databinding.ActivityMainBinding
 import com.mobileer.androidfxlab.datatype.Effect
 
@@ -52,7 +51,9 @@ class MainActivity : AppCompatActivity() {
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
         setSupportActionBar(binding.toolbar)
 
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/apps/fxlab/app/src/main/res/layout/activity_main.xml
+++ b/apps/fxlab/app/src/main/res/layout/activity_main.xml
@@ -15,8 +15,6 @@
   ~ limitations under the License.
   -->
 
-<layout>
-
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -61,4 +59,3 @@
         app:srcCompat="@drawable/ic_add" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</layout>


### PR DESCRIPTION
Switches `MainActivity.kt` from using Data Binding to using View Binding. This was possible after removing the root `<layout>` tag from `activity_main.xml`, as the file was only using the layout wrapper for view access.

This change:
* Removes the dependency on Data Binding utilities (`DataBindingUtil`).
* Eliminates the need for the `kotlin-kapt` plugin and the (implicit) `databinding-compiler` dependency, simplifying the build process.
* Modern Android prefers KSP and so removing KAPT makes this module compatible with current apps builds.