### PR TITLE
Frequency enforcement

### DIFF
--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
@@ -16,12 +16,15 @@
 
 package com.mobileer.oboetester;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.TextView;
 import java.io.IOException;
 
@@ -29,6 +32,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
 
     private Button mStartButton1, mStopButton1;
     private Button mStartButton2, mStopButton2;
+    private CheckBox mEnforcementCheckBox;
     private LineView mWaveformViewTests;
     private int mTest1LineId = -1;
     private int mTest2LineId = -1;
@@ -42,6 +46,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     private TextView mInstructionsView;
     private FrequencySettingView mFrequencySetting;
     private StreamConfigurationView mInputConfigView;
+    private TestSupervisor mTestSupervisor;
     private FrequencyAnalyzer mFrequencyAnalyzer = new FrequencyAnalyzer();
 
     private static final int WAVEFORM_UPDATE_MS = 500;
@@ -54,6 +59,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     private int mCurrentTest = 0; // 1 for test 1, 2 for test 2
 
     private Handler mHandler = new Handler();
+    private int[] mPreferredInputList = {AudioDeviceInfo.TYPE_BUILTIN_MIC, AudioDeviceInfo.TYPE_USB_DEVICE};
 
     private native int getWindowSize();
 
@@ -72,6 +78,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mTestStatusView = findViewById(R.id.testStatusView);
         mTestResultView = findViewById(R.id.testResultView);
         mInstructionsView = findViewById(R.id.test_dual_frequency_instructions);
+        mEnforcementCheckBox = findViewById(R.id.enforcement_check_box);
 
         mInputConfigView = null;
         StreamConfigurationView outputConfigView = null;
@@ -133,6 +140,15 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mStopButton1.setEnabled(false);
         mStartButton2.setEnabled(false);
         mStopButton2.setEnabled(false);
+
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+    }
+
+    @Override
+    protected void onDestroy() {
+        mTestSupervisor.release();
+        super.onDestroy();
     }
 
     @Override
@@ -155,99 +171,179 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         return true;
     }
 
-    public void onStartTest1(View view) {
-        try {
+    public void onStartTest(View view) {
+        boolean isEnforced = mEnforcementCheckBox.isChecked();
+        if (view.getId() == mStartButton1.getId()) {
             mCurrentTest = 1;
-            if (mInputConfigView != null) {
-                AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_BUILTIN_MIC);
-                if (device != null) {
-                    mInputConfigView.setDeviceById(device.getId());
-                } else {
-                    mInputConfigView.setDeviceById(0); // Auto-select
-                    showToast("WARNING: Preferred input device (BUILTIN_MIC) not found!");
-                }
-            }
-            checkPreferredOutput();
-            openAudio();
-            startAudio();
-            mStartButton1.setEnabled(false);
-            mStopButton1.setEnabled(true);
-            startWaveformUpdater();
-            keepScreenOn(true);
-            mTestStatusView.setText("Status: Running Test 1...");
-        } catch (IOException e) {
-            showErrorToast(e.getMessage());
-        }
-    }
-
-    public void onStopTest1(View view) {
-        stopWaveformUpdater();
-        stopAudio();
-        closeAudio();
-        mStartButton1.setEnabled(true);
-        mStopButton1.setEnabled(false);
-        mStartButton2.setEnabled(true);
-        keepScreenOn(false);
-
-        // Save the current buffer for subtraction
-        if (mWaveformBuffer != null) {
-            mTest1WaveformBuffer = mWaveformBuffer.clone();
-        }
-        mTestStatusView.setText("Status: Test 1 Stopped. Ready for Test 2.");
-    }
-
-    public void onStartTest2(View view) {
-        try {
+        } else {
             mCurrentTest = 2;
-            if (mInputConfigView != null) {
-                AudioDeviceInfo device = findInputDeviceByType(AudioDeviceInfo.TYPE_USB_DEVICE);
-                if (device != null) {
-                    mInputConfigView.setDeviceById(device.getId());
-                } else {
-                    mInputConfigView.setDeviceById(0); // Auto-select
-                    showToast("WARNING: Preferred input device (USB_DEVICE) not found!");
-                }
+        }
+        FrequencyPreset activePreset = mFrequencySetting.getActivePreset();
+        boolean inputReady = prepareInput(mPreferredInputList[mCurrentTest - 1]);
+        boolean outputReady = prepareOutput(activePreset);
+        boolean peripheralReady = inputReady && outputReady;
+
+        if (isEnforced && !peripheralReady) {
+            // Mark the test fail
+            mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+            mTestResultView.setTextColor(Color.RED);
+            return;
+        } else if (!peripheralReady) {
+            if (!inputReady) {
+                showToast("WARNING: Preferred input device is not found!");
             }
-            checkPreferredOutput();
+            if (!outputReady) {
+                showToast("WARNING: Preferred output device is not found!");
+            }
+        }
+        if (isEnforced) {
+            showMaxVolumeConfirmationDialog();
+        } else {
+            startTest();
+        }
+    }
+
+    public void onStopTest(View view) {
+        boolean isEnforced = mEnforcementCheckBox.isChecked();
+        stopWaveformUpdater();
+        stopAudio();
+        closeAudio();
+        keepScreenOn(false);
+        if (view.getId() == mStopButton1.getId()) {
+            mStartButton1.setEnabled(true);
+            mStopButton1.setEnabled(false);
+        } else {
+            mStartButton1.setEnabled(true);
+            mStartButton2.setEnabled(true);
+            mStopButton2.setEnabled(false);
+        }
+        mTestSupervisor.stop();
+        String events = checkSupervisorEvents();
+
+        // Process events
+        if (!events.isBlank()) {
+            if(isEnforced) {
+                // Override the result
+                mTestResultView.setText("RESULT: FAIL (" + events + ")");
+                mTestResultView.setTextColor(Color.RED);
+            } else {
+                // Show a toast
+                showToast("WARNING: " + events + " during test!");
+            }
+        }
+        // Update buttons
+        if (events.isBlank() || !isEnforced) {
+            if (view.getId() == mStopButton1.getId()) {
+                // Allow to start the second test
+                if (mWaveformBuffer != null) {
+                    mTest1WaveformBuffer = mWaveformBuffer.clone();
+                }
+                mStartButton2.setEnabled(true);
+            } else {
+                // Do nothing
+            }
+        }
+    }
+
+    private void startTest() {
+        if (mCurrentTest == 1) {
+            clearResult();
+        }
+        mTestSupervisor.start();
+        try {
             openAudio();
             startAudio();
-            mStartButton2.setEnabled(false);
-            mStopButton2.setEnabled(true);
-            mStartButton1.setEnabled(false);
             startWaveformUpdater();
             keepScreenOn(true);
-            mTestStatusView.setText("Status: Running Test 2...");
+
+            mStartButton2.setEnabled(false);
+            mStartButton1.setEnabled(false);
+            if (mCurrentTest == 1) {
+                mStopButton1.setEnabled(true);
+                mStopButton2.setEnabled(false);
+            } else {
+                mStopButton1.setEnabled(false);
+                mStopButton2.setEnabled(true);
+            }
+            mTestStatusView.setText("Status: Running Test " + mCurrentTest);
         } catch (IOException e) {
             showErrorToast(e.getMessage());
         }
     }
 
-    public void onStopTest2(View view) {
-        stopWaveformUpdater();
-        stopAudio();
-        closeAudio();
-        mStartButton2.setEnabled(true);
-        mStopButton2.setEnabled(false);
-        mStartButton1.setEnabled(true);
-        keepScreenOn(false);
-        mTestStatusView.setText("Status: Test 2 Stopped. Tests complete.");
+    private void clearResult() {
+        mTestResultView.setText("Result: N/A");
+        mTest1LineId = -1;
+        mTest2LineId = -1;
+        mSubtractionLineId = -1;
+        mTopThresholdLineId = -1;
+        mBottomThresholdLineId = -1;
+        mWaveformViewTests.removeAllLines();
+        mWaveformViewSubtraction.removeAllLines();
     }
 
-    private void checkPreferredOutput() {
-        FrequencyPreset active = mFrequencySetting.getActivePreset();
-        if (active != null) {
-            int preferredOutput = active.preferredOutput;
+    private void showMaxVolumeConfirmationDialog() {
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Volume Warning")
+                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(android.content.DialogInterface dialog, int which) {
+                        setVolumeToMax();
+                        startTest();
+                    }
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void setVolumeToMax() {
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
+            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+        }
+    }
+
+    private boolean prepareInput(int inputType) {
+        AudioDeviceInfo device = findInputDeviceByType(inputType);
+        if (device != null) {
+            mInputConfigView.setDeviceById(device.getId());
+        } else {
+            mInputConfigView.setDeviceById(0); // Auto-select
+        }
+        return device != null;
+    }
+
+    private boolean prepareOutput(FrequencyPreset preset) {
+        if (preset != null) {
+            int preferredOutput = preset.preferredOutput;
             if (preferredOutput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 int result = checkOutputDeviceSupported(preferredOutput);
                 if (result == DEVICE_NOT_FOUND) {
-                    showToast("WARNING: Preferred output device (" +
-                            StreamConfiguration.deviceTypeToString(preferredOutput) +
-                            ") not found!");
+                    return false;
                 } else if (result == DEVICE_CONFLICT_USB_PLUGGED) {
                     showToast("WARNING: USB device is plugged in while testing Built-in Speaker!");
                 }
             }
         }
+        return true;
+    }
+
+    private String checkSupervisorEvents() {
+        String noError = "";
+        boolean volChanged = mTestSupervisor.isVolumeChanged();
+        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        if (volChanged || devChanged) {
+            StringBuilder reason = new StringBuilder();
+            if (volChanged) reason.append("Volume changed");
+            if (devChanged) {
+                if (reason.length() > 0) reason.append(" & ");
+                reason.append("Device changed");
+            }
+            return reason.toString();
+        }
+        return noError;
     }
 
     private void startWaveformUpdater() {

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/DualFrequencyActivity.java
@@ -46,7 +46,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     private TextView mInstructionsView;
     private FrequencySettingView mFrequencySetting;
     private StreamConfigurationView mInputConfigView;
-    private TestSupervisor mTestSupervisor;
+    private FrequencyTestObserver mTestObserver;
     private FrequencyAnalyzer mFrequencyAnalyzer = new FrequencyAnalyzer();
 
     private static final int WAVEFORM_UPDATE_MS = 500;
@@ -142,12 +142,14 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         mStopButton2.setEnabled(false);
 
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+        mTestObserver = new FrequencyTestObserver(audioManager);
     }
 
     @Override
     protected void onDestroy() {
-        mTestSupervisor.release();
+        if (mTestObserver != null) {
+            mTestObserver.release();
+        }
         super.onDestroy();
     }
 
@@ -217,7 +219,7 @@ public class DualFrequencyActivity extends AnalyzerActivity {
             mStartButton2.setEnabled(true);
             mStopButton2.setEnabled(false);
         }
-        mTestSupervisor.stop();
+        mTestObserver.stop();
         String events = checkSupervisorEvents();
 
         // Process events
@@ -249,9 +251,13 @@ public class DualFrequencyActivity extends AnalyzerActivity {
         if (mCurrentTest == 1) {
             clearResult();
         }
-        mTestSupervisor.start();
         try {
             openAudio();
+            if (mEnforcementCheckBox.isChecked()) {
+                setVolumeToMax();
+            }
+            mTestObserver.start(getOutputStreamType());
+
             startAudio();
             startWaveformUpdater();
             keepScreenOn(true);
@@ -285,11 +291,11 @@ public class DualFrequencyActivity extends AnalyzerActivity {
     private void showMaxVolumeConfirmationDialog() {
         new android.app.AlertDialog.Builder(this)
                 .setTitle("Volume Warning")
-                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setMessage("Enforcement mode will set the volume to MAXIMUM. This may be very loud."
+                    + " Do you want to proceed?")
                 .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(android.content.DialogInterface dialog, int which) {
-                        setVolumeToMax();
                         startTest();
                     }
                 })
@@ -297,11 +303,22 @@ public class DualFrequencyActivity extends AnalyzerActivity {
                 .show();
     }
 
+    private int getOutputStreamType() {
+        if (mAudioOutTester != null) {
+            int usage = isStreamClosed()
+                    ? mAudioOutTester.requestedConfiguration.getUsage()
+                    : mAudioOutTester.actualConfiguration.getUsage();
+            return StreamConfiguration.convertUsageToStreamType(usage);
+        }
+        return AudioManager.STREAM_MUSIC;
+    }
+
     private void setVolumeToMax() {
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         if (audioManager != null) {
-            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+            int streamType = getOutputStreamType();
+            int maxVolume = audioManager.getStreamMaxVolume(streamType);
+            audioManager.setStreamVolume(streamType, maxVolume, 0);
         }
     }
 
@@ -332,8 +349,11 @@ public class DualFrequencyActivity extends AnalyzerActivity {
 
     private String checkSupervisorEvents() {
         String noError = "";
-        boolean volChanged = mTestSupervisor.isVolumeChanged();
-        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        if (mTestObserver == null) {
+            return noError;
+        }
+        boolean volChanged = mTestObserver.isVolumeChanged();
+        boolean devChanged = mTestObserver.isDeviceChanged();
         if (volChanged || devChanged) {
             StringBuilder reason = new StringBuilder();
             if (volChanged) reason.append("Volume changed");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
@@ -16,17 +16,23 @@
 
 package com.mobileer.oboetester;
 
+import android.content.Context;
+import android.graphics.Color;
 import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.EditText;
-import android.widget.AdapterView;
 import androidx.core.text.HtmlCompat;
 import java.io.IOException;
 
@@ -45,9 +51,11 @@ public final class FrequencyActivity extends AnalyzerActivity {
     private TextView mInstructionsView;
 
     private Spinner mOutputSignalSpinner;
+    private CheckBox mEnforcementCheckBox;
     private FrequencySettingView mFrequencySetting;
+    private TestSupervisor mTestSupervisor;
     private TextView mBalanceTextView;
-    private android.widget.SeekBar mBalanceSeekBar;
+    private SeekBar mBalanceSeekBar;
     private StreamConfigurationView mInputConfigView;
     private StreamConfigurationView mOutputConfigView;
 
@@ -95,19 +103,20 @@ public final class FrequencyActivity extends AnalyzerActivity {
 
         mOutputSignalSpinner = (Spinner) findViewById(R.id.spinnerOutputSignal);
         String[] outputSignals = {"White Noise", "Sine", "Silence"};
-        android.widget.ArrayAdapter<String> outputSignalAdapter = new android.widget.ArrayAdapter<>(
+        ArrayAdapter<String> outputSignalAdapter = new ArrayAdapter<>(
                 this,
                 android.R.layout.simple_spinner_item, outputSignals);
         outputSignalAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mOutputSignalSpinner.setAdapter(outputSignalAdapter);
         mOutputSignalSpinner.setOnItemSelectedListener(new OutputSignalSpinnerListener());
+        mEnforcementCheckBox = findViewById(R.id.enforcement_check_box);
 
         mBalanceTextView = (TextView) findViewById(R.id.textBalanceSlider);
-        mBalanceSeekBar = (android.widget.SeekBar) findViewById(R.id.faderBalanceSlider);
+        mBalanceSeekBar = (SeekBar) findViewById(R.id.faderBalanceSlider);
         mBalanceSeekBar.setOnSeekBarChangeListener(
-                new android.widget.SeekBar.OnSeekBarChangeListener() {
+                new SeekBar.OnSeekBarChangeListener() {
                     @Override
-                    public void onProgressChanged(android.widget.SeekBar seekBar, int progress,
+                    public void onProgressChanged(SeekBar seekBar, int progress,
                             boolean fromUser) {
                         float balance = progress / 100.0f;
                         mAudioOutTester.setBalance(balance);
@@ -117,11 +126,11 @@ public final class FrequencyActivity extends AnalyzerActivity {
                     }
 
                     @Override
-                    public void onStartTrackingTouch(android.widget.SeekBar seekBar) {
+                    public void onStartTrackingTouch(SeekBar seekBar) {
                     }
 
                     @Override
-                    public void onStopTrackingTouch(android.widget.SeekBar seekBar) {
+                    public void onStopTrackingTouch(SeekBar seekBar) {
                     }
                 });
 
@@ -182,6 +191,17 @@ public final class FrequencyActivity extends AnalyzerActivity {
                         }
                     }
                 });
+
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.release();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -206,15 +226,18 @@ public final class FrequencyActivity extends AnalyzerActivity {
 
     public void onStartAudioTest(View view) {
         FrequencyPreset active = mFrequencySetting.getActivePreset();
+        boolean isEnforced = mEnforcementCheckBox.isChecked();
+        boolean inputReady = true;
+        boolean outputReady =  true;
+
+        // Check peripherals
         if (active != null) {
             // Check preferred input device
             int preferredInput = active.preferredInput;
             if (preferredInput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 AudioDeviceInfo device = findInputDeviceByType(preferredInput);
                 if (device == null) {
-                    showToast("WARNING: Preferred input device (" +
-                            StreamConfiguration.deviceTypeToString(preferredInput) +
-                            ") not found!");
+                    inputReady = false;
                 }
             }
 
@@ -223,13 +246,64 @@ public final class FrequencyActivity extends AnalyzerActivity {
             if (preferredOutput != AudioDeviceInfo.TYPE_UNKNOWN) {
                 int result = checkOutputDeviceSupported(preferredOutput);
                 if (result == DEVICE_NOT_FOUND) {
-                    showToast("WARNING: Preferred output device (" +
-                            StreamConfiguration.deviceTypeToString(preferredOutput) +
-                            ") not found!");
+                    outputReady = false;
                 } else if (result == DEVICE_CONFLICT_USB_PLUGGED) {
                     showToast("WARNING: USB speaker is plugged in while testing Built-in Speaker!");
                 }
             }
+        }
+        boolean peripheralReady = inputReady && outputReady;
+        if (isEnforced && !peripheralReady) {
+            // Override the result
+            mTestResultView.setText("RESULT: FAIL (Missing Peripherals)");
+            mTestResultView.setTextColor(Color.RED);
+            return;
+        }
+        // Show the toast if necessary
+        if (!inputReady) {
+            showToast("WARNING: Preferred input device (" +
+                StreamConfiguration.deviceTypeToString(active.preferredInput) +
+                ") not found!");
+        }
+        if (!outputReady) {
+            showToast("WARNING: Preferred output device (" +
+                StreamConfiguration.deviceTypeToString(active.preferredOutput) +
+                ") not found!");
+        }
+        // Move forward
+        if (isEnforced) {
+            showMaxVolumeConfirmationDialog();
+        } else {
+            startAudioTest();
+        }
+    }
+
+    private void showMaxVolumeConfirmationDialog() {
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Volume Warning")
+                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(android.content.DialogInterface dialog, int which) {
+                        setVolumeToMax();
+                        startAudioTest();
+                    }
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void setVolumeToMax() {
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
+            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+        }
+    }
+
+    private void startAudioTest() {
+        if (mTestSupervisor != null) {
+            mTestSupervisor.start();
         }
 
         try {
@@ -271,6 +345,32 @@ public final class FrequencyActivity extends AnalyzerActivity {
             mThresholdEditText.setEnabled(true);
         }
         keepScreenOn(false);
+
+        if (mTestSupervisor != null) {
+            mTestSupervisor.stop();
+            checkSupervisorEvents();
+        }
+    }
+
+    private void checkSupervisorEvents() {
+        boolean isEnforced = mEnforcementCheckBox.isChecked();
+        if (mTestSupervisor == null) return;
+        boolean volChanged = mTestSupervisor.isVolumeChanged();
+        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        if (volChanged || devChanged) {
+            StringBuilder reason = new StringBuilder();
+            if (volChanged) reason.append("Volume changed");
+            if (devChanged) {
+                if (reason.length() > 0) reason.append(" & ");
+                reason.append("Device changed");
+            }
+            if (isEnforced) {
+                mTestResultView.setText("RESULT: FAIL (" + reason.toString() + ")");
+                mTestResultView.setTextColor(Color.RED);
+            } else {
+                showToast("WARNING: " + reason.toString() + " during test!");
+            }
+        }
     }
 
     private native int getWindowSize();

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyActivity.java
@@ -53,7 +53,7 @@ public final class FrequencyActivity extends AnalyzerActivity {
     private Spinner mOutputSignalSpinner;
     private CheckBox mEnforcementCheckBox;
     private FrequencySettingView mFrequencySetting;
-    private TestSupervisor mTestSupervisor;
+    private FrequencyTestObserver mTestObserver;
     private TextView mBalanceTextView;
     private SeekBar mBalanceSeekBar;
     private StreamConfigurationView mInputConfigView;
@@ -191,15 +191,14 @@ public final class FrequencyActivity extends AnalyzerActivity {
                         }
                     }
                 });
-
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        mTestSupervisor = new TestSupervisor(audioManager, AudioManager.STREAM_MUSIC);
+        mTestObserver = new FrequencyTestObserver(audioManager);
     }
 
     @Override
     protected void onDestroy() {
-        if (mTestSupervisor != null) {
-            mTestSupervisor.release();
+        if (mTestObserver != null) {
+            mTestObserver.release();
         }
         super.onDestroy();
     }
@@ -281,11 +280,11 @@ public final class FrequencyActivity extends AnalyzerActivity {
     private void showMaxVolumeConfirmationDialog() {
         new android.app.AlertDialog.Builder(this)
                 .setTitle("Volume Warning")
-                .setMessage("High enforcement mode will set the volume to MAXIMUM. This may be very loud. Do you want to proceed?")
+                .setMessage("Enforcement mode will set the volume to MAXIMUM. This may be very loud."
+                    + " Do you want to proceed?")
                 .setPositiveButton("Proceed", new android.content.DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(android.content.DialogInterface dialog, int which) {
-                        setVolumeToMax();
                         startAudioTest();
                     }
                 })
@@ -293,21 +292,32 @@ public final class FrequencyActivity extends AnalyzerActivity {
                 .show();
     }
 
+    private int getOutputStreamType() {
+        if (mAudioOutTester != null) {
+            int usage = isStreamClosed()
+                    ? mAudioOutTester.requestedConfiguration.getUsage()
+                    : mAudioOutTester.actualConfiguration.getUsage();
+            return StreamConfiguration.convertUsageToStreamType(usage);
+        }
+        return AudioManager.STREAM_MUSIC;
+    }
+
     private void setVolumeToMax() {
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         if (audioManager != null) {
-            int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxVolume, 0);
+            int streamType = getOutputStreamType();
+            int maxVolume = audioManager.getStreamMaxVolume(streamType);
+            audioManager.setStreamVolume(streamType, maxVolume, 0);
         }
     }
 
     private void startAudioTest() {
-        if (mTestSupervisor != null) {
-            mTestSupervisor.start();
-        }
-
         try {
             openAudio();
+            if (mEnforcementCheckBox.isChecked()) {
+                setVolumeToMax();
+            }
+            mTestObserver.start(getOutputStreamType());
             startAudio();
             mStartButton.setEnabled(false);
             mStopButton.setEnabled(true);
@@ -346,17 +356,16 @@ public final class FrequencyActivity extends AnalyzerActivity {
         }
         keepScreenOn(false);
 
-        if (mTestSupervisor != null) {
-            mTestSupervisor.stop();
+        if (mTestObserver != null) {
+            mTestObserver.stop();
             checkSupervisorEvents();
         }
     }
 
     private void checkSupervisorEvents() {
         boolean isEnforced = mEnforcementCheckBox.isChecked();
-        if (mTestSupervisor == null) return;
-        boolean volChanged = mTestSupervisor.isVolumeChanged();
-        boolean devChanged = mTestSupervisor.isDeviceChanged();
+        boolean volChanged = mTestObserver.isVolumeChanged();
+        boolean devChanged = mTestObserver.isDeviceChanged();
         if (volChanged || devChanged) {
             StringBuilder reason = new StringBuilder();
             if (volChanged) reason.append("Volume changed");

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyTestObserver.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/FrequencyTestObserver.java
@@ -3,13 +3,19 @@ package com.mobileer.oboetester;
 import android.media.AudioManager;
 import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
-import android.media.AudioAttributes;
 import android.util.Log;
-import java.util.List;
 import java.util.TimerTask;
 import java.util.Timer;
 
-public class TestSupervisor extends AudioDeviceCallback {
+/**
+ * Frequency tests require a high volume to generate a clear frequency response from the speaker and
+ * microphone; however, the volume level is often left unset. Additionally, peripheral adjustments
+ * or volume changes during testing can lead to unexpected results.
+ *
+ * This class monitors any changes related to peripherals and volume during the test execution to
+ * ensure test validity.
+ */
+public class FrequencyTestObserver extends AudioDeviceCallback {
   private static final String TAG = "TestSupervisor";
   private volatile boolean isVolumeChanged = false;
   private volatile int expectedLevel;
@@ -19,14 +25,14 @@ public class TestSupervisor extends AudioDeviceCallback {
   private Timer timer;
   private final int checkPeriodMs = 200;
 
-  public TestSupervisor(AudioManager audioManager, int streamType) {
+  public FrequencyTestObserver(AudioManager audioManager) {
     this.audioManager = audioManager;
     this.isDeviceChanged = false;
-    this.streamType = streamType;
     audioManager.registerAudioDeviceCallback(this, null);
   }
 
-  public void start() {
+  public void start(int streamType) {
+    this.streamType = streamType;
     expectedLevel = audioManager.getStreamVolume(streamType);
     isVolumeChanged = false;
     isDeviceChanged = false;

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfiguration.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/StreamConfiguration.java
@@ -1035,6 +1035,7 @@ public class StreamConfiguration {
 
     public static String deviceTypeToString(int type) {
         switch (type) {
+            case AudioDeviceInfo.TYPE_UNKNOWN: return "TYPE_UNKNOWN";
             case AudioDeviceInfo.TYPE_BUILTIN_EARPIECE: return "BUILTIN_EARPIECE";
             case AudioDeviceInfo.TYPE_BUILTIN_SPEAKER: return "BUILTIN_SPEAKER";
             case AudioDeviceInfo.TYPE_WIRED_HEADSET: return "WIRED_HEADSET";

--- a/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestSupervisor.java
+++ b/apps/OboeTester/app/src/main/java/com/mobileer/oboetester/TestSupervisor.java
@@ -1,0 +1,91 @@
+package com.mobileer.oboetester;
+
+import android.media.AudioManager;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioAttributes;
+import android.util.Log;
+import java.util.List;
+import java.util.TimerTask;
+import java.util.Timer;
+
+public class TestSupervisor extends AudioDeviceCallback {
+  private static final String TAG = "TestSupervisor";
+  private volatile boolean isVolumeChanged = false;
+  private volatile int expectedLevel;
+  private volatile boolean isDeviceChanged;
+  private final AudioManager audioManager;
+  private int streamType;
+  private Timer timer;
+  private final int checkPeriodMs = 200;
+
+  public TestSupervisor(AudioManager audioManager, int streamType) {
+    this.audioManager = audioManager;
+    this.isDeviceChanged = false;
+    this.streamType = streamType;
+    audioManager.registerAudioDeviceCallback(this, null);
+  }
+
+  public void start() {
+    expectedLevel = audioManager.getStreamVolume(streamType);
+    isVolumeChanged = false;
+    isDeviceChanged = false;
+    timer = new Timer();
+    timer.schedule(
+        new TimerTask() {
+          @Override
+          public void run() {
+            check();
+          }
+        },
+        0,
+        checkPeriodMs);
+  }
+
+  public void stop() {
+    if (timer != null) {
+      timer.cancel();
+      timer = null;
+    }
+  }
+
+  public void release() {
+    stop();
+    audioManager.unregisterAudioDeviceCallback(this);
+  }
+
+  private void check() {
+    int currentLevel = audioManager.getStreamVolume(streamType);
+    if (currentLevel != expectedLevel) {
+      isVolumeChanged = true;
+    }
+  }
+
+  public boolean isVolumeChanged() {
+    return isVolumeChanged;
+  }
+
+  public boolean isDeviceChanged() {
+    return this.isDeviceChanged;
+  }
+
+  @Override
+  public void onAudioDevicesAdded(AudioDeviceInfo[] devices) {
+    if (timer != null) {
+      this.isDeviceChanged = true;
+      for (AudioDeviceInfo device : devices) {
+        Log.d(TAG, "Detected a new device of type " + device.getType());
+      }
+    }
+  }
+
+  @Override
+  public void onAudioDevicesRemoved(AudioDeviceInfo[] devices) {
+    if (timer != null) {
+      this.isDeviceChanged = true;
+      for (AudioDeviceInfo device : devices) {
+        Log.d(TAG, "Disconnected to a device of type " + device.getType());
+      }
+    }
+  }
+}

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_dual_frequency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_dual_frequency.xml
@@ -73,7 +73,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:onClick="onStartTest1"
+                        android:onClick="onStartTest"
                         android:text="Start 1" />
 
                     <Button
@@ -81,7 +81,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:onClick="onStopTest1"
+                        android:onClick="onStopTest"
                         android:text="Stop 1" />
                 </LinearLayout>
             </LinearLayout>
@@ -111,7 +111,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:onClick="onStartTest2"
+                        android:onClick="onStartTest"
                         android:text="Start 2" />
 
                     <Button
@@ -119,7 +119,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:onClick="onStopTest2"
+                        android:onClick="onStopTest"
                         android:text="Stop 2" />
                 </LinearLayout>
             </LinearLayout>
@@ -190,6 +190,19 @@
                 android:textStyle="bold"
                 android:padding="4dp"
                 android:layout_marginTop="4dp"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp">
+                <CheckBox
+                    android:id="@+id/enforcement_check_box"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:checked="true"
+                    android:text="@string/common_enforcement_title"/>
+            </LinearLayout>
 
             <com.mobileer.oboetester.FrequencySettingView
                 android:id="@+id/frequency_setting"

--- a/apps/OboeTester/app/src/main/res/layout/activity_test_frequency.xml
+++ b/apps/OboeTester/app/src/main/res/layout/activity_test_frequency.xml
@@ -95,7 +95,6 @@
                 android:layout_height="wrap_content"
                 android:checked="true"
                 android:text="LogX" />
-
             <TextView
                 android:id="@+id/testResultView"
                 android:layout_width="match_parent"
@@ -105,6 +104,18 @@
                 android:textStyle="bold"
                 android:textColor="#000000"
                 android:padding="4dp"/>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp">
+                <CheckBox
+                    android:id="@+id/enforcement_check_box"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:checked="true"
+                    android:text="@string/common_enforcement_title"/>
+            </LinearLayout>
             <com.mobileer.oboetester.FrequencySettingView
                 android:id="@+id/frequency_setting"
                 android:layout_width="match_parent"

--- a/apps/OboeTester/app/src/main/res/values/strings.xml
+++ b/apps/OboeTester/app/src/main/res/values/strings.xml
@@ -347,6 +347,9 @@
     <string name="common_instruction_title">
         Instructions
     </string>
+    <string name="common_enforcement_title">
+        Enforcement
+    </string>
     <string name="analyze">Analyze</string>
 
     <string name="routing_crash_intro">


### PR DESCRIPTION
Frequency tests require a high volume to generate a clear frequency response from the speaker or microphone; however, the volume level is often left unset. Additionally, peripheral adjustments or volume changes during testing can lead to unexpected results. This ticket introduces an enforcement mode to automatically set the volume and monitor any changes during the test. Following is the app behavior when the feature is disabled or enabled:
- Disable: The test will not adjust the volume, allowing users to configure settings for their own needs. There are no peripheral constraints, enabling testing across various scenarios.
- Enable: The test will set the volume to the maximum level and verify all required peripherals before starting. Any changes to the volume or device connections during the test will result in a failure.

The default enforcement mode is  enabled, though users are free to change. This approach increases the application's flexibility.