### PR TITLE
[Frequency tests] Optimize the input process

### DIFF
--- a/apps/OboeTester/app/CMakeLists.txt
+++ b/apps/OboeTester/app/CMakeLists.txt
@@ -19,6 +19,9 @@ add_library(oboetester SHARED ${app_native_sources})
 # Set the path to the Oboe library directory
 set (OBOE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
+# Set the path to the app source directory
+set (APP_NATIVE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp)
+
 # Add the Oboe library as a subproject. Since Oboe is an out-of-tree source library we must also
 # specify a binary directory
 add_subdirectory(${OBOE_DIR} ./oboe-bin)
@@ -27,6 +30,7 @@ add_subdirectory(${OBOE_DIR} ./oboe-bin)
 include_directories(
     ${OBOE_DIR}/include
     ${OBOE_DIR}/src
+    ${APP_NATIVE_SOURCE_DIR}
 )
 
 ### END OBOE INCLUDE SECTION ###

--- a/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
+++ b/apps/OboeTester/app/src/main/cpp/NativeAudioContext.h
@@ -885,6 +885,11 @@ class ActivityFrequency : public ActivityFullDuplex {
       return mFullDuplexAnalyzer->start();
   }
 
+  oboe::Result stop() override {
+      mFrequencyAnalyzer.stop();
+      return ActivityFullDuplex::stop();
+  }
+
   void configureBuilder(bool isInput, oboe::AudioStreamBuilder &builder) override;
 
   void setSignalType(int signalType) override {

--- a/apps/OboeTester/app/src/main/cpp/analyzer/FrequencyAnalyzer.cpp
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/FrequencyAnalyzer.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "FrequencyAnalyzer.h"
 #include <math.h>
-#include "fft.h"
+#include "FrequencyAnalyzer.h"
+#include "android_debug.h"
 
 FrequencyAnalyzer::FrequencyAnalyzer() : LoopbackProcessor() {
     mWindow.resize(WINDOW_SIZE);
@@ -29,31 +29,66 @@ FrequencyAnalyzer::FrequencyAnalyzer() : LoopbackProcessor() {
     }
     mInputBuffer.resize(WINDOW_SIZE);
     mAverageBuffer.resize(WINDOW_SIZE / 2);
+    mFftThreadInput.resize(WINDOW_SIZE);
 
     mInputBufferIndex = 0;
     mFramesAccumulated = 0;
     mOutputPhase = 0.0f;
 
+    mFftThreadFlag = FFT_THREAD_WAITTING;
+    mFftThread = nullptr;
     std::lock_guard<std::mutex> lock(mFftBufferLock);
     mFftMagnitudeBuffer.clear();
+}
+
+FrequencyAnalyzer::~FrequencyAnalyzer() {
+    joinFftThread();
+}
+
+void FrequencyAnalyzer::joinFftThread() {
+    if (mFftThread != nullptr && mFftThread->joinable()) {
+        {
+            std::lock_guard<std::mutex> lock(mFftThreadLock);
+            mFftThreadFlag = FFT_THREAD_END;
+            mFftThreadCond.notify_one();
+        }
+        mFftThread->join();
+        mFftThread = nullptr;
+    }
 }
 
 void FrequencyAnalyzer::reset() {
+    LOGD("FrequencyAnalyzer resets");
     LoopbackProcessor::reset();
     mInputBufferIndex = 0;
     mOutputPhase = 0.0f;
-
-    mAverageBuffer.clear();
-    mFramesAccumulated = 0;
-
-    std::lock_guard<std::mutex> lock(mFftBufferLock);
-    mFftMagnitudeBuffer.clear();
+    
+    // Reset resources for fft thread
+    {
+        std::lock_guard<std::mutex> threadLock(mFftThreadLock);
+        mAverageBuffer.clear();
+        mFramesAccumulated = 0;
+    }
+    // Clean output buffer
+    {
+        std::lock_guard<std::mutex> lock(mFftBufferLock);
+        mFftMagnitudeBuffer.clear();
+    }
 }
 
 void FrequencyAnalyzer::prepareToTest() {
+    LOGD("FrequencyAnalyzer prepares to test");
     LoopbackProcessor::prepareToTest();
     mPhaseIncrement = 2.0 * M_PI * SINE_WAVE_FREQUENCY / getSampleRate();
     mMeasurementWindowFrames = MEASUREMENT_TIME_SEC * getSampleRate();
+    joinFftThread();
+    mFftThreadFlag = FFT_THREAD_WAITTING;
+    mFftThread = std::make_unique<std::thread>(&FrequencyAnalyzer::fftThreadFunction, this);
+}
+
+void FrequencyAnalyzer::stop() {
+    LOGD("FrequencyAnalyzer stops");
+    joinFftThread();
 }
 
 LoopbackProcessor::result_code FrequencyAnalyzer::processInputFrame(const float* frameData,
@@ -61,50 +96,67 @@ LoopbackProcessor::result_code FrequencyAnalyzer::processInputFrame(const float*
     float sample = frameData[getInputChannel()];
     mInputBuffer[mInputBufferIndex++] = sample;
     if (mInputBufferIndex >= WINDOW_SIZE) {
-        // Perform FFT
-        std::lock_guard<std::mutex> lock(mFftBufferLock);
-        CVector fftInput(WINDOW_SIZE);
+        // Set data for FFT thread
+        std::lock_guard<std::mutex> lock(mFftThreadLock);
         for (int i = 0; i < WINDOW_SIZE; i++) {
             double windowed = mInputBuffer[i] * mWindow[i];
-            fftInput[i] = Complex(windowed, 0);
+            mFftThreadInput[i] = Complex(windowed, 0);
         }
-        fft(fftInput);
-
-        // Accumulate magnitude
-        std::vector<double> currentMagnitudes(WINDOW_SIZE / 2);
-        for (int i = 0; i < WINDOW_SIZE / 2; i++) {
-            double mag;
-            if (mSignalType == 1) { // Sine
-                mag = 2.0 * std::abs(fftInput[i]) / mWindowSum;
-            } else {
-                mag = 4.0 * std::abs(fftInput[i]) / std::sqrt(mIncoherentPower);
-            }
-            if (mag < 1e-9) mag = 1e-9; // to prevent log(0)
-            currentMagnitudes[i] = mag;
-        }
-        mAverageBuffer.accumulate(currentMagnitudes.data(),
-                                  currentMagnitudes.size());
+        mFftThreadFlag = FFT_THREAD_READY;
+        mFftThreadCond.notify_one();
         mInputBufferIndex = 0;
     }
 
-    mFramesAccumulated++;
-    if (mFramesAccumulated >= mMeasurementWindowFrames) {
-        // End of measurement window! Compute the average and save it to mFftMagnitudeBuffer
-        std::lock_guard<std::mutex> lock(mFftBufferLock);
-        if (mFftMagnitudeBuffer.empty()) {
-            // First measurement window
-            mFftMagnitudeBuffer.resize(WINDOW_SIZE / 2);
-        }
-        for (int i = 0; i < WINDOW_SIZE / 2; i++) {
-            double avgMag = mAverageBuffer.getAverageAt(i);
-            double dbfs = 20.0 * std::log10(avgMag);
-            mFftMagnitudeBuffer[i] = static_cast<float>(dbfs);
-        }
-        mAverageBuffer.clear();
-        mFramesAccumulated = 0;
-    }
-
     return RESULT_OK;
+}
+
+void FrequencyAnalyzer::fftThreadFunction() {
+    bool isRunning = true;
+    LOGI("Fft thread started");
+    while (isRunning) {
+        // Wait for data or end condition
+        std::unique_lock<std::mutex> lock(mFftThreadLock);
+        mFftThreadCond.wait(lock, [&] () { return mFftThreadFlag != FFT_THREAD_WAITTING;});
+
+        if (mFftThreadFlag == FFT_THREAD_READY) {
+            fft(mFftThreadInput);
+            // Accumulate magnitude
+            std::vector<double> currentMagnitudes(WINDOW_SIZE / 2);
+            for (int i = 0; i < WINDOW_SIZE / 2; i++) {
+                double mag;
+                if (mSignalType == 1) { // Sine
+                    mag = 2.0 * std::abs(mFftThreadInput[i]) / mWindowSum;
+                } else {
+                    mag = 4.0 * std::abs(mFftThreadInput[i]) / std::sqrt(mIncoherentPower);
+                }
+                if (mag < 1e-9) mag = 1e-9; // to prevent log(0)
+                currentMagnitudes[i] = mag;
+            }
+            mAverageBuffer.accumulate(currentMagnitudes.data(),
+                                      currentMagnitudes.size());
+            mFramesAccumulated += WINDOW_SIZE;
+            if (mFramesAccumulated >= mMeasurementWindowFrames) {
+                LOGD("Fft thread is exporting the result");
+                // End of measurement window! Compute the average and save it to mFftMagnitudeBuffer
+                std::lock_guard<std::mutex> outputLock(mFftBufferLock);
+                if (mFftMagnitudeBuffer.empty()) {
+                    // First measurement window
+                    mFftMagnitudeBuffer.resize(WINDOW_SIZE / 2);
+                }
+                for (int i = 0; i < WINDOW_SIZE / 2; i++) {
+                    double avgMag = mAverageBuffer.getAverageAt(i);
+                    double dbfs = 20.0 * std::log10(avgMag);
+                    mFftMagnitudeBuffer[i] = static_cast<float>(dbfs);
+                }
+                mAverageBuffer.clear();
+                mFramesAccumulated = 0;
+            }
+            mFftThreadFlag = FFT_THREAD_WAITTING;
+        } else if (mFftThreadFlag == FFT_THREAD_END) {
+            isRunning = false;
+        }
+    }
+    LOGI("Fft thread stopped");
 }
 
 void FrequencyAnalyzer::setSignalType(int signalType) {

--- a/apps/OboeTester/app/src/main/cpp/analyzer/FrequencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/FrequencyAnalyzer.h
@@ -20,10 +20,13 @@
 #include <vector>
 #include <mutex>
 #include <string>
+#include <thread>
+#include <condition_variable>
 #include "oboe/Oboe.h"
 #include "LatencyAnalyzer.h"
 #include "PseudoRandom.h"
 #include "AverageBuffer.h"
+#include "fft.h"
 
 /**
  * Analyze frequency response by playing a stimulus and measuring the input.
@@ -31,10 +34,11 @@
 class FrequencyAnalyzer : public LoopbackProcessor {
 public:
     FrequencyAnalyzer();
-    virtual ~FrequencyAnalyzer() = default;
+    virtual ~FrequencyAnalyzer();
 
     void reset() override;
     void prepareToTest() override;
+    void stop();
 
     result_code processInputFrame(const float* frameData,
                                   int channelCount) override;
@@ -54,6 +58,10 @@ private:
     const static int SINE_WAVE_FREQUENCY = 1000; // Hz
     const static int WINDOW_SIZE = 4096;
 
+    const static int FFT_THREAD_WAITTING = 0;
+    const static int FFT_THREAD_READY = 1;
+    const static int FFT_THREAD_END = 2;
+
     PseudoRandom mWhiteNoise;
     float mAmplitude = 0.8f;
     float mBalance = 0.5f;
@@ -71,6 +79,14 @@ private:
     AverageBuffer mAverageBuffer;
     int mMeasurementWindowFrames = 0;
     int mFramesAccumulated = 0;
+    std::mutex mFftThreadLock;
+    std::unique_ptr<std::thread> mFftThread;
+    std::condition_variable mFftThreadCond;
+    int mFftThreadFlag;
+    CVector mFftThreadInput;
+
+    void fftThreadFunction();
+    void joinFftThread();
 };
 
 #endif //OBOETESTER_FREQUENCYANALYZER_H


### PR DESCRIPTION
- At the end of a window data, a fft operation will be applied on the input data which cause underrun in the output stream.
<img width="150" height="337" alt="frequency_test_xrun_output" src="https://github.com/user-attachments/assets/36639e96-39e3-4914-91c4-dfa5f7f563cf" />

- This ticket create a worker thread to run fft separately.