### PR TITLE
OboeTester: Fix buffer overrun in fine latency measurement

### DIFF
--- a/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
+++ b/apps/OboeTester/app/src/main/cpp/analyzer/LatencyAnalyzer.h
@@ -313,7 +313,10 @@ static int measureLatencyFromPulse(AudioRecording &recorded,
         return result;
     }
     // Now do a fine resolution search near the coarse latency result.
-    int32_t recordedOffset = std::max(0, courseReport.latencyInFrames - (fineWindowSize / 2));
+    int32_t maxRecordedOffset = recorded.size() - pulse.size() - fineWindowSize;
+    int32_t recordedOffset = courseReport.latencyInFrames - (fineWindowSize / 2);
+    recordedOffset = std::min(maxRecordedOffset, recordedOffset);
+    recordedOffset = std::max(0, recordedOffset);
     result = measureLatencyFromPulsePartial(recorded,
                                             recordedOffset,
                                             fineWindowSize,


### PR DESCRIPTION
In measureLatencyFromPulse, clamp the upper bound of the fine-window offset (recordedOffset) to `recorded.size() - pulse.size() - fineWindowSize`.


Previously, recordedOffset was only clamped at 0. If a correlation peak occurred near the very end of the recording buffer during the coarse search, the fine-resolution search window would attempt to correlate past the end of the buffer, causing measureLatencyFromPulsePartial to fail with error -3.