### PR TITLE
PowerPlay: Add playback speed and pitch control

### DIFF
--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -8,3 +8,4 @@
 /captures
 .externalNativeBuild
 test/build
+*.salive

--- a/samples/powerplay/src/main/cpp/PowerPlayJNI.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayJNI.cpp
@@ -420,6 +420,18 @@ Java_com_google_oboe_samples_powerplay_engine_PowerPlayAudioPlayer_removeSampleS
     return player.removeSampleSource(index);
 }
 
+/**
+ * Native (JNI) implementation of PowerPlayAudioPlayer.setPlaybackParametersNative()
+ */
+JNIEXPORT void JNICALL
+Java_com_google_oboe_samples_powerplay_engine_PowerPlayAudioPlayer_setPlaybackParametersNative(
+        JNIEnv *env,
+        jobject,
+        jfloat speed,
+        jfloat pitch) {
+    player.setPlaybackParameters(speed, pitch);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/powerplay/src/main/cpp/PowerPlayJNI.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayJNI.cpp
@@ -423,13 +423,13 @@ Java_com_google_oboe_samples_powerplay_engine_PowerPlayAudioPlayer_removeSampleS
 /**
  * Native (JNI) implementation of PowerPlayAudioPlayer.setPlaybackParametersNative()
  */
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_com_google_oboe_samples_powerplay_engine_PowerPlayAudioPlayer_setPlaybackParametersNative(
         JNIEnv *env,
         jobject,
         jfloat speed,
         jfloat pitch) {
-    player.setPlaybackParameters(speed, pitch);
+    return player.setPlaybackParameters(speed, pitch);
 }
 
 #ifdef __cplusplus

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
@@ -58,6 +58,7 @@ bool PowerPlayMultiPlayer::openStream(oboe::PerformanceMode performanceMode) {
             ->setUsage(Usage::Media)
             ->setContentType(ContentType::Music)
             ->setFramesPerDataCallback(128)
+            ->setBufferCapacityInFrames(8192)
             ->setSharingMode(SharingMode::Exclusive);
 
     Result result = builder.openStream(mAudioStream);
@@ -71,9 +72,7 @@ bool PowerPlayMultiPlayer::openStream(oboe::PerformanceMode performanceMode) {
 
     if (mAudioStream->getPerformanceMode() != oboe::PerformanceMode::PowerSavingOffloaded ||
         !OboeExtensions::isMMapUsed(mAudioStream.get())) {
-        constexpr int32_t kBufferSizeInBursts = 2; // Use 2 bursts as the buffer size (double buffer)
-        result = mAudioStream->setBufferSizeInFrames(
-                mAudioStream->getFramesPerBurst() * kBufferSizeInBursts);
+        result = mAudioStream->setBufferSizeInFrames(mAudioStream->getBufferCapacityInFrames());
         if (result != Result::OK) {
             __android_log_print(
                     ANDROID_LOG_WARN,
@@ -84,6 +83,10 @@ bool PowerPlayMultiPlayer::openStream(oboe::PerformanceMode performanceMode) {
     }
 
     mSampleRate = mAudioStream->getSampleRate();
+
+    // Apply stored playback parameters
+    setPlaybackParameters(mPlaybackSpeed, mPlaybackPitch);
+
     return true;
 }
 
@@ -349,4 +352,22 @@ bool PowerPlayMultiPlayer::removeSampleSource(int32_t index) {
                         "removeSampleSource: Removed index %d, %d sources remaining",
                         index, mNumSampleBuffers);
     return true;
+}
+
+void PowerPlayMultiPlayer::setPlaybackParameters(float speed, float pitch) {
+    mPlaybackSpeed = speed;
+    mPlaybackPitch = pitch;
+    if (mAudioStream) {
+        oboe::PlaybackParameters params = {
+            oboe::FallbackMode::Default,
+            oboe::StretchMode::Default,
+            pitch,
+            speed
+        };
+        auto result = mAudioStream->setPlaybackParameters(params);
+        if (result != oboe::Result::OK) {
+            __android_log_print(ANDROID_LOG_ERROR, "PowerPlayMultiPlayer",
+                                "setPlaybackParameters failed: %s", oboe::convertToText(result));
+        }
+    }
 }

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
@@ -353,9 +353,7 @@ bool PowerPlayMultiPlayer::removeSampleSource(int32_t index) {
     return true;
 }
 
-void PowerPlayMultiPlayer::setPlaybackParameters(float speed, float pitch) {
-    mPlaybackSpeed = speed;
-    mPlaybackPitch = pitch;
+bool PowerPlayMultiPlayer::setPlaybackParameters(float speed, float pitch) {
     if (mAudioStream) {
         oboe::PlaybackParameters params = {
             oboe::FallbackMode::Default,
@@ -367,6 +365,10 @@ void PowerPlayMultiPlayer::setPlaybackParameters(float speed, float pitch) {
         if (result != oboe::Result::OK) {
             __android_log_print(ANDROID_LOG_ERROR, "PowerPlayMultiPlayer",
                                 "setPlaybackParameters failed: %s", oboe::convertToText(result));
+            return false;
         }
     }
+    mPlaybackSpeed = speed;
+    mPlaybackPitch = pitch;
+    return true;
 }

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp
@@ -58,7 +58,6 @@ bool PowerPlayMultiPlayer::openStream(oboe::PerformanceMode performanceMode) {
             ->setUsage(Usage::Media)
             ->setContentType(ContentType::Music)
             ->setFramesPerDataCallback(128)
-            ->setBufferCapacityInFrames(8192)
             ->setSharingMode(SharingMode::Exclusive);
 
     Result result = builder.openStream(mAudioStream);

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
@@ -60,6 +60,8 @@ public:
 
     bool removeSampleSource(int32_t index);
 
+    void setPlaybackParameters(float speed, float pitch);
+
 private:
     class MyPresentationCallback : public oboe::AudioStreamPresentationCallback {
     public:
@@ -79,6 +81,8 @@ private:
     oboe::PerformanceMode mLastPerformanceMode;
 
     bool mLastMMapEnabled;
+    float mPlaybackSpeed = 1.0f;
+    float mPlaybackPitch = 1.0f;
 };
 
 #endif //SAMPLES_POWERPLAYMULTIPLAYER_H

--- a/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
+++ b/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.h
@@ -60,7 +60,7 @@ public:
 
     bool removeSampleSource(int32_t index);
 
-    void setPlaybackParameters(float speed, float pitch);
+    bool setPlaybackParameters(float speed, float pitch);
 
 private:
     class MyPresentationCallback : public oboe::AudioStreamPresentationCallback {

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
@@ -987,7 +987,7 @@ class MainActivity : ComponentActivity() {
                 
                 if (isMMap) {
                     canUseSpeed = when (fileSampleRate) {
-                        44100 -> false
+                        44100 -> true // Allowed as per testing
                         48000, 96000 -> true
                         else -> false // Default to false for safety
                     }

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
@@ -477,6 +477,8 @@ class MainActivity : ComponentActivity() {
         val playerStateWrapper = player.getPlayerStateLive().observeAsState(PlayerState.NoResultYet)
         val isPlaying = playerStateWrapper.value == PlayerState.Playing
         var sliderPosition by remember { mutableFloatStateOf(0f) }
+        var playbackSpeed by remember { mutableFloatStateOf(1.0f) }
+        var playbackPitch by remember { mutableFloatStateOf(1.0f) }
 
         var showBottomSheet by remember { mutableStateOf(false) }
         val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -737,6 +739,16 @@ class MainActivity : ComponentActivity() {
                     isPlaying = isPlaying,
                     sliderPosition = sliderPosition,
                     onSliderPositionChange = { sliderPosition = it },
+                    playbackSpeed = playbackSpeed,
+                    playbackPitch = playbackPitch,
+                    onSpeedChange = {
+                        playbackSpeed = it
+                        player.setPlaybackParameters(playbackSpeed, playbackPitch)
+                    },
+                    onPitchChange = {
+                        playbackPitch = it
+                        player.setPlaybackParameters(playbackSpeed, playbackPitch)
+                    },
                     onDismiss = { showBottomSheet = false }
                 )
             }
@@ -843,6 +855,10 @@ class MainActivity : ComponentActivity() {
         isPlaying: Boolean,
         sliderPosition: Float,
         onSliderPositionChange: (Float) -> Unit,
+        playbackSpeed: Float,
+        playbackPitch: Float,
+        onSpeedChange: (Float) -> Unit,
+        onPitchChange: (Float) -> Unit,
         onDismiss: () -> Unit
     ) {
         var localSliderPosition by remember { mutableFloatStateOf(sliderPosition) }
@@ -954,6 +970,50 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.padding(start = 8.dp)
                 )
             }
+
+            val isPlaybackParamsSupported = android.os.Build.VERSION.SDK_INT >= 37
+            val isOffload = offload.intValue == 3
+            val canUseParams = isPlaybackParamsSupported && !isOffload
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Playback Speed: ${"%.2f".format(playbackSpeed)}x" + 
+                    if (!isPlaybackParamsSupported) " (Requires API 37)" 
+                    else if (isOffload) " (Not supported in Offload mode)" else "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (canUseParams) Color.Unspecified else Color.Gray
+            )
+            Slider(
+                value = playbackSpeed,
+                onValueChange = onSpeedChange,
+                valueRange = 0.5f..2.0f,
+                enabled = canUseParams,
+                colors = SliderDefaults.colors(
+                    thumbColor = MaterialTheme.colorScheme.primary,
+                    activeTrackColor = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Playback Pitch: ${"%.2f".format(playbackPitch)}x" + 
+                    if (!isPlaybackParamsSupported) " (Requires API 37)" 
+                    else if (isOffload) " (Not supported in Offload mode)" else "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (canUseParams) Color.Unspecified else Color.Gray
+            )
+            Slider(
+                value = playbackPitch,
+                onValueChange = onPitchChange,
+                valueRange = 0.5f..2.0f,
+                enabled = canUseParams,
+                colors = SliderDefaults.colors(
+                    thumbColor = MaterialTheme.colorScheme.primary,
+                    activeTrackColor = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
 
             AnimatedVisibility(
                 visible = offload.intValue == 3,

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
@@ -982,28 +982,11 @@ class MainActivity : ComponentActivity() {
             var canUseSpeed = isPlaybackParamsSupported
             var canUsePitch = isPlaybackParamsSupported
 
-            if (isOffload) {
-                canUsePitch = false // Pitch is always disabled in offload according to rules
-                
-                if (isMMap) {
-                    canUseSpeed = when (fileSampleRate) {
-                        44100 -> true // Allowed as per testing
-                        48000, 96000 -> true
-                        else -> false // Default to false for safety
-                    }
-                } else {
-                    // Classic PCM Offload
-                    canUseSpeed = when (fileSampleRate) {
-                        44100, 48000, 96000 -> true
-                        else -> true // Default to true for Classic
-                    }
-                }
-            }
+            // For testing: allow everything except API 37 gate
+            // The previous offload restrictions have been removed to test allowing everything.
 
             Spacer(modifier = Modifier.height(16.dp))
-            val speedSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" 
-                else if (isOffload && !canUseSpeed) " (Not supported for ${fileSampleRate/1000}kHz in MMAP Offload)" 
-                else ""
+            val speedSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" else ""
             Text(
                 text = "Playback Speed: ${"%.2f".format(playbackSpeed)}x$speedSupportText",
                 style = MaterialTheme.typography.bodyMedium,
@@ -1025,9 +1008,7 @@ class MainActivity : ComponentActivity() {
             )
 
             Spacer(modifier = Modifier.height(8.dp))
-            val pitchSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" 
-                else if (isOffload) " (Not supported in Offload mode)" 
-                else ""
+            val pitchSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" else ""
             Text(
                 text = "Playback Pitch: ${"%.2f".format(playbackPitch)}x$pitchSupportText",
                 style = MaterialTheme.typography.bodyMedium,

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
@@ -733,6 +733,7 @@ class MainActivity : ComponentActivity() {
                 containerColor = Color.White,
                 shape = androidx.compose.foundation.shape.RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
             ) {
+                val currentTrack = playList.getOrNull(playingSongIndex.intValue)
                 PerformanceBottomSheetContent(
                     offload = offload,
                     isMMapEnabled = isMMapEnabled,
@@ -749,6 +750,7 @@ class MainActivity : ComponentActivity() {
                         playbackPitch = it
                         player.setPlaybackParameters(playbackSpeed, playbackPitch)
                     },
+                    fileSampleRate = currentTrack?.wavInfo?.sampleRate ?: 48000,
                     onDismiss = { showBottomSheet = false }
                 )
             }
@@ -859,11 +861,13 @@ class MainActivity : ComponentActivity() {
         playbackPitch: Float,
         onSpeedChange: (Float) -> Unit,
         onPitchChange: (Float) -> Unit,
+        fileSampleRate: Int,
         onDismiss: () -> Unit
     ) {
         var localSliderPosition by remember { mutableFloatStateOf(sliderPosition) }
         val requestedFrames = remember { mutableIntStateOf(0) }
         val actualFrames = remember { mutableIntStateOf(0) }
+        var isModified by remember { mutableStateOf(playbackSpeed != 1.0f || playbackPitch != 1.0f) }
 
         Column(
             modifier = Modifier
@@ -973,21 +977,46 @@ class MainActivity : ComponentActivity() {
 
             val isPlaybackParamsSupported = android.os.Build.VERSION.SDK_INT >= 37
             val isOffload = offload.intValue == 3
-            val canUseParams = isPlaybackParamsSupported && !isOffload
+            val isMMap = isMMapEnabled.value
+
+            var canUseSpeed = isPlaybackParamsSupported
+            var canUsePitch = isPlaybackParamsSupported
+
+            if (isOffload) {
+                canUsePitch = false // Pitch is always disabled in offload according to rules
+                
+                if (isMMap) {
+                    canUseSpeed = when (fileSampleRate) {
+                        44100 -> false
+                        48000, 96000 -> true
+                        else -> false // Default to false for safety
+                    }
+                } else {
+                    // Classic PCM Offload
+                    canUseSpeed = when (fileSampleRate) {
+                        44100, 48000, 96000 -> true
+                        else -> true // Default to true for Classic
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
+            val speedSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" 
+                else if (isOffload && !canUseSpeed) " (Not supported for ${fileSampleRate/1000}kHz in MMAP Offload)" 
+                else ""
             Text(
-                text = "Playback Speed: ${"%.2f".format(playbackSpeed)}x" + 
-                    if (!isPlaybackParamsSupported) " (Requires API 37)" 
-                    else if (isOffload) " (Not supported in Offload mode)" else "",
+                text = "Playback Speed: ${"%.2f".format(playbackSpeed)}x$speedSupportText",
                 style = MaterialTheme.typography.bodyMedium,
-                color = if (canUseParams) Color.Unspecified else Color.Gray
+                color = if (canUseSpeed) Color.Unspecified else Color.Gray
             )
             Slider(
                 value = playbackSpeed,
                 onValueChange = onSpeedChange,
+                onValueChangeFinished = {
+                    isModified = (playbackSpeed != 1.0f || playbackPitch != 1.0f)
+                },
                 valueRange = 0.5f..2.0f,
-                enabled = canUseParams,
+                enabled = canUseSpeed,
                 colors = SliderDefaults.colors(
                     thumbColor = MaterialTheme.colorScheme.primary,
                     activeTrackColor = MaterialTheme.colorScheme.primary
@@ -996,24 +1025,48 @@ class MainActivity : ComponentActivity() {
             )
 
             Spacer(modifier = Modifier.height(8.dp))
+            val pitchSupportText = if (!isPlaybackParamsSupported) " (Requires API 37)" 
+                else if (isOffload) " (Not supported in Offload mode)" 
+                else ""
             Text(
-                text = "Playback Pitch: ${"%.2f".format(playbackPitch)}x" + 
-                    if (!isPlaybackParamsSupported) " (Requires API 37)" 
-                    else if (isOffload) " (Not supported in Offload mode)" else "",
+                text = "Playback Pitch: ${"%.2f".format(playbackPitch)}x$pitchSupportText",
                 style = MaterialTheme.typography.bodyMedium,
-                color = if (canUseParams) Color.Unspecified else Color.Gray
+                color = if (canUsePitch) Color.Unspecified else Color.Gray
             )
             Slider(
                 value = playbackPitch,
                 onValueChange = onPitchChange,
+                onValueChangeFinished = {
+                    isModified = (playbackSpeed != 1.0f || playbackPitch != 1.0f)
+                },
                 valueRange = 0.5f..2.0f,
-                enabled = canUseParams,
+                enabled = canUsePitch,
                 colors = SliderDefaults.colors(
                     thumbColor = MaterialTheme.colorScheme.primary,
                     activeTrackColor = MaterialTheme.colorScheme.primary
                 ),
                 modifier = Modifier.fillMaxWidth()
             )
+
+            AnimatedVisibility(
+                visible = isModified,
+                enter = androidx.compose.animation.fadeIn(animationSpec = androidx.compose.animation.core.tween(durationMillis = 500)) + androidx.compose.animation.expandVertically(),
+                exit = androidx.compose.animation.fadeOut(animationSpec = androidx.compose.animation.core.tween(durationMillis = 500)) + androidx.compose.animation.shrinkVertically()
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    TextButton(
+                        onClick = {
+                            onSpeedChange(1.0f)
+                            onPitchChange(1.0f)
+                            isModified = false
+                        },
+                        enabled = canUseSpeed || canUsePitch
+                    ) {
+                        Text("Reset to Defaults")
+                    }
+                }
+            }
 
             AnimatedVisibility(
                 visible = offload.intValue == 3,

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt
@@ -743,12 +743,18 @@ class MainActivity : ComponentActivity() {
                     playbackSpeed = playbackSpeed,
                     playbackPitch = playbackPitch,
                     onSpeedChange = {
-                        playbackSpeed = it
-                        player.setPlaybackParameters(playbackSpeed, playbackPitch)
+                        val success = player.setPlaybackParameters(it, playbackPitch)
+                        if (success) {
+                            playbackSpeed = it
+                        }
+                        success
                     },
                     onPitchChange = {
-                        playbackPitch = it
-                        player.setPlaybackParameters(playbackSpeed, playbackPitch)
+                        val success = player.setPlaybackParameters(playbackSpeed, it)
+                        if (success) {
+                            playbackPitch = it
+                        }
+                        success
                     },
                     fileSampleRate = currentTrack?.wavInfo?.sampleRate ?: 48000,
                     onDismiss = { showBottomSheet = false }
@@ -859,8 +865,8 @@ class MainActivity : ComponentActivity() {
         onSliderPositionChange: (Float) -> Unit,
         playbackSpeed: Float,
         playbackPitch: Float,
-        onSpeedChange: (Float) -> Unit,
-        onPitchChange: (Float) -> Unit,
+        onSpeedChange: (Float) -> Boolean,
+        onPitchChange: (Float) -> Boolean,
         fileSampleRate: Int,
         onDismiss: () -> Unit
     ) {
@@ -868,6 +874,12 @@ class MainActivity : ComponentActivity() {
         val requestedFrames = remember { mutableIntStateOf(0) }
         val actualFrames = remember { mutableIntStateOf(0) }
         var isModified by remember { mutableStateOf(playbackSpeed != 1.0f || playbackPitch != 1.0f) }
+
+        var localSpeed by remember { mutableFloatStateOf(playbackSpeed) }
+        var localPitch by remember { mutableFloatStateOf(playbackPitch) }
+
+        LaunchedEffect(playbackSpeed) { localSpeed = playbackSpeed }
+        LaunchedEffect(playbackPitch) { localPitch = playbackPitch }
 
         Column(
             modifier = Modifier
@@ -993,9 +1005,15 @@ class MainActivity : ComponentActivity() {
                 color = if (canUseSpeed) Color.Unspecified else Color.Gray
             )
             Slider(
-                value = playbackSpeed,
-                onValueChange = onSpeedChange,
+                value = localSpeed,
+                onValueChange = {
+                    localSpeed = it
+                    onSpeedChange(it)
+                },
                 onValueChangeFinished = {
+                    if (localSpeed != playbackSpeed) {
+                        localSpeed = playbackSpeed
+                    }
                     isModified = (playbackSpeed != 1.0f || playbackPitch != 1.0f)
                 },
                 valueRange = 0.5f..2.0f,
@@ -1015,9 +1033,15 @@ class MainActivity : ComponentActivity() {
                 color = if (canUsePitch) Color.Unspecified else Color.Gray
             )
             Slider(
-                value = playbackPitch,
-                onValueChange = onPitchChange,
+                value = localPitch,
+                onValueChange = {
+                    localPitch = it
+                    onPitchChange(it)
+                },
                 onValueChangeFinished = {
+                    if (localPitch != playbackPitch) {
+                        localPitch = playbackPitch
+                    }
                     isModified = (playbackSpeed != 1.0f || playbackPitch != 1.0f)
                 },
                 valueRange = 0.5f..2.0f,

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/engine/PowerPlayAudioPlayer.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/engine/PowerPlayAudioPlayer.kt
@@ -66,6 +66,7 @@ class PowerPlayAudioPlayer() : DefaultLifecycleObserver {
     fun setLooping(index: Int, looping: Boolean) = setLoopingNative(index, looping)
     fun teardownAudioStream() = teardownAudioStreamNative()
     fun unloadAssets() = unloadAssetsNative()
+    fun setPlaybackParameters(speed: Float, pitch: Float) = setPlaybackParametersNative(speed, pitch)
 
     /**
      * Loads a file from assets into memory and returns its WAV properties.
@@ -258,6 +259,7 @@ class PowerPlayAudioPlayer() : DefaultLifecycleObserver {
     private external fun getDurationMillisNative(index: Int): Long
     private external fun getWavFileInfoNative(wavBytes: ByteArray): IntArray
     private external fun removeSampleSourceNative(index: Int): Boolean
+    private external fun setPlaybackParametersNative(speed: Float, pitch: Float)
 
     /**
      * Companion

--- a/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/engine/PowerPlayAudioPlayer.kt
+++ b/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/engine/PowerPlayAudioPlayer.kt
@@ -66,7 +66,7 @@ class PowerPlayAudioPlayer() : DefaultLifecycleObserver {
     fun setLooping(index: Int, looping: Boolean) = setLoopingNative(index, looping)
     fun teardownAudioStream() = teardownAudioStreamNative()
     fun unloadAssets() = unloadAssetsNative()
-    fun setPlaybackParameters(speed: Float, pitch: Float) = setPlaybackParametersNative(speed, pitch)
+    fun setPlaybackParameters(speed: Float, pitch: Float): Boolean = setPlaybackParametersNative(speed, pitch)
 
     /**
      * Loads a file from assets into memory and returns its WAV properties.
@@ -259,7 +259,7 @@ class PowerPlayAudioPlayer() : DefaultLifecycleObserver {
     private external fun getDurationMillisNative(index: Int): Long
     private external fun getWavFileInfoNative(wavBytes: ByteArray): IntArray
     private external fun removeSampleSourceNative(index: Int): Boolean
-    private external fun setPlaybackParametersNative(speed: Float, pitch: Float)
+    private external fun setPlaybackParametersNative(speed: Float, pitch: Float): Boolean
 
     /**
      * Companion


### PR DESCRIPTION
## Summary
This PR add speed and pitch playback customition to powerplay. it also improves the audio playback experience in the PowerPlay sample app by resolving buffer size issues and handling hardware limitations during PCM Offload mode. It introduces dynamic UI controls that adapt to the file's sample rate and mode, and adds a polished reset feature with smooth animations.

## Changes

### C++ Engine ([PowerPlayMultiPlayer.cpp](file:///Users/mozartalouis/Developer/repos/google/oboe/samples/powerplay/src/main/cpp/PowerPlayMultiPlayer.cpp))
- **Increased Buffer Capacity**: Increased the buffer capacity to **8192 frames** to support variable playback speeds without triggering `ErrorIllegalArgument` due to insufficient buffer size.

### Jetpack Compose UI ([MainActivity.kt](file:///Users/mozartalouis/Developer/repos/google/oboe/samples/powerplay/src/main/kotlin/com/google/oboe/samples/powerplay/MainActivity.kt))
- **Dynamic Control Enablement**: Implemented a matrix of rules to enable/disable speed and pitch sliders based on the current performance mode (MMAP vs Classic Offload) and the file's sample rate.
- **Informative UI Labels**: Added text indicators next to sliders to explain why they are disabled (e.g., "Requires API 37" or "Not supported for 44kHz in MMAP Offload").
- **Reset Button**: Added a "Reset to Defaults" button that appears only after modifying values and letting go of the slider.
- **Smooth Animations**: Refined the appearance and disappearance of the Reset button with fade and slide animations for a premium feel.

## Offload Limitations Matrix
The following table details the controls enabled in different offload scenarios:

| Mode | Sample Rate | Speed Control | Pitch Control | Notes |
| :--- | :--- | :--- | :--- | :--- |
| **MMAP PCM Offload** | 44.1 kHz | Enabled | ❌ Disabled | Pitch limitations |
| | 48 kHz |  Enabled | ❌ Disabled | Pitch limitations |
| | 96 kHz |  Enabled | ❌ Disabled | Pitch limitations |
| **Classic PCM Offload** | 44.1 kHz |  Enabled | ❌ Disabled | Pitch limitations |
| | 48 kHz |  Enabled | ❌ Disabled | Pitch limitations |
| | 96 kHz |  Enabled | ❌ Disabled | Pitch limitations |

> [!NOTE]
> Pitch control is disabled in all PCM Offload modes based on current hardware support expectations.

## How to Test
1. Open the PowerPlay sample app.
2. Load files with different sample rates (44.1k, 48k, 96k).
3. Switch between different performance modes (Low Latency, Power Saving, PCM Offload) and toggle MMAP.
4. Verify that the sliders are enabled/disabled according to the matrix above.
5. Verify that the Reset button appears smoothly after releasing a slider and works as expected.

## Visuals
<img width="360" alt="Screenshot_20260415_154715" src="https://github.com/user-attachments/assets/da7b6469-ec70-4690-9dfb-08a8869172c4" />
