### PR TITLE
Fix flushOnFrame producing times where 0 is peered out

### DIFF
--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
@@ -160,12 +160,14 @@ void PowerPlayMultiPlayer::triggerDown(int32_t index, oboe::PerformanceMode perf
         const auto isPlayHeadAtStart = mSampleSources[index]->getPlayHeadPosition() == 0;
 
         if (isOffloaded && isPlayHeadAtStart) {
-            const auto result = mAudioStream->flushFromFrame(FlushFromAccuracy::Undefined, 0);
-            if (result != Result::OK) {
-                __android_log_print(ANDROID_LOG_ERROR,
-                                    TAG,
-                                    "Failed to flush from frame. Error: %s",
-                                    convertToText(result.error()));
+            if (mAudioStream->getFramesWritten() > 0) {
+                const auto result = mAudioStream->flushFromFrame(FlushFromAccuracy::Undefined, 0);
+                if (result != Result::OK) {
+                    __android_log_print(ANDROID_LOG_ERROR,
+                                        TAG,
+                                        "Failed to flush from frame. Error: %s",
+                                        convertToText(result.error()));
+                }
             }
         }
     }


### PR DESCRIPTION
This addresses and issue where 0 frame from the flushonframe were being called, this causing audio to drop (sometimes)

10-14 09:05:04.351 12339 12339 E AudioStreamInternalPlay_Client: flushFromFrame_l() do not have enough data, safePosition=5760, frameWritten=0