### PR TITLE
Make ResultWithValue copy-assignable

### DIFF
--- a/include/oboe/ResultWithValue.h
+++ b/include/oboe/ResultWithValue.h
@@ -136,8 +136,8 @@ public:
     }
 
 private:
-    const T             mValue;
-    const oboe::Result  mError;
+    T             mValue;
+    oboe::Result  mError;
 };
 
 /**


### PR DESCRIPTION
The data members `mValue` and `mError` in the `ResultWithValue` class were previously declared as `const`. This prevented instances of `ResultWithValue` from being copy-assigned, as the compiler does not generate a copy assignment operator for classes with const members.

This change removes the `const` qualifier from these members.

This allows `ResultWithValue` objects to be reassigned after construction, increasing flexibility. For example, code patterns like this are now possible:

```
ResultWithValue<int> result = func1();
// ...later...
result = func2(); // This was not possible before
```

This aligns with general C++ recommendations ([abseil.io/tips/177](https://abseil.io/tips/177)) that types should be assignable unless they represent resources that cannot or should not be duplicated. While the previous design enforced immutability, the ability to assign to a ResultWithValue variable is often more practically useful.