### PR TITLE
Fix SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS not usable on OpenSL ES streams

### DIFF
--- a/src/opensles/AudioStreamOpenSLES.cpp
+++ b/src/opensles/AudioStreamOpenSLES.cpp
@@ -28,10 +28,9 @@ using namespace oboe;
 
 AudioStreamOpenSLES::AudioStreamOpenSLES(const AudioStreamBuilder &builder)
     : AudioStreamBuffered(builder) {
-    // OpenSL ES does not support device IDs. So overwrite value from builder.
-    mDeviceIds.clear();
-    // OpenSL ES does not support session IDs. So overwrite value from builder.
-    mSessionId = SessionId::None;
+    // Device ID and session ID are deliberately not reset here. They are read from the
+    // builder during open() to configure the stream, e.g. to select the performance mode,
+    // and to log unsupported attributes. They are reset in finishCommonOpen().
 }
 
 static constexpr int32_t   kHighLatencyBufferSizeMillis = 20; // typical Android period
@@ -113,6 +112,13 @@ SLresult AudioStreamOpenSLES::finishCommonOpen(SLAndroidConfigurationItf configI
 
     // Spatialization Behavior is not supported for OpenSL ES.
     mSpatializationBehavior = SpatializationBehavior::Never;
+
+    // Device ID and session ID are not supported for OpenSL ES. They are only used during
+    // open() to configure the stream and to log unsupported attributes, so they are reset
+    // here once the stream has been configured. This also keeps getDeviceId() and
+    // getSessionId() from reporting attributes that OpenSL ES does not actually provide.
+    mDeviceIds.clear();
+    mSessionId = SessionId::None;
 
     SLresult result = registerBufferQueueCallback();
     if (SL_RESULT_SUCCESS != result) {


### PR DESCRIPTION
Fixes #2392.

## Problem

OpenSL ES streams force `mSessionId = SessionId::None` and `mDeviceIds.clear()` in the constructor, before `open()` runs. This makes two code paths in `AudioStreamOpenSLES` unreachable:

1. **`SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS` can never be selected.** `convertPerformanceMode()` maps `PerformanceMode::LowLatency` to `SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS` when `getSessionId() != SessionId::None`, but since the session ID was always reset to `None` in the constructor, the condition was always false and only `SL_ANDROID_PERFORMANCE_LATENCY` was ever used.

2. **`logUnsupportedAttributes()` never warns about device IDs or session IDs** on OpenSL ES, because both had already been cleared before it ran.

## Fix

Keep the builder's device ID and session ID during `open()`, then reset them in `finishCommonOpen()`, which runs *after* `configurePerformanceMode()` on both the output (`AudioOutputStreamOpenSLES::open()`) and input (`AudioInputStreamOpenSLES::open()`) paths. This:

- lets `convertPerformanceMode()` reach the `SL_ANDROID_PERFORMANCE_LATENCY_EFFECTS` branch, so apps can opt into HW pre/post processing on a low-latency OpenSL ES stream,
- makes the unsupported-attribute warnings in `logUnsupportedAttributes()` functional,
- preserves the existing post-open behavior where `getDeviceId()`/`getSessionId()` report no device/session (OpenSL ES does not actually provide them).