### PR TITLE
Frequency enforcement mode

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
@@ -26,6 +26,8 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Spinner;
 import java.io.IOException;
+import android.media.AudioManager;
+import android.content.Context;
 
 public class DualFrequencyActivity extends AnalyzerActivity {
 
@@ -48,6 +50,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     private TextView mInstructionsView;
     private FrequencySettingView mFrequencySetting;
     private StreamConfigurationView mInputConfigView;
+    private TestSupervisor mTestSupervisor;
     private FrequencyAnalyzer mFrequencyAnalyzer = new FrequencyAnalyzer();
 
     private static final int WAVEFORM_UPDATE_MS = 500;
@@ -146,6 +149,17 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mStopButton1.setEnabled(false);
         mStartButton2.setEnabled(false);
         mStopButton2.setEnabled(false);
+
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.release();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -171,31 +185,137 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     public void onStartTest1(View view) {
         int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
         boolean failed = false;
-        try {
-            mCurrentTest = 1;
-            if (mInputConfigView != null) {
-                AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_BUILTIN_MIC);
-                if (device != null) {
-                    mInputConfigView.setDeviceById(device.getId());
+        mCurrentTest = 1;
+        if (mInputConfigView != null) {
+            AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_BUILTIN_MIC);
+            if (device != null) {
+                mInputConfigView.setDeviceById(device.getId());
+            } else {
+                mInputConfigView.setDeviceById(0); // Auto-select
+                if (enforcementLevel == ENFORCEMENT_HIGH) {
+                    failed = true;
                 } else {
-                    mInputConfigView.setDeviceById(0); // Auto-select
-                    if (enforcementLevel == ENFORCEMENT_HIGH) {
-                        failed = true;
-                    } else {
-                        showToast("WARNING: Preferred input device (BUILTIN_MIC) not found!");
-                    }
+                    showToast("WARNING: Preferred input device (BUILTIN_MIC) not found!");
                 }
             }
-            if (!checkPreferredOutput(enforcementLevel)) {
-                failed = true;
-            }
+        }
+        if (!checkPreferredOutput(enforcementLevel)) {
+            failed = true;
+        }
 
-            if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
-                mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
-                mTestResultView.setTextColor(Color.RED);
-                return;
-            }
+        if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
+            mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+            mTestResultView.setTextColor(Color.RED);
+            mStartButton2.setEnabled(false);
+            return;
+        }
 
+        if (enforcementLevel == ENFORCEMENT_HIGH) {
+            showMaxVolumeConfirmationDialog(1);
+        } else {
+            startTest1Actual();
+        }
+    }
+
+    public void onStopTest1(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
+        stopWaveformUpdater();
+        stopAudio();
+        closeAudio();
+        mStartButton1.setEnabled(true);
+        mStopButton1.setEnabled(false);
+        if (mEnforcementSpinner != null) {
+            mEnforcementSpinner.setEnabled(true);
+        }
+        keepScreenOn(false);
+
+        boolean test1Ok = true;
+        if (mTestSupervisor != null) {
+            mTestSupervisor.stop();
+            test1Ok = checkSupervisorEvents(enforcementLevel);
+        }
+
+        if (test1Ok) {
+            mStartButton2.setEnabled(true);
+            // Save the current buffer for subtraction
+            if (mWaveformBuffer != null) {
+                mTest1WaveformBuffer = mWaveformBuffer.clone();
+            }
+            mTestStatusView.setText("Status: Test 1 Stopped. Ready for Test 2.");
+        } else {
+            mStartButton2.setEnabled(false);
+            mTest1WaveformBuffer = null;
+            mTestStatusView.setText("Status: Test 1 FAILED. Please re-run Test 1.");
+        }
+    }
+
+    public void onStartTest2(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
+        boolean failed = false;
+        mCurrentTest = 2;
+        if (mInputConfigView != null) {
+            AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_USB_DEVICE);
+            if (device != null) {
+                mInputConfigView.setDeviceById(device.getId());
+            } else {
+                mInputConfigView.setDeviceById(0); // Auto-select
+                if (enforcementLevel == ENFORCEMENT_HIGH) {
+                    failed = true;
+                } else {
+                    showToast("WARNING: Preferred input device (USB_DEVICE) not found!");
+                }
+            }
+        }
+        if (!checkPreferredOutput(enforcementLevel)) {
+            failed = true;
+        }
+
+        if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
+            mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+            mTestResultView.setTextColor(Color.RED);
+            return;
+        }
+
+        if (enforcementLevel == ENFORCEMENT_HIGH) {
+            showMaxVolumeConfirmationDialog(2);
+        } else {
+            startTest2Actual();
+        }
+    }
+
+    private void showMaxVolumeConfirmationDialog(final int testNumber) {
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Volume Warning")
+                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(android.content.DialogInterface dialog, int which) {
+                        setVolumeToMax();
+                        if (testNumber == 1) {
+                            startTest1Actual();
+                        } else if (testNumber == 2) {
+                            startTest2Actual();
+                        }
+                    }
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void setVolumeToMax() {
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
+            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+        }
+    }
+
+    private void startTest1Actual() {
+        mStartButton2.setEnabled(false);
+        if (mTestSupervisor != null) {
+            mTestSupervisor.start();
+        }
+        try {
             openAudio();
             startAudio();
             mStartButton1.setEnabled(false);
@@ -211,53 +331,11 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         }
     }
 
-    public void onStopTest1(View view) {
-        stopWaveformUpdater();
-        stopAudio();
-        closeAudio();
-        mStartButton1.setEnabled(true);
-        mStopButton1.setEnabled(false);
-        mStartButton2.setEnabled(true);
-        if (mEnforcementSpinner != null) {
-            mEnforcementSpinner.setEnabled(true);
+    private void startTest2Actual() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.start();
         }
-        keepScreenOn(false);
-
-        // Save the current buffer for subtraction
-        if (mWaveformBuffer != null) {
-            mTest1WaveformBuffer = mWaveformBuffer.clone();
-        }
-        mTestStatusView.setText("Status: Test 1 Stopped. Ready for Test 2.");
-    }
-
-    public void onStartTest2(View view) {
-        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
-        boolean failed = false;
         try {
-            mCurrentTest = 2;
-            if (mInputConfigView != null) {
-                AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_USB_DEVICE);
-                if (device != null) {
-                    mInputConfigView.setDeviceById(device.getId());
-                } else {
-                    mInputConfigView.setDeviceById(0); // Auto-select
-                    if (enforcementLevel == ENFORCEMENT_HIGH) {
-                        failed = true;
-                    } else {
-                        showToast("WARNING: Preferred input device (USB_DEVICE) not found!");
-                    }
-                }
-            }
-            if (!checkPreferredOutput(enforcementLevel)) {
-                failed = true;
-            }
-
-            if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
-                mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
-                mTestResultView.setTextColor(Color.RED);
-                return;
-            }
-
             openAudio();
             startAudio();
             mStartButton2.setEnabled(false);
@@ -275,6 +353,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     }
 
     public void onStopTest2(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
         stopWaveformUpdater();
         stopAudio();
         closeAudio();
@@ -286,6 +365,11 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         }
         keepScreenOn(false);
         mTestStatusView.setText("Status: Test 2 Stopped. Tests complete.");
+
+        if (mTestSupervisor != null) {
+            mTestSupervisor.stop();
+            checkSupervisorEvents(enforcementLevel);
+        }
     }
 
     private boolean checkPreferredOutput(int enforcementLevel) {
@@ -305,6 +389,28 @@ public class DualFrequencyActivity extends AnalyzerActivity {
                 } else if (result == DEVICE_CONFLICT_USB_PLUGGED) {
                     showToast("WARNING: USB device is plugged in while testing Built-in Speaker!");
                 }
+            }
+        }
+        return true;
+    }
+
+    private boolean checkSupervisorEvents(int enforcementLevel) {
+        if (mTestSupervisor == null) return true;
+        boolean volChanged = mTestSupervisor.isVolumeChanged();
+        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        if (volChanged || devChanged) {
+            StringBuilder reason = new StringBuilder();
+            if (volChanged) reason.append("Volume changed");
+            if (devChanged) {
+                if (reason.length() > 0) reason.append(" & ");
+                reason.append("Device changed");
+            }
+            if (enforcementLevel == ENFORCEMENT_HIGH) {
+                mTestResultView.setText("RESULT: FAIL (" + reason.toString() + ")");
+                mTestResultView.setTextColor(Color.RED);
+                return false;
+            } else {
+                showToast("WARNING: " + reason.toString() + " during test!");
             }
         }
         return true;

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
@@ -21,14 +21,20 @@ import android.media.AudioDeviceInfo;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Spinner;
 import java.io.IOException;
 
 public class DualFrequencyActivity extends AnalyzerActivity {
 
+    public static final int ENFORCEMENT_MEDIUM = 0;
+    public static final int ENFORCEMENT_HIGH = 1;
+
     private Button mStartButton1, mStopButton1;
     private Button mStartButton2, mStopButton2;
+    private Spinner mEnforcementSpinner;
     private LineView mWaveformViewTests;
     private int mTest1LineId = -1;
     private int mTest2LineId = -1;
@@ -72,6 +78,13 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mTestStatusView = findViewById(R.id.testStatusView);
         mTestResultView = findViewById(R.id.testResultView);
         mInstructionsView = findViewById(R.id.test_dual_frequency_instructions);
+
+        mEnforcementSpinner = findViewById(R.id.spinnerEnforcement);
+        ArrayAdapter<CharSequence> enforcementAdapter = ArrayAdapter.createFromResource(
+                this, R.array.enforcement_levels, android.R.layout.simple_spinner_item);
+        enforcementAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mEnforcementSpinner.setAdapter(enforcementAdapter);
+        mEnforcementSpinner.setSelection(ENFORCEMENT_HIGH);
 
         mInputConfigView = null;
         StreamConfigurationView outputConfigView = null;
@@ -156,6 +169,8 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     }
 
     public void onStartTest1(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
+        boolean failed = false;
         try {
             mCurrentTest = 1;
             if (mInputConfigView != null) {
@@ -164,14 +179,30 @@ public class DualFrequencyActivity extends AnalyzerActivity {
                     mInputConfigView.setDeviceById(device.getId());
                 } else {
                     mInputConfigView.setDeviceById(0); // Auto-select
-                    showToast("WARNING: Preferred input device (BUILTIN_MIC) not found!");
+                    if (enforcementLevel == ENFORCEMENT_HIGH) {
+                        failed = true;
+                    } else {
+                        showToast("WARNING: Preferred input device (BUILTIN_MIC) not found!");
+                    }
                 }
             }
-            checkPreferredOutput();
+            if (!checkPreferredOutput(enforcementLevel)) {
+                failed = true;
+            }
+
+            if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
+                mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+                mTestResultView.setTextColor(Color.RED);
+                return;
+            }
+
             openAudio();
             startAudio();
             mStartButton1.setEnabled(false);
             mStopButton1.setEnabled(true);
+            if (mEnforcementSpinner != null) {
+                mEnforcementSpinner.setEnabled(false);
+            }
             startWaveformUpdater();
             keepScreenOn(true);
             mTestStatusView.setText("Status: Running Test 1...");
@@ -187,6 +218,9 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mStartButton1.setEnabled(true);
         mStopButton1.setEnabled(false);
         mStartButton2.setEnabled(true);
+        if (mEnforcementSpinner != null) {
+            mEnforcementSpinner.setEnabled(true);
+        }
         keepScreenOn(false);
 
         // Save the current buffer for subtraction
@@ -197,6 +231,8 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     }
 
     public void onStartTest2(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
+        boolean failed = false;
         try {
             mCurrentTest = 2;
             if (mInputConfigView != null) {
@@ -205,15 +241,31 @@ public class DualFrequencyActivity extends AnalyzerActivity {
                     mInputConfigView.setDeviceById(device.getId());
                 } else {
                     mInputConfigView.setDeviceById(0); // Auto-select
-                    showToast("WARNING: Preferred input device (USB_DEVICE) not found!");
+                    if (enforcementLevel == ENFORCEMENT_HIGH) {
+                        failed = true;
+                    } else {
+                        showToast("WARNING: Preferred input device (USB_DEVICE) not found!");
+                    }
                 }
             }
-            checkPreferredOutput();
+            if (!checkPreferredOutput(enforcementLevel)) {
+                failed = true;
+            }
+
+            if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
+                mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+                mTestResultView.setTextColor(Color.RED);
+                return;
+            }
+
             openAudio();
             startAudio();
             mStartButton2.setEnabled(false);
             mStopButton2.setEnabled(true);
             mStartButton1.setEnabled(false);
+            if (mEnforcementSpinner != null) {
+                mEnforcementSpinner.setEnabled(false);
+            }
             startWaveformUpdater();
             keepScreenOn(true);
             mTestStatusView.setText("Status: Running Test 2...");
@@ -229,25 +281,33 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mStartButton2.setEnabled(true);
         mStopButton2.setEnabled(false);
         mStartButton1.setEnabled(true);
+        if (mEnforcementSpinner != null) {
+            mEnforcementSpinner.setEnabled(true);
+        }
         keepScreenOn(false);
         mTestStatusView.setText("Status: Test 2 Stopped. Tests complete.");
     }
 
-    private void checkPreferredOutput() {
+    private boolean checkPreferredOutput(int enforcementLevel) {
         FrequencyPreset active = mFrequencySetting.getActivePreset();
         if (active != null) {
             int preferredOutput = active.preferredOutput;
             if (preferredOutput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 int result = checkOutputDeviceSupported(preferredOutput);
                 if (result == DEVICE_NOT_FOUND) {
-                    showToast("WARNING: Preferred output device (" +
+                    if (enforcementLevel == ENFORCEMENT_HIGH) {
+                        return false;
+                    } else {
+                        showToast("WARNING: Preferred output device (" +
                             StreamConfiguration.deviceTypeToString(preferredOutput) +
                             ") not found!");
+                    }
                 } else if (result == DEVICE_CONFLICT_USB_PLUGGED) {
                     showToast("WARNING: USB device is plugged in while testing Built-in Speaker!");
                 }
             }
         }
+        return true;
     }
 
     private void startWaveformUpdater() {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
@@ -19,11 +19,13 @@ package com.mobileer.oboetester;
 import android.os.Bundle;
 import android.media.AudioDeviceInfo;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.EditText;
+import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.EditText;
-import android.widget.AdapterView;
 import java.io.IOException;
 import android.os.Handler;
 import androidx.core.text.HtmlCompat;
@@ -31,6 +33,9 @@ import android.text.method.LinkMovementMethod;
 
 
 public final class FrequencyActivity extends AnalyzerActivity {
+
+    public static final int ENFORCEMENT_MEDIUM = 0;
+    public static final int ENFORCEMENT_HIGH = 1;
 
     private Button mStartButton;
     private Button mStopButton;
@@ -45,9 +50,10 @@ public final class FrequencyActivity extends AnalyzerActivity {
     private TextView mInstructionsView;
 
     private Spinner mOutputSignalSpinner;
+    private Spinner mEnforcementSpinner;
     private FrequencySettingView mFrequencySetting;
     private TextView mBalanceTextView;
-    private android.widget.SeekBar mBalanceSeekBar;
+    private SeekBar mBalanceSeekBar;
     private StreamConfigurationView mInputConfigView;
     private StreamConfigurationView mOutputConfigView;
 
@@ -95,19 +101,26 @@ public final class FrequencyActivity extends AnalyzerActivity {
 
         mOutputSignalSpinner = (Spinner) findViewById(R.id.spinnerOutputSignal);
         String[] outputSignals = {"White Noise", "Sine", "Silence"};
-        android.widget.ArrayAdapter<String> outputSignalAdapter = new android.widget.ArrayAdapter<>(
+        ArrayAdapter<String> outputSignalAdapter = new ArrayAdapter<>(
                 this,
                 android.R.layout.simple_spinner_item, outputSignals);
         outputSignalAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mOutputSignalSpinner.setAdapter(outputSignalAdapter);
         mOutputSignalSpinner.setOnItemSelectedListener(new OutputSignalSpinnerListener());
 
+        mEnforcementSpinner = (Spinner) findViewById(R.id.spinnerEnforcement);
+        ArrayAdapter<CharSequence> enforcementAdapter = ArrayAdapter.createFromResource(
+                this, R.array.enforcement_levels, android.R.layout.simple_spinner_item);
+        enforcementAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mEnforcementSpinner.setAdapter(enforcementAdapter);
+        mEnforcementSpinner.setSelection(ENFORCEMENT_HIGH);
+
         mBalanceTextView = (TextView) findViewById(R.id.textBalanceSlider);
-        mBalanceSeekBar = (android.widget.SeekBar) findViewById(R.id.faderBalanceSlider);
+        mBalanceSeekBar = (SeekBar) findViewById(R.id.faderBalanceSlider);
         mBalanceSeekBar.setOnSeekBarChangeListener(
-                new android.widget.SeekBar.OnSeekBarChangeListener() {
+                new SeekBar.OnSeekBarChangeListener() {
                     @Override
-                    public void onProgressChanged(android.widget.SeekBar seekBar, int progress,
+                    public void onProgressChanged(SeekBar seekBar, int progress,
                             boolean fromUser) {
                         float balance = progress / 100.0f;
                         mAudioOutTester.setBalance(balance);
@@ -117,11 +130,11 @@ public final class FrequencyActivity extends AnalyzerActivity {
                     }
 
                     @Override
-                    public void onStartTrackingTouch(android.widget.SeekBar seekBar) {
+                    public void onStartTrackingTouch(SeekBar seekBar) {
                     }
 
                     @Override
-                    public void onStopTrackingTouch(android.widget.SeekBar seekBar) {
+                    public void onStopTrackingTouch(SeekBar seekBar) {
                     }
                 });
 
@@ -205,15 +218,22 @@ public final class FrequencyActivity extends AnalyzerActivity {
 
     public void onStartAudioTest(View view) {
         FrequencyPreset active = mFrequencySetting.getActivePreset();
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
+        boolean failed = false;
+
         if (active != null) {
             // Check preferred input device
             int preferredInput = active.preferredInput;
             if (preferredInput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 AudioDeviceInfo device = findInputDeviceByType(preferredInput);
                 if (device == null) {
-                    showToast("WARNING: Preferred input device (" +
+                    if (enforcementLevel == ENFORCEMENT_HIGH) {
+                        failed = true;
+                    } else {
+                        showToast("WARNING: Preferred input device (" +
                             StreamConfiguration.deviceTypeToString(preferredInput) +
                             ") not found!");
+                    }
                 }
             }
 
@@ -222,13 +242,23 @@ public final class FrequencyActivity extends AnalyzerActivity {
             if (preferredOutput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 int result = checkOutputDeviceSupported(preferredOutput);
                 if (result == DEVICE_NOT_FOUND) {
-                    showToast("WARNING: Preferred output device (" +
+                    if (enforcementLevel == ENFORCEMENT_HIGH) {
+                        failed = true;
+                    } else {
+                        showToast("WARNING: Preferred output device (" +
                             StreamConfiguration.deviceTypeToString(preferredOutput) +
                             ") not found!");
+                    }
                 } else if (result == DEVICE_CONFLICT_USB_PLUGGED) {
                     showToast("WARNING: USB speaker is plugged in while testing Built-in Speaker!");
                 }
             }
+        }
+
+        if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
+            mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+            mTestResultView.setTextColor(android.graphics.Color.RED);
+            return;
         }
 
         try {
@@ -242,6 +272,9 @@ public final class FrequencyActivity extends AnalyzerActivity {
             }
             if (mOutputSignalSpinner != null) {
                 mOutputSignalSpinner.setEnabled(false);
+            }
+            if (mEnforcementSpinner != null) {
+                mEnforcementSpinner.setEnabled(false);
             }
             if (mThresholdEditText != null) {
                 mThresholdEditText.setEnabled(false);
@@ -265,6 +298,9 @@ public final class FrequencyActivity extends AnalyzerActivity {
         }
         if (mOutputSignalSpinner != null) {
             mOutputSignalSpinner.setEnabled(true);
+        }
+        if (mEnforcementSpinner != null) {
+            mEnforcementSpinner.setEnabled(true);
         }
         if (mThresholdEditText != null) {
             mThresholdEditText.setEnabled(true);

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 import android.os.Handler;
 import androidx.core.text.HtmlCompat;
 import android.text.method.LinkMovementMethod;
+import android.graphics.Color;
+import android.media.AudioManager;
+import android.content.Context;
 
 
 public final class FrequencyActivity extends AnalyzerActivity {
@@ -52,6 +55,7 @@ public final class FrequencyActivity extends AnalyzerActivity {
     private Spinner mOutputSignalSpinner;
     private Spinner mEnforcementSpinner;
     private FrequencySettingView mFrequencySetting;
+    private TestSupervisor mTestSupervisor;
     private TextView mBalanceTextView;
     private SeekBar mBalanceSeekBar;
     private StreamConfigurationView mInputConfigView;
@@ -194,6 +198,17 @@ public final class FrequencyActivity extends AnalyzerActivity {
                         }
                     }
                 });
+
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.release();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -257,8 +272,43 @@ public final class FrequencyActivity extends AnalyzerActivity {
 
         if (failed && enforcementLevel == ENFORCEMENT_HIGH) {
             mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
-            mTestResultView.setTextColor(android.graphics.Color.RED);
+            mTestResultView.setTextColor(Color.RED);
             return;
+        }
+
+        if (enforcementLevel == ENFORCEMENT_HIGH) {
+            showMaxVolumeConfirmationDialog();
+        } else {
+            startAudioTestActual();
+        }
+    }
+
+    private void showMaxVolumeConfirmationDialog() {
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Volume Warning")
+                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(android.content.DialogInterface dialog, int which) {
+                        setVolumeToMax();
+                        startAudioTestActual();
+                    }
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void setVolumeToMax() {
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
+            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+        }
+    }
+
+    private void startAudioTestActual() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.start();
         }
 
         try {
@@ -287,6 +337,7 @@ public final class FrequencyActivity extends AnalyzerActivity {
     }
 
     public void onStopAudioTest(View view) {
+        int enforcementLevel = mEnforcementSpinner != null ? mEnforcementSpinner.getSelectedItemPosition() : ENFORCEMENT_MEDIUM;
         stopWaveformUpdater();
         stopAudio();
         closeAudio();
@@ -306,6 +357,31 @@ public final class FrequencyActivity extends AnalyzerActivity {
             mThresholdEditText.setEnabled(true);
         }
         keepScreenOn(false);
+
+        if (mTestSupervisor != null) {
+            mTestSupervisor.stop();
+            checkSupervisorEvents(enforcementLevel);
+        }
+    }
+
+    private void checkSupervisorEvents(int enforcementLevel) {
+        if (mTestSupervisor == null) return;
+        boolean volChanged = mTestSupervisor.isVolumeChanged();
+        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        if (volChanged || devChanged) {
+            StringBuilder reason = new StringBuilder();
+            if (volChanged) reason.append("Volume changed");
+            if (devChanged) {
+                if (reason.length() > 0) reason.append(" & ");
+                reason.append("Device changed");
+            }
+            if (enforcementLevel == ENFORCEMENT_HIGH) {
+                mTestResultView.setText("RESULT: FAIL (" + reason.toString() + ")");
+                mTestResultView.setTextColor(Color.RED);
+            } else {
+                showToast("WARNING: " + reason.toString() + " during test!");
+            }
+        }
     }
 
     private native int getWindowSize();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestSupervisor.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestSupervisor.java
@@ -1,0 +1,90 @@
+package com.mobileer.oboetester;
+
+import android.media.AudioManager;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioAttributes;
+import android.util.Log;
+import java.util.List;
+import java.util.TimerTask;
+import java.util.Timer;
+
+public class TestSupervisor extends AudioDeviceCallback {
+  private static final String TAG = "TestSupervisor";
+  private boolean isVolumeChanged = false;
+  private int expectedLevel;
+  private boolean isDeviceChanged;
+  private final AudioManager audioManager;
+  private int streamType;
+  private Timer timer;
+  private final int checkPeriodMs = 200;
+
+  public TestSupervisor(AudioManager audioManager, int streamType) {
+    this.audioManager = audioManager;
+    this.isDeviceChanged = false;
+    this.streamType = streamType;
+    audioManager.registerAudioDeviceCallback(this, null);
+  }
+
+  public void start() {
+    expectedLevel = audioManager.getStreamVolume(streamType);
+    isVolumeChanged = false;
+    isDeviceChanged = false;
+    timer = new Timer();
+    timer.schedule(
+        new TimerTask() {
+          @Override
+          public void run() {
+            check();
+          }
+        },
+        0,
+        checkPeriodMs);
+  }
+
+  public void stop() {
+    if (timer != null) {
+      timer.cancel();
+      timer = null;
+    }
+  }
+
+  public void release() {
+    audioManager.unregisterAudioDeviceCallback(this);
+  }
+
+  private void check() {
+    int currentLevel = audioManager.getStreamVolume(streamType);
+    if (currentLevel != expectedLevel) {
+      isVolumeChanged = true;
+    }
+  }
+
+  public boolean isVolumeChanged() {
+    return isVolumeChanged;
+  }
+
+  public boolean isDeviceChanged() {
+    return this.isDeviceChanged;
+  }
+
+  @Override
+  public void onAudioDevicesAdded(AudioDeviceInfo[] devices) {
+    if (timer != null) {
+      this.isDeviceChanged = true;
+      for (AudioDeviceInfo device : devices) {
+        Log.d(TAG, "Detected a new device of type " + device.getType());
+      }
+    }
+  }
+
+  @Override
+  public void onAudioDevicesRemoved(AudioDeviceInfo[] devices) {
+    if (timer != null) {
+      this.isDeviceChanged = true;
+      for (AudioDeviceInfo device : devices) {
+        Log.d(TAG, "Disconnected to a device of type " + device.getType());
+      }
+    }
+  }
+}

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_dual_frequency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_dual_frequency.xml
@@ -191,6 +191,21 @@
                 android:padding="4dp"
                 android:layout_marginTop="4dp"/>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/common_enforcement_title" />
+                <Spinner
+                    android:id="@+id/spinnerEnforcement"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
             <com.mobileer.oboetester.FrequencySettingView
                 android:id="@+id/frequency_setting"
                 android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_frequency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_frequency.xml
@@ -95,7 +95,6 @@
                 android:layout_height="wrap_content"
                 android:checked="true"
                 android:text="LogX" />
-
             <TextView
                 android:id="@+id/testResultView"
                 android:layout_width="match_parent"
@@ -105,6 +104,20 @@
                 android:textStyle="bold"
                 android:textColor="#000000"
                 android:padding="4dp"/>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/common_enforcement_title" />
+                <Spinner
+                    android:id="@+id/spinnerEnforcement"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
             <com.mobileer.oboetester.FrequencySettingView
                 android:id="@+id/frequency_setting"
                 android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -347,6 +347,9 @@
     <string name="common_instruction_title">
         Instructions
     </string>
+    <string name="common_enforcement_title">
+        Enforcement
+    </string>
     <string name="analyze">Analyze</string>
 
     <string name="routing_crash_intro">
@@ -443,5 +446,9 @@
     <string-array name="tone_types">
         <item>Blip</item>
         <item>Saw</item>
+    </string-array>
+    <string-array name="enforcement_levels">
+        <item>Medium</item>
+        <item>High</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Frequency tests require a high volume to generate a clear frequency response from the speaker or microphone; however, the volume level is often left unset. Additionally, peripheral adjustments or volume changes during testing can lead to unexpected results. This ticket introduces an enforcement mode to automatically set the volume and monitor any changes during the test. There are two available modes:
- medium: The test will not adjust the volume, allowing users to configure settings for their own needs. There are no peripheral constraints, enabling testing across various scenarios.
- high: The test will set the volume to the maximum level and verify all required peripherals before starting. Any changes to the volume or device connections during the test will result in a failure.

The default enforcement mode is "high," though users are free to select whichever mode is most suitable. This approach increases the application's flexibility.