### PR TITLE
OboeTester: Move setMode inside CommunicationDeviceView

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/CommunicationDeviceView.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/CommunicationDeviceView.java
@@ -31,6 +31,7 @@ import android.widget.AdapterView;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Spinner;
 
 import com.mobileer.audio_device.CommunicationDeviceSpinner;
 
@@ -44,6 +45,7 @@ public class CommunicationDeviceView extends LinearLayout {
     private BroadcastReceiver mScoStateReceiver;
     private boolean mScoStateReceiverRegistered = false;
     private CommunicationDeviceSpinner mDeviceSpinner;
+    private Spinner mModeSpinner;
     private int mScoState;
 
     private AudioManager.OnCommunicationDeviceChangedListener mCommDeviceListener;
@@ -141,6 +143,19 @@ public class CommunicationDeviceView extends LinearLayout {
             }
         });
 
+        mModeSpinner = (Spinner) findViewById(R.id.spinnerAudioMode);
+        mModeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                Log.d("OboeTester", "CommunicationDeviceView: setting audio mode to " + l);
+                mAudioManager.setMode((int) l);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+            }
+        });
+
         showCommDeviceStatus();
     }
 
@@ -168,6 +183,7 @@ public class CommunicationDeviceView extends LinearLayout {
                 mAudioManager.removeOnCommunicationDeviceChangedListener(mCommDeviceListener);
             }
         }
+        mAudioManager.setMode(AudioManager.MODE_NORMAL);
     }
 
     public void onSetSpeakerphoneOn(View view) {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/MainActivity.java
@@ -50,7 +50,7 @@ public class MainActivity extends BaseOboeTesterActivity {
     public static final String VALUE_TEST_NAME_INPUT = "input";
     public static final String VALUE_TEST_NAME_CPU_LOAD = "cpu_load";
 
-    private Spinner mModeSpinner;
+
     private TextView mCallbackSizeEditor;
     protected TextView mDeviceView;
     private TextView mVersionTextView;
@@ -77,22 +77,6 @@ public class MainActivity extends BaseOboeTesterActivity {
 
         mDeviceView = (TextView) findViewById(R.id.deviceView);
         updateNativeAudioUI();
-
-        // Set mode, eg. MODE_IN_COMMUNICATION
-        mModeSpinner = (Spinner) findViewById(R.id.spinnerAudioMode);
-        // Update AudioManager now in case user is trying to affect a different app.
-        mModeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                long mode = mModeSpinner.getSelectedItemId();
-                AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-                myAudioMgr.setMode((int)mode);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> adapterView) {
-            }
-        });
 
         try {
             PackageInfo pinfo = getPackageManager().getPackageInfo(getPackageName(), 0);
@@ -271,9 +255,7 @@ public class MainActivity extends BaseOboeTesterActivity {
     private void applyUserOptions() {
         updateCallbackSize();
 
-        long mode = mModeSpinner.getSelectedItemId();
-        AudioManager myAudioMgr = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        myAudioMgr.setMode((int) mode);
+
 
         NativeEngine.setWorkaroundsEnabled(mWorkaroundsCheckBox.isChecked());
         TestAudioActivity.setBackgroundEnabled(mBackgroundCheckBox.isChecked());

--- a/apps/OboeTester/app/src/main/res/layout/activity_main.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_main.xml
@@ -248,19 +248,6 @@
             android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/textView2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Mode:" />
-
-            <Spinner
-                android:id="@+id/spinnerAudioMode"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:entries="@array/audio_modes"
-                android:prompt="@string/audio_mode_prompt" />
-
-            <TextView
                 android:id="@+id/deviceView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/apps/OboeTester/app/src/main/res/layout/comm_device_view.xml
+++ b/apps/OboeTester/app/src/main/res/layout/comm_device_view.xml
@@ -10,6 +10,23 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Audio Mode: " />
+
+        <Spinner
+            android:id="@+id/spinnerAudioMode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/audio_modes" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
         <CheckBox
             android:id="@+id/setSpeakerphoneOn"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #2371 

On new Android versions, AudioManager.setMode() now clears if it's not used within 6 seconds.

AudioManager.setMode() is also deprecated in favor of AudioManager.setCommunicationDevice(AudioDeviceInfo).

Thus, moving setMode() next to the communication device view.