### PR TITLE
Re-open stream when MMAP is disabled

### DIFF
--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
@@ -38,6 +38,7 @@ void PowerPlayMultiPlayer::setupAudioStream(int32_t channelCount,
 bool PowerPlayMultiPlayer::openStream(oboe::PerformanceMode performanceMode) {
     __android_log_print(ANDROID_LOG_INFO, TAG, "openStream()");
     mLastPerformanceMode = performanceMode;
+    mLastMMapEnabled = isMMapEnabled();
 
     // Use shared_ptr to prevent use of a deleted callback.
     mDataCallback = std::make_shared<MyDataCallback>(this);
@@ -131,10 +132,10 @@ void PowerPlayMultiPlayer::triggerDown(int32_t index, oboe::PerformanceMode perf
         return;
     }
 
-    // If the performance mode has changed, or if MMAP is disabled but currently used,
-    bool isMMapGlobal = isMMapEnabled();
-    bool isMMapCurrentlyUsed = OboeExtensions::isMMapUsed(mAudioStream.get());
-    if (performanceMode != mLastPerformanceMode || (!isMMapGlobal && isMMapCurrentlyUsed)) {
+    // If the performance mode has changed, we need to reopen the stream.
+    // Also reopen if the user has changed the MMAP policy (enabled/disabled) since the stream was opened.
+    if (performanceMode != mLastPerformanceMode ||
+        isMMapEnabled() != mLastMMapEnabled) {
         teardownAudioStream();
 
         // Attempt here to reopen the stream with the new performance mode.

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
@@ -67,6 +67,8 @@ private:
     std::shared_ptr<MyPresentationCallback> mPresentationCallback;
 
     oboe::PerformanceMode mLastPerformanceMode;
+
+    bool mLastMMapEnabled;
 };
 
 #endif //SAMPLES_POWERPLAYMULTIPLAYER_H


### PR DESCRIPTION
This fixes a bug where the stream would not restart if MMAP setting was changed