### PR TITLE
Add check for disconnected stream in close method

### DIFF
--- a/src/common/AudioStream.cpp
+++ b/src/common/AudioStream.cpp
@@ -44,8 +44,11 @@ AudioStream::~AudioStream() {
 Result AudioStream::close() {
     closePerformanceHint();
     // Update local counters so they can be read after the close.
-    updateFramesWritten();
-    updateFramesRead();
+    // But don't update the counters if the stream is disconnected.
+    if (mErrorCallbackResult != Result::ErrorDisconnected) {
+        updateFramesWritten();
+        updateFramesRead();
+    }
     return Result::OK;
 }
 


### PR DESCRIPTION
Prevent updating frame counters if the stream is disconnected.

Fixes #2329